### PR TITLE
Improve container startup time

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/prepare/30-ownership.sh
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/prepare/30-ownership.sh
@@ -24,4 +24,4 @@ chown -R "$PUID:$PGID" /etc/nginx/nginx.conf
 chown -R "$PUID:$PGID" /etc/nginx/conf.d
 
 # Prevents errors when installing python certbot plugins when non-root
-chown -R "$PUID:$PGID" /opt/certbot
+chown "$PUID:$PGID" /opt/certbot/lib/python3.7/site-packages/


### PR DESCRIPTION
See https://github.com/NginxProxyManager/nginx-proxy-manager/issues/2991

Removes uneeded file permission changes in rootfs certbot install. Tested installing custom DNS provider plugins for certbot, works correctly.