### PR TITLE
update docker-compose execution

### DIFF
--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -35,7 +35,7 @@ services:
 Then:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ## Using MySQL / MariaDB Database


### PR DESCRIPTION
As of Jun 2023, the docker-compose command has been deprecated in favor of the compose plugin.

https://docs.docker.com/compose/install/linux/

This is a small change but that could make difference for new users getting docker freshly installed (with the plugin). "Older" users with previous version of docker compose will spot the difference and adapt for their usage.
I intentionally did not put the two possible way of running the container, as the new version will stand on its own

