### PR TITLE
only add hsts header with https.

### DIFF
--- a/backend/templates/_hsts.conf
+++ b/backend/templates/_hsts.conf
@@ -2,7 +2,7 @@
 {% if ssl_forced == 1 or ssl_forced == true %}
 {% if hsts_enabled == 1 or hsts_enabled == true %}
   # HSTS (ngx_http_headers_module is required) (63072000 seconds = 2 years)
-  add_header Strict-Transport-Security "max-age=63072000;{% if hsts_subdomains == 1 or hsts_subdomains == true -%} includeSubDomains;{% endif %} preload" always;
+  add_header Strict-Transport-Security $hsts_header always;
 {% endif %}
 {% endif %}
 {% endif %}

--- a/backend/templates/_hsts_map.conf
+++ b/backend/templates/_hsts_map.conf
@@ -1,0 +1,3 @@
+map $scheme $hsts_header {
+    https   "max-age=63072000;{% if hsts_subdomains == 1 or hsts_subdomains == true -%} includeSubDomains;{% endif %} preload";
+}

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,3 +1,5 @@
+  {% include "_hsts_map.conf" %}
+
   location {{ path }} {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;

--- a/backend/templates/dead_host.conf
+++ b/backend/templates/dead_host.conf
@@ -1,6 +1,9 @@
 {% include "_header_comment.conf" %}
 
 {% if enabled %}
+
+{% include "_hsts_map.conf" %}
+
 server {
 {% include "_listen.conf" %}
 {% include "_certificates.conf" %}

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -1,6 +1,9 @@
 {% include "_header_comment.conf" %}
 
 {% if enabled %}
+
+{% include "_hsts_map.conf" %}
+
 server {
   set $forward_scheme {{ forward_scheme }};
   set $server         "{{ forward_host }}";

--- a/backend/templates/redirection_host.conf
+++ b/backend/templates/redirection_host.conf
@@ -1,6 +1,9 @@
 {% include "_header_comment.conf" %}
 
 {% if enabled %}
+
+{% include "_hsts_map.conf" %}
+
 server {
 {% include "_listen.conf" %}
 {% include "_certificates.conf" %}


### PR DESCRIPTION
fixes https://github.com/NginxProxyManager/nginx-proxy-manager/issues/1005 for more information look at: https://websistent.com/add-the-hsts-header-only-for-https-requests-nginx/

It would be really great if you could check if this solution really works.