### PR TITLE
Replace the description string on the default-site page with i18n

### DIFF
--- a/frontend/js/app/settings/default-site/main.ejs
+++ b/frontend/js/app/settings/default-site/main.ejs
@@ -8,7 +8,7 @@
             <div class="row">
                 <div class="col-sm-12 col-md-12">
                     <div class="form-group">
-                        <div class="form-label"><%- description %></div>
+                        <div class="form-label"><%- i18n('settings', 'default-site-description') %></div>
                         <div class="custom-controls-stacked">
                             <label class="custom-control custom-radio">
                                 <input class="custom-control-input" name="value" value="congratulations" type="radio" required <%- value === 'congratulations' ? 'checked' : '' %>>

--- a/frontend/js/app/settings/list/item.ejs
+++ b/frontend/js/app/settings/list/item.ejs
@@ -1,7 +1,7 @@
 <td>
-    <div><%- name %></div>
+    <div><%- i18n('settings', 'default-site') %></div>
     <div class="small text-muted">
-        <%- description %>
+        <%- i18n('settings', 'default-site-description') %>
     </div>
 </td>
 <td>

--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -285,6 +285,7 @@
     "settings": {
       "title": "Settings",
       "default-site": "Default Site",
+      "default-site-description": "What to show when Nginx is hit with an unknown Host",
       "default-site-congratulations": "Congratulations Page",
       "default-site-404": "404 Page",
       "default-site-444": "No Response (444)",


### PR DESCRIPTION
This pull request will not change the UI, just replace the string variable with the i18n method

In order to facilitate the subsequent multi-language adaptation, it is recommended that the interface string use i18n as far as possible

