### PR TITLE
Update README.md

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -18,8 +18,8 @@ services running on this Docker host:
 ```yml
 networks:
   default:
-    external:
-      name: scoobydoo
+    name: scoobydoo
+    external: true
 ```
 
 Let's look at a Portainer example:


### PR DESCRIPTION
Deprecated docker network syntax updated so it doesn't give error anymore.