### PR TITLE
Always load access list details for proxy hosts

### DIFF
--- a/backend/internal/access-list.js
+++ b/backend/internal/access-list.js
@@ -71,7 +71,7 @@ const internalAccessList = {
 				// re-fetch with expansions
 				return internalAccessList.get(access, {
 					id:     data.id,
-					expand: ['owner', 'items', 'clients', 'proxy_hosts.access_list.clients']
+					expand: ['owner', 'items', 'clients', 'proxy_hosts']
 				}, true /* <- skip masking */);
 			})
 			.then((row) => {
@@ -216,10 +216,11 @@ const internalAccessList = {
 				// re-fetch with expansions
 				return internalAccessList.get(access, {
 					id:     data.id,
-					expand: ['owner', 'items', 'clients', 'proxy_hosts.access_list.clients']
+					expand: ['owner', 'items', 'clients', 'proxy_hosts']
 				}, true /* <- skip masking */);
 			})
 			.then((row) => {
+				console.log(row);
 				return internalAccessList.build(row)
 					.then(() => {
 						if (row.proxy_host_count) {
@@ -254,7 +255,7 @@ const internalAccessList = {
 					.joinRaw('LEFT JOIN `proxy_host` ON `proxy_host`.`access_list_id` = `access_list`.`id` AND `proxy_host`.`is_deleted` = 0')
 					.where('access_list.is_deleted', 0)
 					.andWhere('access_list.id', data.id)
-					.allowEager('[owner,items,clients,proxy_hosts,proxy_hosts.access_list.clients]')
+					.allowEager('[owner, items, clients, proxy_hosts]')
 					.omit(['access_list.is_deleted'])
 					.first();
 

--- a/backend/internal/proxy-host.js
+++ b/backend/internal/proxy-host.js
@@ -73,7 +73,7 @@ const internalProxyHost = {
 				// re-fetch with cert
 				return internalProxyHost.get(access, {
 					id:     row.id,
-					expand: ['certificate', 'owner', 'access_list.clients']
+					expand: ['certificate', 'owner']
 				});
 			})
 			.then((row) => {
@@ -186,7 +186,7 @@ const internalProxyHost = {
 			.then(() => {
 				return internalProxyHost.get(access, {
 					id:     data.id,
-					expand: ['owner', 'certificate', 'access_list.clients']
+					expand: ['owner', 'certificate']
 				})
 					.then((row) => {
 						// Configure nginx
@@ -219,7 +219,6 @@ const internalProxyHost = {
 					.query()
 					.where('is_deleted', 0)
 					.andWhere('id', data.id)
-					.allowEager('[owner,access_list,access_list.clients,certificate]')
 					.first();
 
 				if (access_data.permission_visibility !== 'all') {
@@ -304,7 +303,7 @@ const internalProxyHost = {
 			.then(() => {
 				return internalProxyHost.get(access, {
 					id:     data.id,
-					expand: ['certificate', 'owner', 'access_list']
+					expand: ['certificate', 'owner']
 				});
 			})
 			.then((row) => {
@@ -406,7 +405,7 @@ const internalProxyHost = {
 					.where('is_deleted', 0)
 					.groupBy('id')
 					.omit(['is_deleted'])
-					.allowEager('[owner,access_list,certificate]')
+					.allowGraph('[owner,certificate]')
 					.orderBy('domain_names', 'ASC');
 
 				if (access_data.permission_visibility !== 'all') {

--- a/backend/models/proxy_host.js
+++ b/backend/models/proxy_host.js
@@ -1,11 +1,12 @@
 // Objection Docs:
 // http://vincit.github.io/objection.js/
 
-const db          = require('../db');
-const Model       = require('objection').Model;
-const User        = require('./user');
-const AccessList  = require('./access_list');
-const Certificate = require('./certificate');
+const db                    = require('../db');
+const Model                 = require('objection').Model;
+const User                  = require('./user');
+const AccessList            = require('./access_list');
+const Certificate           = require('./certificate');
+const ProxyHostQueryBuilder = require('../query/proxy_host');
 
 Model.knex(db);
 
@@ -34,6 +35,10 @@ class ProxyHost extends Model {
 		if (typeof this.domain_names !== 'undefined') {
 			this.domain_names.sort();
 		}
+	}
+
+	static get QueryBuilder() {
+		return ProxyHostQueryBuilder;
 	}
 
 	static get name () {

--- a/backend/query/proxy_host.js
+++ b/backend/query/proxy_host.js
@@ -1,0 +1,11 @@
+const QueryBuilder = require('objection').QueryBuilder;
+
+class ProxyHostQueryBuilder extends QueryBuilder {
+	execute () {
+		this.allowGraph('[access_list.[items, clients]]');
+		this.withGraphFetched('[access_list.[items, clients]]');
+		return super.execute();
+	}
+}
+
+module.exports = ProxyHostQueryBuilder;


### PR DESCRIPTION
This PR extracts a decorated QueryBuilder for the proxy_host model which will always load the access list and its details any time the proxy_host model is hydrated. 

This PR potentially fixes a slew of "internal error" bugs where access list details were not available when attempting to construct the Nginx config file for proxy hosts. 

Fixes #382 by populating the access list details when adding a certificate to a proxy host
