### PR TITLE
Feature: Use configurable PUID and PGID to get rid of permission issues

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,10 @@ RUN chmod 644 /etc/logrotate.d/nginx-proxy-manager
 RUN pip uninstall --yes setuptools \
 	&& pip install "setuptools==58.0.0"
 
+RUN groupmod -g 1000 users \
+	&& useradd -u 911 -U -d /data -s /bin/false abc \
+	&& usermod -G users abc
+
 VOLUME [ "/data", "/etc/letsencrypt" ]
 ENTRYPOINT [ "/init" ]
 

--- a/docker/rootfs/etc/cont-init.d/01_perms.sh
+++ b/docker/rootfs/etc/cont-init.d/01_perms.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/with-contenv bash
-set -e
-
-mkdir -p /data/logs
-echo "Changing ownership of /data/logs to $(id -u):$(id -g)"
-chown -R "$(id -u):$(id -g)" /data/logs
-

--- a/docker/rootfs/etc/cont-init.d/02_perms.sh
+++ b/docker/rootfs/etc/cont-init.d/02_perms.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/with-contenv bash
+set -e
+
+PUID=${PUID:-911}
+PGID=${PGID:-911}
+
+groupmod -o -g "$PGID" abc
+usermod -o -u "$PUID" abc
+
+echo '
+-------------------------------------
+GID/UID
+-------------------------------------'
+echo "
+User uid:    $(id -u abc)
+User gid:    $(id -g abc)
+-------------------------------------
+"
+
+mkdir -p /data/logs
+echo "Changing ownership of /data to abc:abc"
+chown -R abc:abc /data
+
+echo "Changing ownership of /etc/letsencrypt to abc:abc"
+chown -R abc:abc /etc/letsencrypt

--- a/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
+++ b/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
@@ -1,5 +1,6 @@
 /data/logs/*_access.log /data/logs/*/access.log {
-    create 0644 root root
+    su root root
+    create 0644 abc abc
     weekly
     rotate 4
     missingok
@@ -12,7 +13,8 @@
 }
 
 /data/logs/*_error.log /data/logs/*/error.log {
-    create 0644 root root
+    su root root
+    create 0644 abc abc
     weekly
     rotate 10
     missingok

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -27,6 +27,10 @@ services:
       # Uncomment this if IPv6 is not enabled on your host
       # DISABLE_IPV6: 'true'
 
+      # Uncomment this if you want to use custom UID/GID
+      # PUID: 1000
+      # PGID: 1000
+
     volumes:
       - ./data:/data
       - ./letsencrypt:/etc/letsencrypt
@@ -71,6 +75,10 @@ services:
       DB_MYSQL_NAME: "npm"
       # Uncomment this if IPv6 is not enabled on your host
       # DISABLE_IPV6: 'true'
+
+      # Uncomment this if you want to use custom UID/GID
+      # PUID: 1000
+      # PGID: 1000
     volumes:
       - ./data:/data
       - ./letsencrypt:/etc/letsencrypt


### PR DESCRIPTION
So, I am using nginx-proxy-manager with my NAS and it is great.
Except that if you map volumes, like /data or /etc/letsencrypt, to some folders for more flexible configuration, they have different owner/group than all other files and folders.
This is solved by creating abc user and then using him as owner of the files.
