### PR TITLE
Add unofficial Hosting.de DNS provider

### DIFF
--- a/global/certbot-dns-plugins.js
+++ b/global/certbot-dns-plugins.js
@@ -284,6 +284,15 @@ dns_godaddy_key = abcdef0123456789abcdef01234567abcdef0123`,
 		credentials:         'dns_hetzner_api_token = 0123456789abcdef0123456789abcdef',
 		full_plugin_name:    'dns-hetzner',
 	},
+        //####################################################//
+        hostingde: {
+                display_name:        'Hosting.de (Experimental)',
+                package_name:        'no-hostingde-api',
+                version_requirement: '~=0.3.1',
+                dependencies:        '',
+                credentials:         'no_hostingde_api:dns_hostingde_apikey = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+                full_plugin_name:    'no-hostingde-api:dns-hostingde',
+        },
 	//####################################################//
 	infomaniak: {
 		display_name:        'Infomaniak',


### PR DESCRIPTION
Requested in [#1795](https://github.com/NginxProxyManager/nginx-proxy-manager/issues/1795) by @Benni-chan.

The author of [no-hostingde-api](https://github.com/DimeOne/no-hostingde-api) explicitly stated that it's not actively maintained and may contain bugs. I marked it as experimental because of this. 

It's up to the maintainer to include this one.