### PR TITLE
OCSP Stapling switch

### DIFF
--- a/backend/doc/api.swagger.json
+++ b/backend/doc/api.swagger.json
@@ -96,6 +96,7 @@
 												"locations": [],
 												"hsts_enabled": 0,
 												"hsts_subdomains": 0,
+												"ocsp_stapling": 0,
 												"owner": {
 													"id": 1,
 													"created_on": "2023-03-30T01:11:50.000Z",
@@ -138,6 +139,7 @@
 												"locations": [],
 												"hsts_enabled": 0,
 												"hsts_subdomains": 0,
+												"ocsp_stapling": 0,
 												"owner": {
 													"id": 1,
 													"created_on": "2023-03-30T01:11:50.000Z",
@@ -216,6 +218,7 @@
 											"locations": [],
 											"hsts_enabled": 0,
 											"hsts_subdomains": 0,
+											"ocsp_stapling": 0,
 											"certificate": null,
 											"owner": {
 												"id": 1,
@@ -1125,6 +1128,7 @@
 					"enabled",
 					"locations",
 					"hsts_enabled",
+					"ocsp_stapling",
 					"hsts_subdomains",
 					"certificate",
 					"use_default_location",
@@ -1209,6 +1213,9 @@
 						"type": "integer"
 					},
 					"hsts_subdomains": {
+						"type": "integer"
+					},
+					"ocsp_stapling": {
 						"type": "integer"
 					},
 					"certificate": {

--- a/backend/internal/host.js
+++ b/backend/internal/host.js
@@ -22,6 +22,7 @@ const internalHost = {
 		if (!combined_data.certificate_id) {
 			combined_data.ssl_forced    = false;
 			combined_data.http2_support = false;
+			combined_data.ocsp_stapling = false;
 		}
 
 		if (!combined_data.ssl_forced) {

--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -155,7 +155,7 @@ const internalNginx = {
 					let locationCopy = Object.assign({}, {access_list_id: host.access_list_id}, {certificate_id: host.certificate_id},
 						{ssl_forced: host.ssl_forced}, {caching_enabled: host.caching_enabled}, {block_exploits: host.block_exploits},
 						{allow_websocket_upgrade: host.allow_websocket_upgrade}, {http2_support: host.http2_support},
-						{hsts_enabled: host.hsts_enabled}, {hsts_subdomains: host.hsts_subdomains}, {access_list: host.access_list},
+						{hsts_enabled: host.hsts_enabled}, {hsts_subdomains: host.hsts_subdomains}, {ocsp_stapling: host.ocsp_stapling}, {access_list: host.access_list},
 						{certificate: host.certificate}, host.locations[i]);
 
 					if (locationCopy.forward_host.indexOf('/') > -1) {

--- a/backend/migrations/20230823010130_ocsp.js
+++ b/backend/migrations/20230823010130_ocsp.js
@@ -1,0 +1,49 @@
+const migrate_name = 'ocsp';
+const logger       = require('../logger').migrate;
+
+/**
+ * Migrate
+ *
+ * @see http://knexjs.org/#Schema
+ *
+ * @param   {Object}  knex
+ * @param   {Promise} Promise
+ * @returns {Promise}
+ */
+exports.up = function (knex/*, Promise*/) {
+	logger.info('[' + migrate_name + '] Migrating Up...');
+
+	return knex.schema.table('proxy_host', function (proxy_host) {
+		proxy_host.integer('ocsp_stapling').notNull().unsigned().defaultTo(0);
+	})
+		.then(() => {
+			logger.info('[' + migrate_name + '] proxy_host Table altered');
+
+			return knex.schema.table('redirection_host', function (redirection_host) {
+
+				redirection_host.integer('ocsp_stapling').notNull().unsigned().defaultTo(0);
+			});
+		})
+		.then(() => {
+			logger.info('[' + migrate_name + '] redirection_host Table altered');
+
+			return knex.schema.table('dead_host', function (dead_host) {
+				dead_host.integer('ocsp_stapling').notNull().unsigned().defaultTo(0);
+			});
+		})
+		.then(() => {
+			logger.info('[' + migrate_name + '] dead_host Table altered');
+		});
+};
+
+/**
+ * Undo Migrate
+ *
+ * @param   {Object}  knex
+ * @param   {Promise} Promise
+ * @returns {Promise}
+ */
+exports.down = function (knex, Promise) {
+	logger.warn('[' + migrate_name + '] You can\'t migrate down this one.');
+	return Promise.resolve(true);
+};

--- a/backend/schema/definitions.json
+++ b/backend/schema/definitions.json
@@ -217,6 +217,11 @@
       "example": false,
       "type": "boolean"
     },
+    "ocsp_stapling": {
+      "description": "Is OCSP Stapling Enabled",
+      "example": false,
+      "type": "boolean"
+    },
     "ssl_provider": {
       "type": "string",
       "pattern": "^(letsencrypt|other)$"

--- a/backend/schema/endpoints/dead-hosts.json
+++ b/backend/schema/endpoints/dead-hosts.json
@@ -30,6 +30,9 @@
     "hsts_subdomains": {
       "$ref": "../definitions.json#/definitions/hsts_subdomains"
     },
+    "ocsp_stapling": {
+      "$ref": "../definitions.json#/definitions/ocsp_stapling"
+    },
     "http2_support": {
       "$ref": "../definitions.json#/definitions/http2_support"
     },
@@ -67,6 +70,9 @@
     },
     "hsts_subdomains": {
       "$ref": "#/definitions/hsts_subdomains"
+    },
+    "ocsp_stapling": {
+      "$ref": "#/definitions/ocsp_stapling"
     },
     "http2_support": {
       "$ref": "#/definitions/http2_support"
@@ -131,6 +137,9 @@
           "hsts_subdomains": {
             "$ref": "#/definitions/hsts_enabled"
           },
+          "ocsp_stapling": {
+            "$ref": "#/definitions/ocsp_stapling"
+          },
           "http2_support": {
             "$ref": "#/definitions/http2_support"
           },
@@ -176,6 +185,9 @@
           },
           "hsts_subdomains": {
             "$ref": "#/definitions/hsts_enabled"
+          },
+          "ocsp_stapling": {
+            "$ref": "#/definitions/ocsp_stapling"
           },
           "http2_support": {
             "$ref": "#/definitions/http2_support"

--- a/backend/schema/endpoints/proxy-hosts.json
+++ b/backend/schema/endpoints/proxy-hosts.json
@@ -44,6 +44,9 @@
     "hsts_subdomains": {
       "$ref": "../definitions.json#/definitions/hsts_subdomains"
     },
+    "ocsp_stapling": {
+      "$ref": "../definitions.json#/definitions/ocsp_stapling"
+    },
     "http2_support": {
       "$ref": "../definitions.json#/definitions/http2_support"
     },
@@ -143,6 +146,9 @@
     "hsts_subdomains": {
       "$ref": "#/definitions/hsts_subdomains"
     },
+    "ocsp_stapling": {
+      "$ref": "#/definitions/ocsp_stapling"
+    },
     "http2_support": {
       "$ref": "#/definitions/http2_support"
     },
@@ -233,6 +239,9 @@
           "hsts_subdomains": {
             "$ref": "#/definitions/hsts_enabled"
           },
+          "ocsp_stapling": {
+            "$ref": "#/definitions/ocsp_stapling"
+          },
           "http2_support": {
             "$ref": "#/definitions/http2_support"
           },
@@ -305,6 +314,9 @@
           },
           "hsts_subdomains": {
             "$ref": "#/definitions/hsts_enabled"
+          },
+          "ocsp_stapling": {
+            "$ref": "#/definitions/ocsp_stapling"
           },
           "http2_support": {
             "$ref": "#/definitions/http2_support"

--- a/backend/schema/endpoints/redirection-hosts.json
+++ b/backend/schema/endpoints/redirection-hosts.json
@@ -44,6 +44,9 @@
     "hsts_subdomains": {
       "$ref": "../definitions.json#/definitions/hsts_subdomains"
     },
+    "ocsp_stapling": {
+      "$ref": "../definitions.json#/definitions/ocsp_stapling"
+    },
     "http2_support": {
       "$ref": "../definitions.json#/definitions/http2_support"
     },
@@ -96,6 +99,9 @@
     },
     "hsts_subdomains": {
       "$ref": "#/definitions/hsts_subdomains"
+    },
+    "ocsp_stapling": {
+      "$ref": "#/definitions/ocsp_stapling"
     },
     "http2_support": {
       "$ref": "#/definitions/http2_support"
@@ -178,6 +184,9 @@
           "hsts_subdomains": {
             "$ref": "#/definitions/hsts_enabled"
           },
+          "ocsp_stapling": {
+            "$ref": "#/definitions/ocsp_stapling"
+          },
           "http2_support": {
             "$ref": "#/definitions/http2_support"
           },
@@ -238,6 +247,9 @@
           },
           "hsts_subdomains": {
             "$ref": "#/definitions/hsts_enabled"
+          },
+          "ocsp_stapling": {
+            "$ref": "#/definitions/ocsp_stapling"
           },
           "http2_support": {
             "$ref": "#/definitions/http2_support"

--- a/backend/templates/_ocsp.conf
+++ b/backend/templates/_ocsp.conf
@@ -1,0 +1,7 @@
+{% if certificate and certificate_id > 0 -%}
+{% if ocsp_stapling == 1 or ocsp_stapling == true %}
+  # OCSP Stapling
+  ssl_stapling on;
+  ssl_stapling_verify on;
+{% endif %}
+{% endif %}

--- a/backend/templates/dead_host.conf
+++ b/backend/templates/dead_host.conf
@@ -5,6 +5,7 @@ server {
 {% include "_listen.conf" %}
 {% include "_certificates.conf" %}
 {% include "_hsts.conf" %}
+{% include "_ocsp.conf" %}
 {% include "_forced_ssl.conf" %}
 
   access_log /data/logs/dead-host-{{ id }}_access.log standard;

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -11,6 +11,7 @@ server {
 {% include "_assets.conf" %}
 {% include "_exploits.conf" %}
 {% include "_hsts.conf" %}
+{% include "_ocsp.conf" %}
 {% include "_forced_ssl.conf" %}
 
 {% if allow_websocket_upgrade == 1 or allow_websocket_upgrade == true %}

--- a/backend/templates/redirection_host.conf
+++ b/backend/templates/redirection_host.conf
@@ -7,6 +7,7 @@ server {
 {% include "_assets.conf" %}
 {% include "_exploits.conf" %}
 {% include "_hsts.conf" %}
+{% include "_ocsp.conf" %}
 {% include "_forced_ssl.conf" %}
 
   access_log /data/logs/redirection-host-{{ id }}_access.log standard;

--- a/frontend/js/app/nginx/dead/form.ejs
+++ b/frontend/js/app/nginx/dead/form.ejs
@@ -73,6 +73,15 @@
                                 </label>
                             </div>
                         </div>
+                        <div class="col-sm-6 col-md-6">
+                            <div class="form-group">
+                                <label class="custom-switch">
+                                    <input type="checkbox" class="custom-switch-input" name="ocsp_stapling" value="1"<%- ocsp_stapling ? ' checked' : '' %><%- certificate_id ? '' : ' disabled' %>>
+                                    <span class="custom-switch-indicator"></span>
+                                    <span class="custom-switch-description"><%- i18n('all-hosts', 'ocsp-stapling') %> <a href="https://en.wikipedia.org/wiki/OCSP_stapling" target="_blank"><i class="fe fe-help-circle"></i></a></span>
+                                </label>
+                            </div>
+                        </div>
 
                         <!-- DNS challenge -->
                         <div class="col-sm-12 col-md-12 letsencrypt">

--- a/frontend/js/app/nginx/dead/form.js
+++ b/frontend/js/app/nginx/dead/form.js
@@ -25,6 +25,7 @@ module.exports = Mn.View.extend({
         ssl_forced:               'input[name="ssl_forced"]',
         hsts_enabled:             'input[name="hsts_enabled"]',
         hsts_subdomains:          'input[name="hsts_subdomains"]',
+        ocsp_stapling:            'input[name="ocsp_stapling"]',
         http2_support:            'input[name="http2_support"]',
         dns_challenge_switch:     'input[name="meta[dns_challenge]"]',
         dns_challenge_content:    '.dns-challenge',
@@ -48,7 +49,7 @@ module.exports = Mn.View.extend({
 
             let enabled = id === 'new' || parseInt(id, 10) > 0;
 
-            let inputs = this.ui.ssl_forced.add(this.ui.http2_support);
+            let inputs = this.ui.ssl_forced.add(this.ui.http2_support).add(this.ui.ocsp_stapling);
             inputs
                 .prop('disabled', !enabled)
                 .parents('.form-group')
@@ -130,6 +131,7 @@ module.exports = Mn.View.extend({
             // Manipulate
             data.hsts_enabled       = !!data.hsts_enabled;
             data.hsts_subdomains    = !!data.hsts_subdomains;
+            data.ocsp_stapling      = !!data.ocsp_stapling;
             data.http2_support      = !!data.http2_support;
             data.ssl_forced         = !!data.ssl_forced;
 

--- a/frontend/js/app/nginx/proxy/form.ejs
+++ b/frontend/js/app/nginx/proxy/form.ejs
@@ -141,7 +141,15 @@
                                 </label>
                             </div>
                         </div>
-
+                        <div class="col-sm-6 col-md-6">
+                            <div class="form-group">
+                                <label class="custom-switch">
+                                    <input type="checkbox" class="custom-switch-input" name="ocsp_stapling" value="1"<%- ocsp_stapling ? ' checked' : '' %><%- certificate_id ? '' : ' disabled' %>>
+                                    <span class="custom-switch-indicator"></span>
+                                    <span class="custom-switch-description"><%- i18n('all-hosts', 'ocsp-stapling') %> <a href="https://en.wikipedia.org/wiki/OCSP_stapling" target="_blank"><i class="fe fe-help-circle"></i></a></span>
+                                </label>
+                            </div>
+                        </div>
                         <!-- DNS challenge -->
                         <div class="col-sm-12 col-md-12 letsencrypt">
                             <div class="form-group">

--- a/frontend/js/app/nginx/proxy/form.js
+++ b/frontend/js/app/nginx/proxy/form.js
@@ -35,6 +35,7 @@ module.exports = Mn.View.extend({
         ssl_forced:               'input[name="ssl_forced"]',
         hsts_enabled:             'input[name="hsts_enabled"]',
         hsts_subdomains:          'input[name="hsts_subdomains"]',
+        ocsp_stapling:            'input[name="ocsp_stapling"]',
         http2_support:            'input[name="http2_support"]',
         dns_challenge_switch:     'input[name="meta[dns_challenge]"]',
         dns_challenge_content:    '.dns-challenge',
@@ -62,7 +63,7 @@ module.exports = Mn.View.extend({
 
             let enabled = id === 'new' || parseInt(id, 10) > 0;
 
-            let inputs = this.ui.ssl_forced.add(this.ui.http2_support);
+            let inputs = this.ui.ssl_forced.add(this.ui.http2_support).add(this.ui.ocsp_stapling);
             inputs
                 .prop('disabled', !enabled)
                 .parents('.form-group')
@@ -166,6 +167,7 @@ module.exports = Mn.View.extend({
             data.http2_support           = !!data.http2_support;
             data.hsts_enabled            = !!data.hsts_enabled;
             data.hsts_subdomains         = !!data.hsts_subdomains;
+            data.ocsp_stapling           = !!data.ocsp_stapling;
             data.ssl_forced              = !!data.ssl_forced;
             
             if (typeof data.meta === 'undefined') data.meta = {};

--- a/frontend/js/app/nginx/redirection/form.ejs
+++ b/frontend/js/app/nginx/redirection/form.ejs
@@ -120,6 +120,15 @@
                                 </label>
                             </div>
                         </div>
+                        <div class="col-sm-6 col-md-6">
+                            <div class="form-group">
+                                <label class="custom-switch">
+                                    <input type="checkbox" class="custom-switch-input" name="ocsp_stapling" value="1"<%- ocsp_stapling ? ' checked' : '' %><%- certificate_id ? '' : ' disabled' %>>
+                                    <span class="custom-switch-indicator"></span>
+                                    <span class="custom-switch-description"><%- i18n('all-hosts', 'ocsp-stapling') %> <a href="https://en.wikipedia.org/wiki/OCSP_stapling" target="_blank"><i class="fe fe-help-circle"></i></a></span>
+                                </label>
+                            </div>
+                        </div>
 
                         <!-- DNS challenge -->
                         <div class="col-sm-12 col-md-12 letsencrypt">

--- a/frontend/js/app/nginx/redirection/form.js
+++ b/frontend/js/app/nginx/redirection/form.js
@@ -26,6 +26,7 @@ module.exports = Mn.View.extend({
         ssl_forced:               'input[name="ssl_forced"]',
         hsts_enabled:             'input[name="hsts_enabled"]',
         hsts_subdomains:          'input[name="hsts_subdomains"]',
+        ocsp_stapling:            'input[name="ocsp_stapling"]',
         http2_support:            'input[name="http2_support"]',
         dns_challenge_switch:     'input[name="meta[dns_challenge]"]',
         dns_challenge_content:    '.dns-challenge',
@@ -48,7 +49,7 @@ module.exports = Mn.View.extend({
 
             let enabled = id === 'new' || parseInt(id, 10) > 0;
 
-            let inputs = this.ui.ssl_forced.add(this.ui.http2_support);
+            let inputs = this.ui.ssl_forced.add(this.ui.http2_support).add(this.ui.ocsp_stapling);
             inputs
                 .prop('disabled', !enabled)
                 .parents('.form-group')
@@ -133,6 +134,7 @@ module.exports = Mn.View.extend({
             data.http2_support      = !!data.http2_support;
             data.hsts_enabled       = !!data.hsts_enabled;
             data.hsts_subdomains    = !!data.hsts_subdomains;
+            data.ocsp_stapling      = !!data.ocsp_stapling;
             data.ssl_forced         = !!data.ssl_forced;
             
             if (typeof data.meta === 'undefined') data.meta = {};

--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -88,6 +88,7 @@
       "advanced-config-header-info": "Please note, that any add_header or set_header directives added here will not be used by nginx. You will have to add a custom location '/' and add the header in the custom config there.",
       "hsts-enabled": "HSTS Enabled",
       "hsts-subdomains": "HSTS Subdomains",
+      "ocsp-stapling": "OCSP Stapling",
       "locations": "Custom locations"
     },
     "locations": {

--- a/frontend/js/models/dead-host.js
+++ b/frontend/js/models/dead-host.js
@@ -14,6 +14,7 @@ const model = Backbone.Model.extend({
             http2_support:   false,
             hsts_enabled:    false,
             hsts_subdomains: false,
+            ocsp_stapling:   false,
             enabled:         true,
             meta:            {},
             advanced_config: '',

--- a/frontend/js/models/proxy-host.js
+++ b/frontend/js/models/proxy-host.js
@@ -17,6 +17,7 @@ const model = Backbone.Model.extend({
             ssl_forced:              false,
             hsts_enabled:            false,
             hsts_subdomains:         false,
+            ocsp_stapling:           false,
             caching_enabled:         false,
             allow_websocket_upgrade: false,
             block_exploits:          false,

--- a/frontend/js/models/redirection-host.js
+++ b/frontend/js/models/redirection-host.js
@@ -17,6 +17,7 @@ const model = Backbone.Model.extend({
             ssl_forced:          false,
             hsts_enabled:        false,
             hsts_subdomains:     false,
+            ocsp_stapling:       false,
             block_exploits:      false,
             http2_support:       false,
             advanced_config:     '',

--- a/test/cypress/integration/api/Hosts.spec.js
+++ b/test/cypress/integration/api/Hosts.spec.js
@@ -32,6 +32,7 @@ describe('Hosts endpoints', () => {
 				http2_support:           false,
 				hsts_enabled:            false,
 				hsts_subdomains:         false,
+				ocsp_stapling:           false,
 				ssl_forced:              false
 			}
 		}).then((data) => {


### PR DESCRIPTION
With this PR Dead, Proxy, and Redirect Hosts are now able to have OCSP Stapling enabled via the webgui with a simple toggle in the SSL tab.

The two config options added when OCSP Stapling is enabled are:
> ssl_stapling on;
> ssl_stapling_verify on;

The file used for OCSP Stapling is already provided by certbot (chain.pem), so all this PR does is allow for that stapling to occur by enabling those two options in each site's .conf file.
This is already possible in the current version of NPM by putting the two options into the Advanced Settings, but this PR allows for the config to look nicer and makes it easier for users to implement across their proxies.

The database does have to be migrated (a new migration file is included) in order to store if the Host has OCSP Stapling enabled or not.