### PR TITLE
Fixed full_plugin_name for reg.ru plugin

### DIFF
--- a/global/certbot-dns-plugins.js
+++ b/global/certbot-dns-plugins.js
@@ -487,9 +487,9 @@ dns_powerdns_api_key = AbCbASsd!@34`,
 		package_name:        'certbot-regru',
 		version_requirement: '~=1.0.2',
 		dependencies:        '',
-		credentials:         `certbot_regru:dns_username=username
-certbot_regru:dns_password=password`,
-		full_plugin_name: 'certbot-regru:dns',
+		credentials:         `dns_username=username
+dns_password=password`,
+		full_plugin_name: 'dns',
 	},
 	//####################################################//
 	rfc2136: {


### PR DESCRIPTION
For `reg.ru` plugin we don't need prefix `certbot_regru:` in it's `credentials` and `full_plugin_name`.
#2632 