### PR TITLE
Add Custom IP-Ranges URL And Custom PIP URL

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -879,7 +879,7 @@ const internalCertificate = {
 
 		// Special case for cloudflare
 		if (dns_plugin.package_name === 'certbot-dns-cloudflare') {
-			prepareCmd = 'pip install certbot-dns-cloudflare  --prefer-binary --index-url ' + PIP_URL;
+			prepareCmd = 'pip install certbot-dns-cloudflare --prefer-binary --index-url ' + PIP_URL;
 		}
 
 		// Whether the plugin has a --<name>-credentials argument

--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -17,7 +17,7 @@ const certbotCommand     = 'certbot';
 const archiver           = require('archiver');
 const path               = require('path');
 const { isArray }        = require('lodash');
-const PIP_URL = process.env.PIP_URL !== '' ? process.env.PIP_URL : 'https://www.piwheels.org/simple';
+const PIP_URL            = process.env.PIP_URL !== '' ? process.env.PIP_URL : 'https://www.piwheels.org/simple';
 
 function omissions() {
 	return ['is_deleted'];

--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -17,6 +17,7 @@ const certbotCommand     = 'certbot';
 const archiver           = require('archiver');
 const path               = require('path');
 const { isArray }        = require('lodash');
+const PIP_URL = process.env.PIP_URL !== '' ? process.env.PIP_URL : 'https://www.piwheels.org/simple';
 
 function omissions() {
 	return ['is_deleted'];
@@ -878,7 +879,7 @@ const internalCertificate = {
 
 		// Special case for cloudflare
 		if (dns_plugin.package_name === 'certbot-dns-cloudflare') {
-			prepareCmd = 'pip install certbot-dns-cloudflare --index-url https://www.piwheels.org/simple --prefer-binary';
+			prepareCmd = 'pip install certbot-dns-cloudflare  --prefer-binary --index-url ' + PIP_URL;
 		}
 
 		// Whether the plugin has a --<name>-credentials argument

--- a/backend/internal/ip_ranges.js
+++ b/backend/internal/ip_ranges.js
@@ -5,9 +5,9 @@ const error         = require('../lib/error');
 const internalNginx = require('./nginx');
 const { Liquid }    = require('liquidjs');
 
-const CLOUDFRONT_URL   = 'https://ip-ranges.amazonaws.com/ip-ranges.json';
-const CLOUDFARE_V4_URL = 'https://www.cloudflare.com/ips-v4';
-const CLOUDFARE_V6_URL = 'https://www.cloudflare.com/ips-v6';
+const CLOUDFRONT_URL   = process.env.CLOUDFRONT_URL !== '' ? process.env.CLOUDFRONT_URL : 'https://ip-ranges.amazonaws.com/ip-ranges.json';
+const CLOUDFARE_V4_URL = process.env.CLOUDFARE_V4_URL !== '' ? process.env.CLOUDFARE_V4_URL : 'https://www.cloudflare.com/ips-v4';
+const CLOUDFARE_V6_URL = process.env.CLOUDFARE_V6_URL !== '' ? process.env.CLOUDFARE_V6_URL : 'https://www.cloudflare.com/ips-v6';
 
 const regIpV4 = /^(\d+\.?){4}\/\d+/;
 const regIpV6 = /^(([\da-fA-F]+)?:)+\/\d+/;

--- a/backend/setup.js
+++ b/backend/setup.js
@@ -10,7 +10,7 @@ const authModel           = require('./models/auth');
 const settingModel        = require('./models/setting');
 const dns_plugins         = require('./global/certbot-dns-plugins');
 const debug_mode          = process.env.NODE_ENV !== 'production' || !!process.env.DEBUG;
-const PIP_URL = process.env.PIP_URL !== '' ? process.env.PIP_URL : 'https://www.piwheels.org/simple';
+const PIP_URL             = process.env.PIP_URL !== '' ? process.env.PIP_URL : 'https://www.piwheels.org/simple';
 
 /**
  * Creates a new JWT RSA Keypair if not alread set on the config

--- a/backend/setup.js
+++ b/backend/setup.js
@@ -200,7 +200,7 @@ const setupCertbotPlugins = () => {
 				}
 
 				if (install_cloudflare_plugin) {
-					promises.push(utils.exec('pip install certbot-dns-cloudflare  --prefer-binary --index-url ' + PIP_URL));
+					promises.push(utils.exec('pip install certbot-dns-cloudflare --prefer-binary --index-url ' + PIP_URL));
 				}
 
 				if (promises.length) {

--- a/backend/setup.js
+++ b/backend/setup.js
@@ -10,6 +10,7 @@ const authModel           = require('./models/auth');
 const settingModel        = require('./models/setting');
 const dns_plugins         = require('./global/certbot-dns-plugins');
 const debug_mode          = process.env.NODE_ENV !== 'production' || !!process.env.DEBUG;
+const PIP_URL = process.env.PIP_URL !== '' ? process.env.PIP_URL : 'https://www.piwheels.org/simple';
 
 /**
  * Creates a new JWT RSA Keypair if not alread set on the config
@@ -199,7 +200,7 @@ const setupCertbotPlugins = () => {
 				}
 
 				if (install_cloudflare_plugin) {
-					promises.push(utils.exec('pip install certbot-dns-cloudflare --index-url https://www.piwheels.org/simple --prefer-binary'));
+					promises.push(utils.exec('pip install certbot-dns-cloudflare  --prefer-binary --index-url ' + PIP_URL));
 				}
 
 				if (promises.length) {


### PR DESCRIPTION
This project is set to update the IP address library when Docker is started and every 6 hours during running. This IP address library will request the public network domain name, which will cause Docker to start slowly or not start in an environment where the Internet is not connected or the Internet needs to be accessed through a proxy server.

This PR has added the ability to customize the URL, which can point the relevant URL to the proxy server or other source address inside the network at startup, so that it can be used normally in an environment without Internet access or an environment where the Internet needs to be accessed through a proxy server.

I'm not familiar with the JS/TS language, so I would like to the developer to check carefully and confirm that it is normal before merging to avoid problems may have.