### PR TITLE
Host should be $proxy_host, not $host

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
@@ -1,5 +1,4 @@
 add_header       X-Served-By $host;
-proxy_set_header Host $host;
 proxy_set_header X-Forwarded-Scheme $scheme;
 proxy_set_header X-Forwarded-Proto  $scheme;
 proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;


### PR DESCRIPTION
* $host is the Host sent by the user's browser. This is the correct setting if the service has built-in support for being proxied.

* $proxy_host is the Host as if the browser would run on the proxy. This is the correct setting if the service does not have built-in support for reverse proxies. It is also the nginx default.

* In nginx, you cannot unset the Host header. Configuring headers multiple times just sends multiple values with the http request. So there is no way to "fix" the Host by adding a custom header if it is already set.

For these reasons, Host should not be set (and default to $proxy_host). In the unlikely case that your service needs something else you can then just set a custom Host header in the GUI.

Fixes https://github.com/NginxProxyManager/nginx-proxy-manager/issues/2675