### PR TITLE
removing HSTS include from location as it is superfluous. 

### DIFF
--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -51,7 +51,6 @@ proxy_http_version 1.1;
 
     {% endif %}
 
-{% include "_hsts.conf" %}
 
     {% if allow_websocket_upgrade == 1 or allow_websocket_upgrade == true %}
     proxy_set_header Upgrade $http_upgrade;

--- a/backend/templates/redirection_host.conf
+++ b/backend/templates/redirection_host.conf
@@ -16,7 +16,6 @@ server {
 
 {% if use_default_location %}
   location / {
-{% include "_hsts.conf" %}
 
     {% if preserve_path == 1 or preserve_path == true %}
         return {{ forward_http_code }} {{ forward_scheme }}://{{ forward_domain_name }}$request_uri;


### PR DESCRIPTION
HSTS header is already added at the server level and re-adding the host header at the location prevents inheritance from the advanced config include.

Per the NGINX documentation,
"These directives are inherited from the previous configuration level if and only if there are no add_header directives defined on the current level."