### PR TITLE
Set RSA key size to 4096 (defaults to 2048 which is debatably insecure)

### DIFF
--- a/docker/rootfs/etc/letsencrypt.ini
+++ b/docker/rootfs/etc/letsencrypt.ini
@@ -4,3 +4,4 @@ webroot-path = /data/letsencrypt-acme-challenge
 key-type = ecdsa
 elliptic-curve = secp384r1
 preferred-chain = ISRG Root X1
+rsa-key-size = 4096


### PR DESCRIPTION
If nothing else is specified the RSA key requested from letsencrypt is 2048 bits. This is possibly insecure and 4096 bit keys should be a negligible difference in processing speed.