### PR TITLE
X-Forwarded-Host missing from default proxy.conf

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
@@ -3,6 +3,7 @@ proxy_set_header Host $host;
 proxy_set_header X-Forwarded-Scheme $scheme;
 proxy_set_header X-Forwarded-Proto  $scheme;
 proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Host   $http_host;
 proxy_set_header X-Real-IP          $remote_addr;
 proxy_pass       $forward_scheme://$server:$port$request_uri;
 


### PR DESCRIPTION
https://github.com/NginxProxyManager/nginx-proxy-manager/issues/2804

Add X-Forwarded-Host header for better compatibility with proxied servers/code.