### PR TITLE
Update force-ssl.conf to allow for letsencrypt directories over http

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/include/force-ssl.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/force-ssl.conf
@@ -1,3 +1,14 @@
+# Since force-ssl.conf has now moved to the server section it overrides the letsencrypt config
+# which is inside a location section
+# Set FORCE variable in first 2 if tests and action in the third
+set $FORCE "";
 if ($scheme = "http") {
-	return 301 https://$host$request_uri;
+        set $FORCE 'H';
+}
+if ($request_uri !~ "^/.well-known/acme-challenge/(.*)") {
+        set $FORCE "${FORCE}D";
+}
+# If we are http and outside the letsencrypt directories redirect via 301
+if ($FORCE = HD) {
+        return 301 https://$host$request_uri;
 }


### PR DESCRIPTION
Since we have moved force-ssl.conf into the server section, it overrides the location based letsencrypt allowed over http

- Make force-ssl only work if both http traffic and outside the letsencrypt directories.
-  Fixes #1625 