### PR TITLE
Add support for nginx 444 default response

### DIFF
--- a/backend/templates/default.conf
+++ b/backend/templates/default.conf
@@ -24,6 +24,12 @@ server {
   }
 {% endif %}
 
+{%- if value == "444" %}
+  location / {
+    return 444;
+  }
+{% endif %}
+
 {%- if value == "redirect" %}
   location / {
     return 301 {{ meta.redirect }};

--- a/frontend/js/app/settings/default-site/main.ejs
+++ b/frontend/js/app/settings/default-site/main.ejs
@@ -19,6 +19,10 @@
                                 <div class="custom-control-label"><%- i18n('settings', 'default-site-404') %></div>
                             </label>
                             <label class="custom-control custom-radio">
+                                <input class="custom-control-input" name="value" value="444" type="radio" required <%- value === '444' ? 'checked' : '' %>>
+                                <div class="custom-control-label"><%- i18n('settings', 'default-site-444') %></div>
+                            </label>
+                            <label class="custom-control custom-radio">
                                 <input class="custom-control-input" name="value" value="redirect" type="radio" required <%- value === 'redirect' ? 'checked' : '' %>>
                                 <div class="custom-control-label"><%- i18n('settings', 'default-site-redirect') %></div>
                             </label>

--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -287,6 +287,7 @@
       "default-site": "Default Site",
       "default-site-congratulations": "Congratulations Page",
       "default-site-404": "404 Page",
+      "default-site-444": "No Response (444)",
       "default-site-html": "Custom Page",
       "default-site-redirect": "Redirect"
     }


### PR DESCRIPTION
Handles part of #622 .

The default nginx 444 response drops the inbound connection without sending any response to the client. 

This has the benefit of tending to reduce attention by automated scrapers and other such internet noise, and is a common parameter nginx users add to their servers.

This PR implements support for this parameter - the option is labelled "No Response" with "444" in brackets since informed users tend to know it by this value.