### PR TITLE
Streams Basic Load Balancing (Allows multiple Forwarding Hosts)

### DIFF
--- a/backend/migrations/20220413214306_stream_multi.js
+++ b/backend/migrations/20220413214306_stream_multi.js
@@ -1,0 +1,40 @@
+const migrate_name = 'identifier_for_migrate';
+const logger       = require('../logger').migrate;
+
+/**
+ * Migrate
+ *
+ * @see http://knexjs.org/#Schema
+ *
+ * @param {Object} knex
+ * @param {Promise} Promise
+ * @returns {Promise}
+ */
+exports.up = function (knex, Promise) {
+    logger.info('[' + migrate_name + '] Migrating Up...');
+
+    return knex.schema.table('stream', (table) => {
+        table.renameColumn('forwarding_host', 'forwarding_hosts');
+    })
+        .then(function () {
+            logger.info('[' + migrate_name + '] stream Table altered');
+        });
+};
+
+/**
+ * Undo Migrate
+ *
+ * @param {Object} knex
+ * @param {Promise} Promise
+ * @returns {Promise}
+ */
+exports.down = function (knex, Promise) {
+    logger.info('[' + migrate_name + '] Migrating Down...');
+
+    return knex.schema.table('stream', (table) => {
+        table.renameColumn('forwarding_hosts', 'forwarding_host');
+    })
+        .then(function () {
+            logger.info('[' + migrate_name + '] stream Table altered');
+        });
+};

--- a/backend/models/stream.js
+++ b/backend/models/stream.js
@@ -13,6 +13,11 @@ class Stream extends Model {
 		this.created_on  = now();
 		this.modified_on = now();
 
+		// Default for forwarding_hosts
+		if (typeof this.forwarding_hosts === 'undefined') {
+			this.forwarding_hosts = [];
+		}
+		
 		// Default for meta
 		if (typeof this.meta === 'undefined') {
 			this.meta = {};
@@ -21,6 +26,11 @@ class Stream extends Model {
 
 	$beforeUpdate () {
 		this.modified_on = now();
+
+		// Sort domain_names
+		if (typeof this.forwarding_hosts !== 'undefined') {
+			this.forwarding_hosts.sort();
+		}
 	}
 
 	static get name () {
@@ -32,7 +42,7 @@ class Stream extends Model {
 	}
 
 	static get jsonAttributes () {
-		return ['meta'];
+		return ['forwarding_hosts', 'meta'];
 	}
 
 	static get relationMappings () {

--- a/backend/schema/endpoints/streams.json
+++ b/backend/schema/endpoints/streams.json
@@ -20,20 +20,26 @@
       "minimum": 1,
       "maximum": 65535
     },
-    "forwarding_host": {
-      "anyOf": [
-        {
-          "$ref": "../definitions.json#/definitions/domain_name"
-        },
-        {
-          "type": "string",
-          "format": "ipv4"
-        },
-        {
-          "type": "string",
-          "format": "ipv6"
-        }
-      ]
+    "forwarding_hosts": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 15,
+      "uniqueItems": true,
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "../definitions.json#/definitions/domain_name"
+          },
+          {
+            "type": "string",
+            "format": "ipv4"
+          },
+          {
+            "type": "string",
+            "format": "ipv6"
+          }
+        ]
+      }
     },
     "forwarding_port": {
       "type": "integer",
@@ -66,8 +72,8 @@
     "incoming_port": {
       "$ref": "#/definitions/incoming_port"
     },
-    "forwarding_host": {
-      "$ref": "#/definitions/forwarding_host"
+    "forwarding_hosts": {
+      "$ref": "#/definitions/forwarding_hosts"
     },
     "forwarding_port": {
       "$ref": "#/definitions/forwarding_port"
@@ -118,15 +124,15 @@
         "additionalProperties": false,
         "required": [
           "incoming_port",
-          "forwarding_host",
+          "forwarding_hosts",
           "forwarding_port"
         ],
         "properties": {
           "incoming_port": {
             "$ref": "#/definitions/incoming_port"
           },
-          "forwarding_host": {
-            "$ref": "#/definitions/forwarding_host"
+          "forwarding_hosts": {
+            "$ref": "#/definitions/forwarding_hosts"
           },
           "forwarding_port": {
             "$ref": "#/definitions/forwarding_port"
@@ -165,8 +171,8 @@
           "incoming_port": {
             "$ref": "#/definitions/incoming_port"
           },
-          "forwarding_host": {
-            "$ref": "#/definitions/forwarding_host"
+          "forwarding_hosts": {
+            "$ref": "#/definitions/forwarding_hosts"
           },
           "forwarding_port": {
             "$ref": "#/definitions/forwarding_port"

--- a/backend/templates/stream.conf
+++ b/backend/templates/stream.conf
@@ -3,6 +3,13 @@
 # ------------------------------------------------------------
 
 {% if enabled %}
+
+upstream stream_{{ incoming_port }}_tcp {
+  {% for forwarding_host in forwarding_hosts %}
+  server {{ forwarding_host }}:{{ forwarding_port }};
+  {%- endfor %}
+}
+
 {% if tcp_forwarding == 1 or tcp_forwarding == true -%}
 server {
   listen {{ incoming_port }};
@@ -12,7 +19,7 @@ server {
   #listen [::]:{{ incoming_port }};
 {% endif %}
 
-  proxy_pass {{ forwarding_host }}:{{ forwarding_port }};
+  proxy_pass stream_{{ incoming_port }}_tcp;
 
   # Custom
   include /data/nginx/custom/server_stream[.]conf;
@@ -20,14 +27,22 @@ server {
 }
 {% endif %}
 {% if udp_forwarding == 1 or udp_forwarding == true %}
+
+upstream stream_{{ incoming_port }}_udp {
+  {% for forwarding_host in forwarding_hosts %}
+  server {{ forwarding_host }}:{{ forwarding_port }};
+  {%- endfor %}
+}
+
 server {
   listen {{ incoming_port }} udp;
 {% if ipv6 -%}
   listen [::]:{{ incoming_port }} udp;
 {% else -%}
-  #listen [::]:{{ incoming_port }} udp;
+   #listen [::]:{{ incoming_port }} udp;
 {% endif %}
-  proxy_pass {{ forwarding_host }}:{{ forwarding_port }};
+
+  proxy_pass stream_{{ incoming_port }}_udp;
 
   # Custom
   include /data/nginx/custom/server_stream[.]conf;

--- a/frontend/js/app/nginx/stream/form.ejs
+++ b/frontend/js/app/nginx/stream/form.ejs
@@ -14,8 +14,8 @@
                 </div>
                 <div class="col-sm-8 col-md-8">
                     <div class="form-group">
-                        <label class="form-label"><%- i18n('streams', 'forwarding-host') %><span class="form-required">*</span></label>
-                        <input type="text" name="forwarding_host" class="form-control text-monospace" placeholder="example.com or 10.0.0.1 or 2001:db8:3333:4444:5555:6666:7777:8888" value="<%- forwarding_host %>" autocomplete="off" maxlength="255" required>
+                        <label class="form-label"><%- i18n('streams', 'forwarding-hosts') %><span class="form-required">*</span></label>
+                        <input type="text" name="forwarding_hosts" class="form-control" placeholder="example.com or 10.0.0.1 or 2001:db8:3333:4444:5555:6666:7777:8888" id="input-forwarding-hosts" value="<%- forwarding_hosts.join(',') %>" required>
                     </div>
                 </div>
                 <div class="col-sm-4 col-md-4">

--- a/frontend/js/app/nginx/stream/form.js
+++ b/frontend/js/app/nginx/stream/form.js
@@ -6,6 +6,8 @@ const template    = require('./form.ejs');
 require('jquery-serializejson');
 require('jquery-mask-plugin');
 require('selectize');
+const Helpers = require("../../../lib/helpers");
+const certListItemTemplate = require("../certificates-list-item.ejs");
 
 module.exports = Mn.View.extend({
     template:  template,
@@ -13,7 +15,7 @@ module.exports = Mn.View.extend({
 
     ui: {
         form:       'form',
-        forwarding_host: 'input[name="forwarding_host"]',
+        forwarding_hosts: 'input[name="forwarding_hosts"]',
         type_error: '.forward-type-error',
         buttons:    '.modal-footer button',
         switches:   '.custom-switch-input',
@@ -48,6 +50,10 @@ module.exports = Mn.View.extend({
             data.tcp_forwarding  = !!data.tcp_forwarding;
             data.udp_forwarding  = !!data.udp_forwarding;
 
+            if (typeof data.forwarding_hosts === 'string' && data.forwarding_hosts) {
+                data.forwarding_hosts = data.forwarding_hosts.split(',');
+            }
+
             let method = App.Api.Nginx.Streams.create;
             let is_new = true;
 
@@ -74,6 +80,24 @@ module.exports = Mn.View.extend({
                     this.ui.buttons.prop('disabled', false).removeClass('btn-disabled');
                 });
         }
+    },
+
+    onRender: function () {
+        let view = this;
+
+        // Domain names
+        this.ui.forwarding_hosts.selectize({
+            delimiter:    ',',
+            persist:      false,
+            maxOptions:   15,
+            create:       function (input) {
+                return {
+                    value: input,
+                    text:  input
+                };
+            },
+            createFilter: /^(?:\*\.)?(?:[^.*]+\.?)+[^.]$/
+        });
     },
 
     initialize: function (options) {

--- a/frontend/js/app/nginx/stream/list/item.ejs
+++ b/frontend/js/app/nginx/stream/list/item.ejs
@@ -12,7 +12,11 @@
     </div>
 </td>
 <td>
-    <div class="text-monospace"><%- forwarding_host %>:<%- forwarding_port %></div>
+    <div class="wrap">
+        <% forwarding_hosts.map(function(forwarding_host) { %>
+            <span class="tag hover-green"><%- forwarding_host %></span>
+        <% }); %>
+    </div>
 </td>
 <td>
     <div>
@@ -22,6 +26,11 @@
         if (udp_forwarding) { %>
             <span class="tag"><%- i18n('streams', 'udp') %></span>
         <% } %>
+    </div>
+</td>
+<td>
+    <div class="text-monospace">
+        <%- forwarding_port %>
     </div>
 </td>
 <td>

--- a/frontend/js/app/nginx/stream/list/main.ejs
+++ b/frontend/js/app/nginx/stream/list/main.ejs
@@ -3,6 +3,7 @@
     <th><%- i18n('streams', 'incoming-port') %></th>
     <th><%- i18n('str', 'destination') %></th>
     <th><%- i18n('streams', 'protocol') %></th>
+    <th><%- i18n('streams', 'forwarding-port') %></th>
     <th><%- i18n('str', 'status') %></th>
     <% if (canManage) { %>
     <th>&nbsp;</th>

--- a/frontend/js/models/stream.js
+++ b/frontend/js/models/stream.js
@@ -9,7 +9,7 @@ const model = Backbone.Model.extend({
             created_on:      null,
             modified_on:     null,
             incoming_port:   null,
-            forwarding_host: null,
+            forwarding_hosts: [],
             forwarding_port: null,
             tcp_forwarding:  true,
             udp_forwarding:  false,


### PR DESCRIPTION
Hello,

I have added the ability to add several IPs/Hostnames to a Stream which is then defined into an upstream in the configuration.

I wanted to use your project (thank you for this!) to manage a simplistic implementation of [Nginx's TCP and UDP Load Balancing](https://docs.nginx.com/nginx/admin-guide/load-balancer/tcp-udp-load-balancer/) that would suit my needs.

Maybe someone else would be interested and add more options.