### PR TITLE
drop --user on pip install dns plugin

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -877,7 +877,7 @@ const internalCertificate = {
 		const escapedCredentials = certificate.meta.dns_provider_credentials.replaceAll('\'', '\\\'').replaceAll('\\', '\\\\');
 		const credentialsCmd     = 'mkdir -p /etc/letsencrypt/credentials 2> /dev/null; echo \'' + escapedCredentials + '\' > \'' + credentialsLocation + '\' && chmod 600 \'' + credentialsLocation + '\'';
 		// we call `. /opt/certbot/bin/activate` (`.` is alternative to `source` in dash) to access certbot venv
-		const prepareCmd = '. /opt/certbot/bin/activate && pip install --no-cache-dir --user ' + dns_plugin.package_name + (dns_plugin.version_requirement || '') + ' ' + dns_plugin.dependencies + ' && deactivate';
+		const prepareCmd = '. /opt/certbot/bin/activate && pip install --no-cache-dir ' + dns_plugin.package_name + (dns_plugin.version_requirement || '') + ' ' + dns_plugin.dependencies + ' && deactivate';
 
 		// Whether the plugin has a --<name>-credentials argument
 		const hasConfigArg = certificate.meta.dns_provider !== 'route53';


### PR DESCRIPTION
Do not install dns_plugin (via pip) into the user site because it will lack sys.path precedence to urllib3 in /opt/certbot/lib/python3.7/site-packages.
resolves #2921 and #2844
solution recommended by certbot engineer: [https://community.letsencrypt.org/t/nginx-proxy-manager-and-cert/198147](https://community.letsencrypt.org/t/nginx-proxy-manager-and-cert/198147)
Tested with docker image 'jc21/nginx-proxy-manager:latest', Godaddy DNS API credentials and wildcard certificate.
