### PR TITLE
add forward path prefix to prefix services in a sub path.

### DIFF
--- a/backend/migrations/20230811144605_forward_path.js
+++ b/backend/migrations/20230811144605_forward_path.js
@@ -1,0 +1,42 @@
+const migrate_name = 'identifier_for_migrate';
+const logger       = require('../logger').migrate;
+
+/**
+ * Migrate
+ *
+ * @see http://knexjs.org/#Schema
+ *
+ * @param {Object} knex
+ * @param {Promise} Promise
+ * @returns {Promise}
+ */
+exports.up = function (knex, Promise) {
+
+	logger.info('[' + migrate_name + '] Migrating Up...');
+
+
+	return knex.schema.alterTable('proxy_host',function(table){
+		table.string("forward_path_prefix").notNull().defaultTo("");
+	})
+	.then(function() {
+		logger.info('[' + migrate_name + '] Migrating Up Complete');
+	})
+};
+
+/**
+ * Undo Migrate
+ *
+ * @param {Object} knex
+ * @param {Promise} Promise
+ * @returns {Promise}
+ */
+exports.down = function (knex, Promise) {
+	logger.info('[' + migrate_name + '] Migrating Down...');
+
+	return knex.schema.alterTable("proxy_host", function(table){
+		table.dropColumn('forward_path_prefix');
+	})
+	.then(() => {
+		logger.info('[' + migrate_name + '] Migrating Down Complete');
+	});
+};

--- a/backend/schema/endpoints/proxy-hosts.json
+++ b/backend/schema/endpoints/proxy-hosts.json
@@ -32,6 +32,11 @@
       "minimum": 1,
       "maximum": 65535
     },
+    "forward_path_prefix":{
+      "type":"string",
+      "pattern": "^(\/[^/]+)*$",
+      "maxLength":255
+    },
     "certificate_id": {
       "$ref": "../definitions.json#/definitions/certificate_id"
     },
@@ -101,6 +106,10 @@
           },
           "forward_path": {
             "type": "string"
+          },
+          "forward_path_prefix":{
+            "type":"string",
+            "pattern": "^(\/[^/]+)*$"
           },
           "advanced_config": {
             "type": "string"
@@ -221,6 +230,9 @@
           "forward_port": {
             "$ref": "#/definitions/forward_port"
           },
+          "forward_path_prefix":{
+            "$ref": "#/definitions/forward_path_prefix"
+          },
           "certificate_id": {
             "$ref": "#/definitions/certificate_id"
           },
@@ -293,6 +305,9 @@
           },
           "forward_port": {
             "$ref": "#/definitions/forward_port"
+          },
+          "forward_path_prefix":{
+            "$ref": "#/definitions/forward_path_prefix"
           },
           "certificate_id": {
             "$ref": "#/definitions/certificate_id"

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -4,7 +4,7 @@
     proxy_set_header X-Forwarded-Proto  $scheme;
     proxy_set_header X-Forwarded-For    $remote_addr;
     proxy_set_header X-Real-IP		$remote_addr;
-    proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
+    proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path_prefix }}{{ forward_path }};
 
     {% include "_access.conf" %}
     {% include "_assets.conf" %}

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -5,6 +5,7 @@ server {
   set $forward_scheme {{ forward_scheme }};
   set $server         "{{ forward_host }}";
   set $port           {{ forward_port }};
+  set $path_prefix    "{{ forward_path_prefix }}";
 
 {% include "_listen.conf" %}
 {% include "_certificates.conf" %}

--- a/docker/rootfs/etc/nginx/conf.d/default.conf
+++ b/docker/rootfs/etc/nginx/conf.d/default.conf
@@ -6,6 +6,7 @@ server {
 	set $forward_scheme "http";
 	set $server "127.0.0.1";
 	set $port "80";
+	set $path_prefix "";
 
 	server_name localhost-nginx-proxy-manager;
 	access_log /data/logs/fallback_access.log standard;

--- a/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
@@ -4,5 +4,5 @@ proxy_set_header X-Forwarded-Scheme $scheme;
 proxy_set_header X-Forwarded-Proto  $scheme;
 proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
 proxy_set_header X-Real-IP          $remote_addr;
-proxy_pass       $forward_scheme://$server:$port$request_uri;
+proxy_pass       $forward_scheme://$server:$port$path_prefix$request_uri;
 

--- a/frontend/js/app/nginx/proxy/form.ejs
+++ b/frontend/js/app/nginx/proxy/form.ejs
@@ -54,6 +54,12 @@
                                 <input name="forward_port" type="number" class="form-control text-monospace" placeholder="80" value="<%- forward_port %>" required>
                             </div>
                         </div>
+                        <div class="col-sm-12 col-md-12">
+                            <div class="form-group">
+                                <label class="form-label"><%- i18n('proxy-hosts','forward-path-prefix') %></label>
+                                <input name="forward_path_prefix" type="text" class="form-control text-monospace" placeholder="/" value="<%- forward_path_prefix %>">
+                            </div>
+                        </div>
                         <div class="col-sm-6 col-md-6">
                             <div class="form-group">
                                 <label class="custom-switch">

--- a/frontend/js/app/nginx/proxy/form.js
+++ b/frontend/js/app/nginx/proxy/form.js
@@ -43,7 +43,8 @@ module.exports = Mn.View.extend({
         dns_provider_credentials: 'textarea[name="meta[dns_provider_credentials]"]',
         propagation_seconds:      'input[name="meta[propagation_seconds]"]',
         forward_scheme:           'select[name="forward_scheme"]',
-        letsencrypt:              '.letsencrypt'
+        letsencrypt:              '.letsencrypt',
+        forward_path_prefix:      'input[name="forward_path_prefix"]'
     },
 
     regions: {
@@ -149,6 +150,7 @@ module.exports = Mn.View.extend({
             let data = this.ui.form.serializeJSON();
 
             // Add locations
+            console.log(this.locationsCollection.models)
             data.locations = [];
             this.locationsCollection.models.forEach((location) => {
                 data.locations.push(location.toJSON());
@@ -361,6 +363,7 @@ module.exports = Mn.View.extend({
         // Check wether there are any location defined
         if (options.model && Array.isArray(options.model.attributes.locations)) {
             options.model.attributes.locations.forEach((location) => {
+                console.log(location)
                 let m = new ProxyLocationModel.Model(location);
                 this.locationsCollection.add(m);
             });

--- a/frontend/js/app/nginx/proxy/list/item.ejs
+++ b/frontend/js/app/nginx/proxy/list/item.ejs
@@ -23,7 +23,7 @@
     </div>
 </td>
 <td>
-    <div class="text-monospace"><%- forward_scheme %>://<%- forward_host %>:<%- forward_port %></div>
+    <div class="text-monospace"><%- forward_scheme %>://<%- forward_host %>:<%- forward_port %><%- forward_path_prefix %></div>
 </td>
 <td>
     <div><%- certificate && certificate_id ? i18n('ssl', certificate.provider) : i18n('ssl', 'none') %></div>

--- a/frontend/js/app/nginx/proxy/location-item.ejs
+++ b/frontend/js/app/nginx/proxy/location-item.ejs
@@ -48,6 +48,12 @@
                     <input name="forward_port" type="number" class="form-control text-monospace model" placeholder="80" value="<%- forward_port %>" required>
                 </div>
             </div>
+            <div class="col-sm-12 col-md-12">
+                <div class="form-group">
+                    <label class="form-label"><%- i18n('proxy-hosts','forward-path-prefix') %></label>
+                    <input name="forward_path_prefix" type="text" class="form-control text-monospace model" placeholder="" value="<%- forward_path_prefix %>">
+                </div>
+            </div>
         </div>
         <div class="row config">
             <div class="col-md-12">

--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -125,6 +125,7 @@
       "forward-scheme": "Scheme",
       "forward-host": "Forward Hostname / IP",
       "forward-port": "Forward Port",
+      "forward-path-prefix": "Forward Path Prefix",
       "delete": "Delete Proxy Host",
       "delete-confirm": "Are you sure you want to delete the Proxy host for: <strong>{domains}</strong>?",
       "help-title": "What is a Proxy Host?",

--- a/frontend/js/models/proxy-host-location.js
+++ b/frontend/js/models/proxy-host-location.js
@@ -10,7 +10,8 @@ const model = Backbone.Model.extend({
             advanced_config:    '',
             forward_scheme:     'http',
             forward_host:       '',
-            forward_port:       '80'
+            forward_port:       '80',
+            forward_path_prefix:''
         }
     },
 

--- a/frontend/js/models/proxy-host.js
+++ b/frontend/js/models/proxy-host.js
@@ -12,6 +12,7 @@ const model = Backbone.Model.extend({
             forward_scheme:          'http',
             forward_host:            '',
             forward_port:            null,
+            forward_path_prefix:     '',
             access_list_id:          0,
             certificate_id:          0,
             ssl_forced:              false,


### PR DESCRIPTION
I have opened an issue #3110  that I need to add some path prefix when forwarding requests, in order to proxy a sub dir into a independent domain.

I added a field on proxy host and proxy host's location configurations, which will be the path prefix of proxy_pass.

I am a Java backend developer. This is the first time I am modifying a project that uses Node.js as the backend implementation. If there are any inappropriate modifications, please feel free to correct my work.