### PR TITLE
FIX:  libc.musl-x86_64.so.1: cannot open shared object file: No such file or directory

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,10 @@ ENV SUPPRESS_NO_CONFIG_WARNING=1 \
 
 RUN echo "fs.file-max = 65535" > /etc/sysctl.conf \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends jq logrotate \
+	&& apt-get install -y --no-install-recommends jq logrotate musl-dev \
 	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/* \
+	&& ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
 
 # s6 overlay
 COPY scripts/install-s6 /tmp/install-s6


### PR DESCRIPTION
I have to do this manually inside the container every time I update the image.
These small tweaks should fix it.

Error I get when updating the container and starting it:

libc.musl-x86_64.so.1: cannot open shared object file: No such file or directory

Added musl-dev to install
Added link /usr/lib