### PR TITLE
Update default Docker subnet CIDR

### DIFF
--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -60,7 +60,7 @@ http {
 
 	# Local subnets:
 	set_real_ip_from 10.0.0.0/8;
-	set_real_ip_from 172.16.0.0/12; # Includes Docker subnet
+	set_real_ip_from 172.0.0.0/8; # Includes Docker subnet
 	set_real_ip_from 192.168.0.0/16;
 	# NPM generated CDN ip ranges:
 	include conf.d/include/ip_ranges.conf;


### PR DESCRIPTION
Expand default Docker subnet CIDR to be more inclusive. Resolving issue #2829.