### PR TITLE
Adds cache busting to js bundles as well

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -13,8 +13,8 @@ module.exports = {
 	},
 	output:    {
 		path:          path.resolve(__dirname, 'dist'),
-		filename:      'js/[name].bundle.js',
-		chunkFilename: 'js/[name].bundle.[id].js',
+		filename:      `js/[name].bundle.js?v=${PACKAGE.version}`,
+		chunkFilename: `js/[name].bundle.[id].js?v=${PACKAGE.version}`,
 		publicPath:    '/'
 	},
 	resolve:   {


### PR DESCRIPTION
Currently the version number is only appended to the css and the main bundle, not the other bundle parts. This also adds the version number to other bundle parts.

Fixes https://github.com/jc21/nginx-proxy-manager/issues/1495