### PR TITLE
feat: DB_MYSQL_CA ssl connection for mysql

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,4 +1,5 @@
 const config = require('config');
+const fs     = require('fs');
 
 if (!config.has('database')) {
 	throw new Error('Database config does not exist! Please read the instructions: https://github.com/jc21/nginx-proxy-manager/blob/master/doc/INSTALL.md');
@@ -7,8 +8,8 @@ if (!config.has('database')) {
 function generateDbConfig() {
 	if (config.database.engine === 'knex-native') {
 		return config.database.knex;
-	} else
-		return {
+	} else {
+		let newConfig = {
 			client:     config.database.engine,
 			connection: {
 				host:     config.database.host,
@@ -21,6 +22,16 @@ function generateDbConfig() {
 				tableName: 'migrations'
 			}
 		};
+
+        if (process.env.DB_MYSQL_CA) {
+			newConfig.connection.ssl = {
+				ca: fs.readFileSync(process.env.DB_MYSQL_CA),
+				rejectUnauthorized: true
+			};
+		}
+
+		return newConfig;
+    }
 }
 
 


### PR DESCRIPTION
## What?
I added support for MySQL SSL connection.

## Why?
As I am working on my project, I needed an external MYSQL DB for NPM, which happened to be on [planetscale.com](https://planetscale.com).
But PlanetScale uses a secure connection which most clients support.
After searching for a long time I couldn't find an option to enable MySQL secure connection on NPM.

## Testing?
I made Dockerfile pulling the NPM image and replacing the 'db.js' file.
DB_MYSQL_CA environment variable added, with a value of default Debian CA path.
[More info...](https://planetscale.com/docs/concepts/secure-connections#ca-root-configuration)
```
FROM jc21/nginx-proxy-manager:latest
WORKDIR /app
COPY ./app ./
```
**DockerHub**
> [brqxpro/nginx-proxy-manager-ca](https://hub.docker.com/r/brqxpro/nginx-proxy-manager-ca)


## Screenshots
**before** --> ERROR
![image](https://user-images.githubusercontent.com/31969166/205481018-5e0bea87-d553-4ddb-a29e-1f1eb2620996.png)

**after** -> worked
![image](https://user-images.githubusercontent.com/31969166/205481321-90fbdc67-5c03-4922-bf10-d5ac7883036e.png)
