### PR TITLE
FIX: Ngnix fails to start if upstream host for stream is unavailable/unreachable

### DIFF
--- a/backend/templates/stream.conf
+++ b/backend/templates/stream.conf
@@ -3,35 +3,37 @@
 # ------------------------------------------------------------
 
 {% if enabled %}
-{% if tcp_forwarding == 1 or tcp_forwarding == true -%}
-server {
-  listen {{ incoming_port }};
-{% if ipv6 -%}
-  listen [::]:{{ incoming_port }};
-{% else -%}
-  #listen [::]:{{ incoming_port }};
-{% endif %}
+  set $forwarding_host {{ forwarding_host }};
+  set $forwarding_port {{ forwarding_port }};
+  {% if tcp_forwarding == 1 or tcp_forwarding == true -%}
+    server {
+      listen {{ incoming_port }};
+    {% if ipv6 -%}
+      listen [::]:{{ incoming_port }};
+    {% else -%}
+      #listen [::]:{{ incoming_port }};
+    {% endif %}
 
-  proxy_pass {{ forwarding_host }}:{{ forwarding_port }};
+      proxy_pass $forwarding_host:$forwarding_port;
 
-  # Custom
-  include /data/nginx/custom/server_stream[.]conf;
-  include /data/nginx/custom/server_stream_tcp[.]conf;
-}
-{% endif %}
-{% if udp_forwarding == 1 or udp_forwarding == true %}
-server {
-  listen {{ incoming_port }} udp;
-{% if ipv6 -%}
-  listen [::]:{{ incoming_port }} udp;
-{% else -%}
-  #listen [::]:{{ incoming_port }} udp;
-{% endif %}
-  proxy_pass {{ forwarding_host }}:{{ forwarding_port }};
+      # Custom
+      include /data/nginx/custom/server_stream[.]conf;
+      include /data/nginx/custom/server_stream_tcp[.]conf;
+    }
+  {% endif %}
+  {% if udp_forwarding == 1 or udp_forwarding == true %}
+    server {
+      listen {{ incoming_port }} udp;
+    {% if ipv6 -%}
+      listen [::]:{{ incoming_port }} udp;
+    {% else -%}
+      #listen [::]:{{ incoming_port }} udp;
+    {% endif %}
+      proxy_pass $forwarding_host:$forwarding_port;
 
-  # Custom
-  include /data/nginx/custom/server_stream[.]conf;
-  include /data/nginx/custom/server_stream_udp[.]conf;
-}
-{% endif %}
+      # Custom
+      include /data/nginx/custom/server_stream[.]conf;
+      include /data/nginx/custom/server_stream_udp[.]conf;
+    }
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
### Issue:
Currently, if the upstream host being forwarded to is down, Nginx fails to start.
Reported by @StefaBa here: https://github.com/NginxProxyManager/nginx-proxy-manager/pull/2672#issuecomment-1475361687

### Impact:
In this scenario:
- All other hosts managed by NPM are now also taken out.
- NPM cannot be started in order to disable or edit the host configuration in order to rectify the issue.

### Solution:
Declare a variable for `forwarding_host` instead of simply injecting it directly into the `proxy_pass` directive.
Use variables for `proxy_pass` directive in order to prevent startup failure if the upstream host is down.

@StefaBa this one is for you. I think it should work, but I don't use this functionality, so can you please test it?