### PR TITLE
Fix for ignored ssl_protocols and ssl_ciphers directive in conf.d/inc…

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/default.conf
+++ b/docker/rootfs/etc/nginx/conf.d/default.conf
@@ -32,6 +32,7 @@ server {
 	server_name localhost;
 	access_log /data/logs/fallback_access.log standard;
 	error_log /dev/null crit;
+	include conf.d/include/ssl-ciphers.conf;
 	ssl_reject_handshake on;
 
 	return 444;


### PR DESCRIPTION
…lude/ssl-ciphers.conf

nginx only uses the `ssl_protocols` directive in the `server{}` block of the first processed host config, which is the default config in `/etc/nginx/conf.d/default.conf`. in version `v2.9.20` the default ssl site was dropped by using `ssl_reject_handshake on` in the default host config. but beside the include of `conf.d/include/ssl-ciphers.conf` was removed from the default host config. that's why `tlsv1.3` isn't applied by default anymore, same thing with the defined cipher suites. npm is so broken since `2023-03-16`.

commit that broke the config -> https://github.com/NginxProxyManager/nginx-proxy-manager/commit/a7f0c3b730678ae4352ade2829d891a3ce3cd3bc