### PR TITLE
Add trailing slash to example

### DIFF
--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -132,7 +132,7 @@
       "access-list": "Access List",
       "allow-websocket-upgrade": "Websockets Support",
       "ignore-invalid-upstream-ssl": "Ignore Invalid SSL",
-      "custom-forward-host-help": "Add a path for sub-folder forwarding.\nExample: 203.0.113.25/path",
+      "custom-forward-host-help": "Add a path for sub-folder forwarding.\nExample: 203.0.113.25/path/",
       "search": "Search Host…"
     },
     "redirection-hosts": {


### PR DESCRIPTION
As per https://github.com/NginxProxyManager/nginx-proxy-manager/issues/104#issuecomment-490720849, the custom location neeeds a trailing slash, otherwise it will not work.

This updates the example shown in the UI.