### PR TITLE
Use ssl_reject_handshake to reject requests to default https site

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/default.conf
+++ b/docker/rootfs/etc/nginx/conf.d/default.conf
@@ -32,9 +32,7 @@ server {
 	server_name localhost;
 	access_log /data/logs/fallback_access.log standard;
 	error_log /dev/null crit;
-	ssl_certificate /data/nginx/dummycert.pem;
-	ssl_certificate_key /data/nginx/dummykey.pem;
-	include conf.d/include/ssl-ciphers.conf;
+	ssl_reject_handshake on;
 
 	return 444;
 }

--- a/docker/rootfs/etc/services.d/nginx/run
+++ b/docker/rootfs/etc/services.d/nginx/run
@@ -30,21 +30,6 @@ then
 else
   echo resolver "$(awk 'BEGIN{ORS=" "} $1=="nameserver" { sub(/%.*$/,"",$2); print ($2 ~ ":")? "["$2"]": $2}' /etc/resolv.conf) valid=10s;" > /etc/nginx/conf.d/include/resolvers.conf
 fi
-# Generate dummy self-signed certificate.
-if [ ! -f /data/nginx/dummycert.pem ] || [ ! -f /data/nginx/dummykey.pem ]
-then
-	echo "Generating dummy SSL certificate..."
-	openssl req \
-		-new \
-		-newkey rsa:2048 \
-		-days 3650 \
-		-nodes \
-		-x509 \
-		-subj '/O=localhost/OU=localhost/CN=localhost' \
-		-keyout /data/nginx/dummykey.pem \
-		-out /data/nginx/dummycert.pem
-	echo "Complete"
-fi
 
 # Handle IPV6 settings
 /bin/handle-ipv6-setting /etc/nginx/conf.d


### PR DESCRIPTION
Instead of creating a dummy certificate, we can return an SSL protocol error, which will generate a descriptive error message in the browser.