### PR TITLE
Add webp format to assets.conf for Cache Assets

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/include/assets.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/assets.conf
@@ -1,4 +1,4 @@
-location ~* ^.*\.(css|js|jpe?g|gif|png|woff|eot|ttf|svg|ico|css\.map|js\.map)$ {
+location ~* ^.*\.(css|js|jpe?g|gif|png|webp|woff|eot|ttf|svg|ico|css\.map|js\.map)$ {
 	if_modified_since off;
 
 	# use the public cache


### PR DESCRIPTION
Hi, guys:
Thanks for the awesome repo!
In recent years, the compatibility and usage of webp has been increasing, so I added webp to assets.conf. When users check Cache Assets, their webp images can be cached by default. 
References: https://caniuse.com/?search=webp