### PR TITLE
Fix "portainer example" deprecated element 'external:' in 'network:'

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -38,8 +38,7 @@ services:
 
 networks:
   default:
-    external:
-      name: scoobydoo
+    name: scoobydoo
 ```
 
 Now in the NPM UI you can create a proxy host with `portainer` as the hostname,


### PR DESCRIPTION
'external:' from "Let's look at a Portainer example:" is deprecated, works just fine without that