### PR TITLE
certbot-dns-tencentcloud should be 2.0.2 or above.

### DIFF
--- a/global/certbot-dns-plugins.js
+++ b/global/certbot-dns-plugins.js
@@ -557,7 +557,7 @@ dns_transip_key_file = /etc/letsencrypt/transip-rsa.key`,
 	tencentcloud: {
 		display_name:        'Tencent Cloud',
 		package_name:        'certbot-dns-tencentcloud',
-		version_requirement: '~=2.0.0',
+		version_requirement: '~=2.0.2',
 		dependencies:        '',
 		credentials:         `dns_tencentcloud_secret_id  = TENCENT_CLOUD_SECRET_ID
 dns_tencentcloud_secret_key = TENCENT_CLOUD_SECRET_KEY`,


### PR DESCRIPTION
fixes <a title="[Unable to renew certificate · Issue #3164 · NginxProxyManager/nginx-proxy-manager](https://github.com/NginxProxyManager/nginx-proxy-manager/issues/3164)" href="https://github.com/NginxProxyManager/nginx-proxy-manager/issues/3164">Unable to renew certificate · Issue #3164 · NginxProxyManager/nginx-proxy-manager</a>

though the next official docker image will most likely fix this without changing version, but this helps those who install locally.