### PR TITLE
Update certbot desec plugin fixes #2485

### DIFF
--- a/global/certbot-dns-plugins.js
+++ b/global/certbot-dns-plugins.js
@@ -137,7 +137,7 @@ cpanel_password = hunter2`,
 	desec: {
 		display_name:        'deSEC',
 		package_name:        'certbot-dns-desec',
-		version_requirement: '~=0.3.0',
+		version_requirement: '~=1.2.1',
 		dependencies:        '',
 		credentials:         `dns_desec_token = YOUR_DESEC_API_TOKEN
 dns_desec_endpoint = https://desec.io/api/v1/`,


### PR DESCRIPTION
The current version of the desec plugin is incompatible with certbot 2.0.0.
This was fixed by the authors of the desec plugin (https://github.com/desec-io/certbot-dns-desec/issues/22), so we just have to update to the fixed release.

Thanks for this project btw!