### PR TITLE
Load events configuration from custom file

### DIFF
--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -15,7 +15,7 @@ error_log /data/logs/fallback_error.log warn;
 include /etc/nginx/modules/*.conf;
 
 events {
-	worker_connections  1024;
+	include /data/nginx/custom/events[.]conf;
 }
 
 http {

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -151,6 +151,7 @@ You can add your custom configuration snippet files at `/data/nginx/custom` as f
  - `/data/nginx/custom/root.conf`: Included at the very end of nginx.conf
  - `/data/nginx/custom/http_top.conf`: Included at the top of the main http block
  - `/data/nginx/custom/http.conf`: Included at the end of the main http block
+ - `/data/nginx/custom/events.conf`: Included at the end of the events block
  - `/data/nginx/custom/stream.conf`: Included at the end of the main stream block
  - `/data/nginx/custom/server_proxy.conf`: Included at the end of every proxy server block
  - `/data/nginx/custom/server_redirect.conf`: Included at the end of every redirection server block


### PR DESCRIPTION
## Changes

Instead of forcing users to mount a custom `nginx.conf` file to modify the **events** configuration, we should instead allow them to use a `/custom/events.conf` file to modify it, as is standard for other advanced parts of NPMs configuration. It also reverts the default `worker_connections` amount to NGINX's default to prevent duplicate key issues if a user wants to set a custom `worker_connections` amount.

## Rationale

I was consistently running into issues when using NPM as I was unable to modify my worker_connections amount without some hacky workarounds, so I wanted to make it as easy as changing other parts of the configuration.

## Additional Information

Let me know if anything in this PR needs adjusting, I am by no means an NGINX expert and just wanted to upstream some of my local changes. If this is unwanted, feel free to just close the PR.

## Linked Issues

Fixes #1435, #1912, #2388

