### PR TITLE
Added autofocus to email input on login screen

### DIFF
--- a/frontend/js/login/ui/login.ejs
+++ b/frontend/js/login/ui/login.ejs
@@ -17,7 +17,7 @@
                                 <div class="card-title"><%- i18n('login', 'title') %></div>
                                 <div class="form-group">
                                     <label class="form-label"><%- i18n('str', 'email-address') %></label>
-                                    <input name="identity" type="email" class="form-control" placeholder="<%- i18n('str', 'email-address') %>" required>
+                                    <input name="identity" type="email" class="form-control" placeholder="<%- i18n('str', 'email-address') %>" required autofocus>
                                 </div>
                                 <div class="form-group">
                                     <label class="form-label"><%- i18n('str', 'password') %></label>


### PR DESCRIPTION
To allow immediate input after loading the login page, without the need to select an input field manually, I added the HTML tag `autofocus` to the email input field.

There is no separate issue for this change but it was mentioned in NginxProxyManager/nginx-proxy-manager#1753.