### PR TITLE
Fix for testing SSL certificates (Possibly Issue #2011)

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -1181,9 +1181,8 @@ const internalCertificate = {
 						try {
 							const parsedBody = JSON.parse(responseBody + '');
 							resolve(parsedBody);
-						}
-						catch {
-							logger.warn("Error");
+						} catch (err) {
+    						logger.warn("Error: " + err.message);
 							logger.warn(`Status Code: ${res.statusCode}`);
 							logger.warn(`Failed to test HTTP challenge for domain ${domain}`, res);
 							resolve(undefined);

--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -1164,10 +1164,10 @@ const internalCertificate = {
 				method:  'POST',
 				headers: {
 					'Content-Type':   'application/x-www-form-urlencoded',
-					'Content-Length': Buffer.byteLength(formBody),
-					'Connection': 'keep-alive',
-					'User-Agent': 'Nginx Proxy Manager',
-					'Accept': '*/*'
+					'Content-Length':   Buffer.byteLength(formBody),
+					'Connection':   'keep-alive',
+					'User-Agent':   'Nginx Proxy Manager',
+					'Accept':   '*/*'
 				}
 			};
 
@@ -1182,7 +1182,7 @@ const internalCertificate = {
 							const parsedBody = JSON.parse(responseBody + '');
 							resolve(parsedBody);
 						} catch (err) {
-    						logger.warn("Error: " + err.message);
+							logger.warn(`Error: ${err.message}`);
 							logger.warn(`Status Code: ${res.statusCode}`);
 							logger.warn(`Failed to test HTTP challenge for domain ${domain}`, res);
 							resolve(undefined);

--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -1164,7 +1164,10 @@ const internalCertificate = {
 				method:  'POST',
 				headers: {
 					'Content-Type':   'application/x-www-form-urlencoded',
-					'Content-Length': Buffer.byteLength(formBody)
+					'Content-Length': Buffer.byteLength(formBody),
+					'Connection': 'keep-alive',
+					'User-Agent': 'Nginx Proxy Manager',
+					'Accept': '*/*'
 				}
 			};
 
@@ -1175,12 +1178,16 @@ const internalCertificate = {
 
 					res.on('data', (chunk) => responseBody = responseBody + chunk);
 					res.on('end', function () {
-						const parsedBody = JSON.parse(responseBody + '');
-						if (res.statusCode !== 200) {
+						try {
+							const parsedBody = JSON.parse(responseBody + '');
+							resolve(parsedBody);
+						}
+						catch {
+							logger.warn("Error");
+							logger.warn(`Status Code: ${res.statusCode}`);
 							logger.warn(`Failed to test HTTP challenge for domain ${domain}`, res);
 							resolve(undefined);
 						}
-						resolve(parsedBody);
 					});
 				});
 


### PR DESCRIPTION
- Keepalive, User Agent + Accept headers
- Catch added for failed JSON parsing
- More accurate errors displayed to user