### PR TITLE
Update certbot-dns-plugins.js

### DIFF
--- a/global/certbot-dns-plugins.js
+++ b/global/certbot-dns-plugins.js
@@ -267,7 +267,7 @@ dns_gandi_sharing_id=SHARINGID`,
 	godaddy: {
 		display_name:        'GoDaddy',
 		package_name:        'certbot-dns-godaddy',
-		version_requirement: '~=0.2.0',
+		version_requirement: '~=2.6.0',
 		dependencies:        '',
 		credentials:         `dns_godaddy_secret = 0123456789abcdef0123456789abcdef01234567
 dns_godaddy_key = abcdef0123456789abcdef01234567abcdef0123`,


### PR DESCRIPTION
certbot-dns-godaddy should be 2.6.0, otherwise the application will fail.

application will fail message: 
> ImportError: cannot import name 'ClientBase' from 'acme.client' 