### PR TITLE
Possible multiple X-Forwarded-For headers

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
@@ -2,7 +2,7 @@ add_header       X-Served-By $host;
 proxy_set_header Host $host;
 proxy_set_header X-Forwarded-Scheme $scheme;
 proxy_set_header X-Forwarded-Proto  $scheme;
-proxy_set_header X-Forwarded-For    $remote_addr;
+proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
 proxy_set_header X-Real-IP          $remote_addr;
 proxy_pass       $forward_scheme://$server:$port$request_uri;
 


### PR DESCRIPTION
NMP behind another reverse proxy can multiply X-Forwarded-For headers. $proxy_add_x_forwarded_for equals to $remote_addr if this header not present in client request  https://nginx.org/en/docs/http/ngx_http_proxy_module.html#var_proxy_add_x_forwarded_for