### PR TITLE
Added timezone to docker-compose examples

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -120,6 +120,8 @@ services:
       # If you would rather use Sqlite, remove all DB_MYSQL_* lines above
       # Uncomment this if IPv6 is not enabled on your host
       # DISABLE_IPV6: 'true'
+      # Uncomment this if you want to change the timezone of the web UI and logfiles
+      # TZ: 'Etc/UTC'
     volumes:
       - ./data:/data
       - ./letsencrypt:/etc/letsencrypt

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -27,6 +27,9 @@ services:
       # Uncomment this if IPv6 is not enabled on your host
       # DISABLE_IPV6: 'true'
 
+      # Uncomment this if you want to change the timezone of the web UI and logfiles
+      # TZ: 'Etc/UTC'
+
     volumes:
       - ./data:/data
       - ./letsencrypt:/etc/letsencrypt


### PR DESCRIPTION
If you would like I can also add a little description for the timezone in `docs/advanced-config/README.md` like there is for `DISABLE_IPV6`