### PR TITLE
Make logrotate use the proper user and group.

### DIFF
--- a/docker/rootfs/bin/common.sh
+++ b/docker/rootfs/bin/common.sh
@@ -12,6 +12,10 @@ export CYAN BLUE YELLOW RED RESET
 PUID=${PUID:-0}
 PGID=${PGID:-0}
 
+# If changing the username and group name below,
+# ensure all references to this user is also changed.
+# See docker/rootfs/etc/logrotate.d/nginx-proxy-manager
+# and docker/rootfs/etc/nginx/nginx.conf
 NPMUSER=npm
 NPMGROUP=npm
 NPMHOME=/tmp/npmuserhome

--- a/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
+++ b/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
@@ -1,5 +1,6 @@
 /data/logs/*_access.log /data/logs/*/access.log {
-    create 0644 npm npm
+    su npm npm
+    create 0644
     weekly
     rotate 4
     missingok
@@ -12,7 +13,8 @@
 }
 
 /data/logs/*_error.log /data/logs/*/error.log {
-    create 0644 npm npm
+    su npm npm
+    create 0644
     weekly
     rotate 10
     missingok

--- a/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
+++ b/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
@@ -1,5 +1,5 @@
 /data/logs/*_access.log /data/logs/*/access.log {
-    create 0644 root root
+    create 0644 npm npm
     weekly
     rotate 4
     missingok
@@ -12,7 +12,7 @@
 }
 
 /data/logs/*_error.log /data/logs/*/error.log {
-    create 0644 root root
+    create 0644 npm npm
     weekly
     rotate 10
     missingok


### PR DESCRIPTION
Fixes https://github.com/NginxProxyManager/nginx-proxy-manager/issues/2938.

As seen in that issue, users are seeing an error when logrotate tries to own log files as root:
```
[9/24/2023] [6:11:02 PM] [Setup    ] › ⚠  warning   Error: Command failed: logrotate /etc/logrotate.d/nginx-proxy-manager
error: error setting owner of /data/logs/default-host_access.log to uid 0 and gid 0: Operation not permitted
```
where /data/logs/\<anything\> is the log failing to be owned. This causes logrotate to never be able to compress and delete logs.

Since the logrotate configuration was made before (the better) user and group configuration was implemented earlier this year, it was written to own the files as root.

This pull makes logrotate create the logs as whoever owned them beforehand by removing the explicit root user and group in the `create` directive. It also makes logrotate perform all actions as npm:npm, to ensure it doesn't regress https://github.com/NginxProxyManager/nginx-proxy-manager/issues/1250.

It will also work when running as root, as when a PUID and PGID is not set, the npm:npm user/group will have the uid/gid of 0.