### PR TITLE
Fix issue caused by certbot-dns-godaddy version

### DIFF
--- a/global/certbot-dns-plugins.js
+++ b/global/certbot-dns-plugins.js
@@ -267,7 +267,7 @@ dns_gandi_sharing_id=SHARINGID`,
 	godaddy: {
 		display_name:        'GoDaddy',
 		package_name:        'certbot-dns-godaddy',
-		version_requirement: '~=0.2.0',
+		version_requirement: '~=2.6.0',
 		dependencies:        '',
 		credentials:         `dns_godaddy_secret = 0123456789abcdef0123456789abcdef01234567
 dns_godaddy_key = abcdef0123456789abcdef01234567abcdef0123`,


### PR DESCRIPTION
Updated the version for certbot-dns-godaddy to 2.6.0

Fix https://github.com/NginxProxyManager/nginx-proxy-manager/issues/3159 and https://github.com/NginxProxyManager/nginx-proxy-manager/issues/3103

Got the idea from https://github.com/NginxProxyManager/nginx-proxy-manager/pull/3147 but that put the file in a wrong place