### PR TITLE
Added support for proxying with TSLv1.3 encryption.

### DIFF
--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -36,6 +36,7 @@ http {
 	client_max_body_size          2000m;
 	server_names_hash_bucket_size 1024;
 	proxy_http_version            1.1;
+        proxy_ssl_protocols           TLSv1 TLSv1.1 TLSv1.2 TLSv1.3
 	proxy_set_header              X-Forwarded-Scheme $scheme;
 	proxy_set_header              X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header              Accept-Encoding "";

--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -36,7 +36,7 @@ http {
 	client_max_body_size          2000m;
 	server_names_hash_bucket_size 1024;
 	proxy_http_version            1.1;
-        proxy_ssl_protocols           TLSv1 TLSv1.1 TLSv1.2 TLSv1.3
+        proxy_ssl_protocols           TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
 	proxy_set_header              X-Forwarded-Scheme $scheme;
 	proxy_set_header              X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header              Accept-Encoding "";


### PR DESCRIPTION
After Portainer dropped support for everything but TLSv1.3 in 2.13, it was noticed (https://github.com/portainer/portainer/issues/6902 and https://github.com/portainer/portainer/issues/6900) that NPM seemed to only offer TLSv1.3 for serving, but not for proxying.
This makes sense, since the ssl_protocols flag is manually set to support TLSv1.2 and TSLv1.3 [here](https://github.com/NginxProxyManager/nginx-proxy-manager/blob/4db34f5894a2eb86e99683d52e9b7a859dd206a8/docker/rootfs/etc/nginx/conf.d/include/ssl-ciphers.conf#L5), but the respective proxy_ssl_protocols flag is unset, meaning it is relied on the [default NGINX setting](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_protocols), which enables support for TLSv1, TLSv1.1 and TLSv1.2, but not TLSv1.3.
Please note that I was not able to test this and just wanted to get the fix out as fast as possible. Since I included all the older versions, that are also in the default settings, unlike the ssl_protocols flag, which theoretically drops support for some older version, the functionality should only be enhanced and there should be no compatibility issues. With regards to the age of some of these older protocols, feel free to change this to exclude support for those, though.
I am not 100% sure about the location for this flag, but I think there is no better place for it. The ssl_protocols is only imported for HTTPS connections, but since you can also proxy an HTTP server over an HTTPS connection, I think it should be included in the main config.