### PR TITLE
Fix #2741 - Prevent excessive disk writes by only adding frontend service when in development

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,7 @@ RUN yarn install \
 COPY docker/rootfs /
 
 # Remove frontend service not required for prod, dev nginx config as well
-RUN rm -rf /etc/services.d/frontend /etc/nginx/conf.d/dev.conf \
+RUN rm -rf /etc/s6-overlay/s6-rc.d/user/contents.d/frontend /etc/nginx/conf.d/dev.conf \
 	&& chmod 644 /etc/logrotate.d/nginx-proxy-manager \
 	&& pip uninstall --yes setuptools \
 	&& pip install --no-cache-dir "setuptools==58.0.0"


### PR DESCRIPTION
This implements the fix suggested in https://github.com/NginxProxyManager/nginx-proxy-manager/issues/2741#issuecomment-1594553319

Unfortunately I'm not sure how to properly build the docker image in order to test this myself, so this is for now untested. The build error I get is:

```
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref 1c25faae-8c5e-4c01-a343-e27860ce8d72::qeafbfkg7uwrk4wmzaom0sdh5: "/frontend/dist": not found
```

And attempting `npm install` in the `frontend` dir yields `npm ERR! ERESOLVE unable to resolve dependency tree`.

If anyone is able to assist I'd really appreciate it 🙏 in the meantime I've also [reached out to the author of s6](https://github.com/NginxProxyManager/nginx-proxy-manager/issues/2741#issuecomment-1624770029) (who wrote the comment I linked to) to see if they can confirm that this is the right strategy.

EDIT: just seen that the PR branch gets built automatically, so I'm testing with that :+1: