### PR TITLE
ACL changes should not blow away cert config

### DIFF
--- a/backend/internal/access-list.js
+++ b/backend/internal/access-list.js
@@ -218,7 +218,7 @@ const internalAccessList = {
 				// re-fetch with expansions
 				return internalAccessList.get(access, {
 					id:     data.id,
-					expand: ['owner', 'items', 'clients', 'proxy_hosts.access_list.[clients,items]']
+					expand: ['owner', 'items', 'clients', 'proxy_hosts.[certificate,access_list.[clients,items]]']
 				}, true /* <- skip masking */);
 			})
 			.then((row) => {
@@ -256,7 +256,7 @@ const internalAccessList = {
 					.joinRaw('LEFT JOIN `proxy_host` ON `proxy_host`.`access_list_id` = `access_list`.`id` AND `proxy_host`.`is_deleted` = 0')
 					.where('access_list.is_deleted', 0)
 					.andWhere('access_list.id', data.id)
-					.allowEager('[owner,items,clients,proxy_hosts.[*, access_list.[clients,items]]]')
+					.allowEager('[owner,items,clients,proxy_hosts.[certificate,access_list.[clients,items]]]')
 					.omit(['access_list.is_deleted'])
 					.first();
 


### PR DESCRIPTION
When editing an access list, all affected sites get their config updated without certificates, functionally breaking https on those sites until they get a manual config change that rewrites the config properly. Properly fetch the certificate from the DB before `bulkGenerateConfigs` so it gets updated right.

I am not certain whether there are similar bugs in other places that use `bulkGenerateConfigs`.

Should fix #2254