### PR TITLE
Added support for ddns lookups for addresses in access lists

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -9,6 +9,7 @@ async function appStart () {
 	const apiValidator        = require('./lib/validator/api');
 	const internalCertificate = require('./internal/certificate');
 	const internalIpRanges    = require('./internal/ip_ranges');
+	const ddnsResolver        = require('./lib/ddns_resolver/ddns_resolver');
 
 	return migrate.latest()
 		.then(setup)
@@ -20,6 +21,7 @@ async function appStart () {
 
 			internalCertificate.initTimer();
 			internalIpRanges.initTimer();
+			ddnsResolver.initTimer();
 
 			const server = app.listen(3000, () => {
 				logger.info('Backend PID ' + process.pid + ' listening on port 3000 ...');

--- a/backend/index.js
+++ b/backend/index.js
@@ -9,7 +9,7 @@ async function appStart () {
 	const apiValidator        = require('./lib/validator/api');
 	const internalCertificate = require('./internal/certificate');
 	const internalIpRanges    = require('./internal/ip_ranges');
-	const ddnsResolver        = require('./lib/ddns_resolver');
+	const ddnsUpdater         = require('./lib/ddns_resolver/ddns_updater');
 
 	return migrate.latest()
 		.then(setup)
@@ -21,7 +21,7 @@ async function appStart () {
 
 			internalCertificate.initTimer();
 			internalIpRanges.initTimer();
-			ddnsResolver.initTimer();
+			ddnsUpdater.initTimer();
 
 			const server = app.listen(3000, () => {
 				logger.info('Backend PID ' + process.pid + ' listening on port 3000 ...');

--- a/backend/index.js
+++ b/backend/index.js
@@ -9,7 +9,7 @@ async function appStart () {
 	const apiValidator        = require('./lib/validator/api');
 	const internalCertificate = require('./internal/certificate');
 	const internalIpRanges    = require('./internal/ip_ranges');
-	const ddnsResolver        = require('./lib/ddns_resolver/ddns_resolver');
+	const ddnsResolver        = require('./lib/ddns_resolver');
 
 	return migrate.latest()
 		.then(setup)

--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -134,6 +134,7 @@ const internalNginx = {
 
 	/**
 	 * Resolves any ddns addresses that need to be resolved for clients in the host's access list.
+	 * Defines a new property 'resolvedAddress' on each client in `host.access_list.clients` that uses a ddns address.
 	 * @param {Object} host 
 	 * @returns {Promise}
 	 */

--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -4,7 +4,7 @@ const logger       = require('../logger').nginx;
 const config       = require('../lib/config');
 const utils        = require('../lib/utils');
 const error        = require('../lib/error');
-const ddnsResolver = require('../lib/ddns_resolver');
+const ddnsResolver = require('../lib/ddns_resolver/ddns_resolver');
 
 const internalNginx = {
 

--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -139,12 +139,13 @@ const internalNginx = {
 	 */
 	resolveDDNSAddresses: (host) => {
 		const promises = [];
-		if (typeof host.access_list !== 'undefined' && typeof host.access_list.clients !== 'undefined') {
+		if (typeof host.access_list !== 'undefined' && host.access_list && typeof host.access_list.clients !== 'undefined' && host.access_list.clients) {
 			for (const client of host.access_list.clients) {
-				if (ddnsResolver.requiresResolution(client.address)) {
-					const p = ddnsResolver.resolveAddress(client.address)
+				const address = client.address;
+				if (ddnsResolver.requiresResolution(address)) {
+					const p = ddnsResolver.resolveAddress(address)
 						.then((resolvedIP) => {
-							client.address = `${resolvedIP}; # ${client.address}`;
+							Object.defineProperty(client, 'resolvedAddress', {value: resolvedIP});
 							return Promise.resolve();
 						});
 					promises.push(p);

--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -1,9 +1,9 @@
-const _      = require('lodash');
-const fs     = require('fs');
-const logger = require('../logger').nginx;
-const config = require('../lib/config');
-const utils  = require('../lib/utils');
-const error  = require('../lib/error');
+const _            = require('lodash');
+const fs           = require('fs');
+const logger       = require('../logger').nginx;
+const config       = require('../lib/config');
+const utils        = require('../lib/utils');
+const error        = require('../lib/error');
 const ddnsResolver = require('../lib/ddns_resolver');
 
 const internalNginx = {
@@ -151,7 +151,7 @@ const internalNginx = {
 				}
 			}
 		}
-        if (promises.length) {
+		if (promises.length) {
 			return Promise.all(promises);
 		}
 		return Promise.resolve();

--- a/backend/lib/ddns_resolver.js
+++ b/backend/lib/ddns_resolver.js
@@ -1,239 +1,239 @@
-const error                 = require('./error')
-const logger                = require('../logger').ddns;
-const internalAccessList    = require('../internal/access-list');
-const utils                 = require('./utils');
+const error              = require('./error');
+const logger             = require('../logger').ddns;
+const internalAccessList = require('../internal/access-list');
+const utils              = require('./utils');
 
 const ddnsResolver = {
-    /**
+	/**
      * Starts a timer to periodically check for ddns updates
      */
-    initTimer: () => {
-        ddnsResolver._initialize();
-        ddnsResolver._interval = setInterval(ddnsResolver._checkForDDNSUpdates, ddnsResolver._updateIntervalMs);
-        logger.info(`DDNS Update Timer initialized (interval: ${Math.floor(ddnsResolver._updateIntervalMs / 1000)}s)`);
-        // Trigger a run so that initial cache is populated and hosts can be updated - delay by 10s to give server time to boot up
-        setTimeout(ddnsResolver._checkForDDNSUpdates, 10 * 1000);
-    },
+	initTimer: () => {
+		ddnsResolver._initialize();
+		ddnsResolver._interval = setInterval(ddnsResolver._checkForDDNSUpdates, ddnsResolver._updateIntervalMs);
+		logger.info(`DDNS Update Timer initialized (interval: ${Math.floor(ddnsResolver._updateIntervalMs / 1000)}s)`);
+		// Trigger a run so that initial cache is populated and hosts can be updated - delay by 10s to give server time to boot up
+		setTimeout(ddnsResolver._checkForDDNSUpdates, 10 * 1000);
+	},
 
-    /**
+	/**
      * Checks whether the address requires resolution (i.e. starts with ddns:)
      * @param {String} address 
      * @returns {boolean}
      */
-    requiresResolution: (address) => {
-        if (typeof address !== 'undefined' && address && address.toLowerCase().startsWith('ddns:')) {
+	requiresResolution: (address) => {
+		if (typeof address !== 'undefined' && address && address.toLowerCase().startsWith('ddns:')) {
 			return true;
 		}
 		return false;
-    },
+	},
 
-    /**
+	/**
      * Resolves the given address to its IP
      * @param {String} address 
      * @param {boolean} forceUpdate: whether to force resolution instead of using the cached value
      */
-    resolveAddress: (address, forceUpdate=false) => {
-        if (!forceUpdate && ddnsResolver._cache.has(address)) {
-            // Check if it is still valid
-            const value = ddnsResolver._cache.get(address);
-            const ip = value[0];
-            const lastUpdated = value[1];
-            const nowSeconds = Date.now();
-            const delta = nowSeconds - lastUpdated;
-            if (delta < ddnsResolver._updateIntervalMs) {
-                return Promise.resolve(ip);
-            }
-        }
-        ddnsResolver._cache.delete(address);
-        // Reach here only if cache value doesn't exist or needs to be updated 
-        let host = address.toLowerCase();
-        if (host.startsWith('ddns:')) {
-            host = host.substring(5);
-        }
-        return ddnsResolver._queryHost(host)
-            .then((resolvedIP) => {
-                ddnsResolver._cache.set(address, [resolvedIP, Date.now()]);
-                return resolvedIP;
-            })
-            .catch((_error) => {
-                // return input address in case of failure
-                return address;
-            });
-    },
+	resolveAddress: (address, forceUpdate=false) => {
+		if (!forceUpdate && ddnsResolver._cache.has(address)) {
+			// Check if it is still valid
+			const value       = ddnsResolver._cache.get(address);
+			const ip          = value[0];
+			const lastUpdated = value[1];
+			const nowSeconds  = Date.now();
+			const delta       = nowSeconds - lastUpdated;
+			if (delta < ddnsResolver._updateIntervalMs) {
+				return Promise.resolve(ip);
+			}
+		}
+		ddnsResolver._cache.delete(address);
+		// Reach here only if cache value doesn't exist or needs to be updated 
+		let host = address.toLowerCase();
+		if (host.startsWith('ddns:')) {
+			host = host.substring(5);
+		}
+		return ddnsResolver._queryHost(host)
+			.then((resolvedIP) => {
+				ddnsResolver._cache.set(address, [resolvedIP, Date.now()]);
+				return resolvedIP;
+			})
+			.catch((/*error*/) => {
+				// return input address in case of failure
+				return address;
+			});
+	},
 
     
-    /** Private **/
-    // Properties
-    _initialized: false,
-    _updateIntervalMs: 60 * 60 * 1000, // 1 hr default (overriden with $DDNS_UPDATE_INTERVAL env var)
-    /**
+	/** Private **/
+	// Properties
+	_initialized:          false,
+	_updateIntervalMs:     60 * 60 * 1000, // 1 hr default (overriden with $DDNS_UPDATE_INTERVAL env var)
+	/**
      * cache mapping host to (ip address, last updated time)
      */
-    _cache: new Map(),
-    _interval: null, // reference to created interval id
-    _processingDDNSUpdate: false,
+	_cache:                new Map(),
+	_interval:             null, // reference to created interval id
+	_processingDDNSUpdate: false,
 
-    // Methods
+	// Methods
 
-    _initialize: () => {
-        if (ddnsResolver._initialized) {
-            return;
-        }
-        // Init the resolver
-        // Read and set custom update interval from env if needed
-        if (typeof process.env.DDNS_UPDATE_INTERVAL !== 'undefined') {
-            const interval = Number(process.env.DDNS_UPDATE_INTERVAL.toLowerCase());
-            if (!isNaN(interval)) {
-                // Interval value from env is in seconds. Set min to 60s.
-                ddnsResolver._updateIntervalMs = Math.max(interval * 1000, 60 * 1000);
-            } else {
-                logger.warn(`[DDNS] invalid value for update interval: '${process.env.DDNS_UPDATE_INTERVAL}'`);
-            }
-        }
-        ddnsResolver._initialized = true;
-    },
+	_initialize: () => {
+		if (ddnsResolver._initialized) {
+			return;
+		}
+		// Init the resolver
+		// Read and set custom update interval from env if needed
+		if (typeof process.env.DDNS_UPDATE_INTERVAL !== 'undefined') {
+			const interval = Number(process.env.DDNS_UPDATE_INTERVAL.toLowerCase());
+			if (!isNaN(interval)) {
+				// Interval value from env is in seconds. Set min to 60s.
+				ddnsResolver._updateIntervalMs = Math.max(interval * 1000, 60 * 1000);
+			} else {
+				logger.warn(`[DDNS] invalid value for update interval: '${process.env.DDNS_UPDATE_INTERVAL}'`);
+			}
+		}
+		ddnsResolver._initialized = true;
+	},
 
-    /**
+	/**
      * 
      * @param {String} host 
      * @returns {Promise}
      */
-    _queryHost: (host) => {
-        logger.info('Looking up IP for ', host);
-        return utils.execSafe('getent', ['hosts', host])
-            .then((result) => {
-                if (result.length < 8) {
-                    logger.error('IP lookup returned invalid output: ', result);
-                    throw error.ValidationError('Invalid output from getent hosts');
-                }
-                const out = result.split(/\s+/);
-                logger.info(`Resolved ${host} to ${out[0]}`);
-                return out[0];
-            },
-            (error) => {
-                logger.error('Error looking up IP for ' + host + ': ', error);
-                throw error; 
-            });
-    },
+	_queryHost: (host) => {
+		logger.info('Looking up IP for ', host);
+		return utils.execSafe('getent', ['hosts', host])
+			.then((result) => {
+				if (result.length < 8) {
+					logger.error('IP lookup returned invalid output: ', result);
+					throw error.ValidationError('Invalid output from getent hosts');
+				}
+				const out = result.split(/\s+/);
+				logger.info(`Resolved ${host} to ${out[0]}`);
+				return out[0];
+			},
+			(error) => {
+				logger.error('Error looking up IP for ' + host + ': ', error);
+				throw error; 
+			});
+	},
 
-    /**
+	/**
      * Triggered by a timer, will check for and update ddns hosts in access list clients
     */
-    _checkForDDNSUpdates: () => {
-        const internalNginx         = require('../internal/nginx'); // Prevent circular import
+	_checkForDDNSUpdates: () => {
+		const internalNginx = require('../internal/nginx'); // Prevent circular import
 
-        logger.info('Checking for DDNS updates...');
-        if (!ddnsResolver._processingDDNSUpdate) {
-            ddnsResolver._processingDDNSUpdate = true;
+		logger.info('Checking for DDNS updates...');
+		if (!ddnsResolver._processingDDNSUpdate) {
+			ddnsResolver._processingDDNSUpdate = true;
             
-            const updatedAddresses = new Map();
+			const updatedAddresses = new Map();
 
-            // Get all ddns hostnames in use
-            return ddnsResolver._getAccessLists()
-                .then((rows) => {
-                    // Build map of used addresses that require resolution
-                    const usedAddresses = new Map();
-                    for (const row of rows) {
-                        if (!row.proxy_host_count) {
-                            // Ignore rows (access lists) that are not associated to any hosts
-                            continue;
-                        }
-                        for (const client of row.clients) {
-                            if (!ddnsResolver.requiresResolution(client.address)) {
-                                continue;
-                            }
-                            if (!usedAddresses.has(client.address)) {
-                                usedAddresses.set(client.address, [row]);
-                            } else {
-                                usedAddresses.get(client.address).push(row);
-                            }
-                        }
-                    }
-                    logger.info(`Found ${usedAddresses.size} address(es) in use.`);
-                    // Remove unused addresses
-                    const addressesToRemove = [];
-                    for (const address of ddnsResolver._cache.keys()) {
-                        if (!usedAddresses.has(address)) {
-                            addressesToRemove.push(address);
-                        }
-                    }
-                    addressesToRemove.forEach((address) => { ddnsResolver._cache.delete(address); });
+			// Get all ddns hostnames in use
+			return ddnsResolver._getAccessLists()
+				.then((rows) => {
+					// Build map of used addresses that require resolution
+					const usedAddresses = new Map();
+					for (const row of rows) {
+						if (!row.proxy_host_count) {
+							// Ignore rows (access lists) that are not associated to any hosts
+							continue;
+						}
+						for (const client of row.clients) {
+							if (!ddnsResolver.requiresResolution(client.address)) {
+								continue;
+							}
+							if (!usedAddresses.has(client.address)) {
+								usedAddresses.set(client.address, [row]);
+							} else {
+								usedAddresses.get(client.address).push(row);
+							}
+						}
+					}
+					logger.info(`Found ${usedAddresses.size} address(es) in use.`);
+					// Remove unused addresses
+					const addressesToRemove = [];
+					for (const address of ddnsResolver._cache.keys()) {
+						if (!usedAddresses.has(address)) {
+							addressesToRemove.push(address);
+						}
+					}
+					addressesToRemove.forEach((address) => { ddnsResolver._cache.delete(address); });
 
-                    const promises = [];
+					const promises = [];
 
-                    for (const [address, rows] of usedAddresses) {
-                        let oldIP = '';
-                        if (ddnsResolver._cache.has(address)) {
-                            oldIP = ddnsResolver._cache.get(address)[0];
-                        }
-                        const p = ddnsResolver.resolveAddress(address, true)
-                        .then((resolvedIP) => {
-                                if (resolvedIP !== address && resolvedIP !== oldIP) {
-                                    // Mark this as an updated address
-                                    updatedAddresses.set(address, rows);
-                                }
-                            });
-                        promises.push(p);
-                    }
+					for (const [address, rows] of usedAddresses) {
+						let oldIP = '';
+						if (ddnsResolver._cache.has(address)) {
+							oldIP = ddnsResolver._cache.get(address)[0];
+						}
+						const p = ddnsResolver.resolveAddress(address, true)
+							.then((resolvedIP) => {
+								if (resolvedIP !== address && resolvedIP !== oldIP) {
+									// Mark this as an updated address
+									updatedAddresses.set(address, rows);
+								}
+							});
+						promises.push(p);
+					}
 
-                    if (promises.length) {
-                        return Promise.all(promises);
-                    }
-                    return Promise.resolve();
-                })
-                .then(() => {
-                    logger.info(`${updatedAddresses.size} DDNS IP(s) updated.`);
-                    const updatedRows = new Map();
-                    const proxy_hosts = [];
-                    for (const rows of updatedAddresses.values()) {
-                        for (const row of rows) {
-                            if (!updatedRows.has(row.id)) {
-                                updatedRows.set(row.id, 1);
-                                proxy_hosts.push(...row.proxy_hosts);
-                            }
-                        }
-                    }
-                    if (proxy_hosts.length) {
-                        logger.info(`Updating ${proxy_hosts.length} proxy host(s) affected by DDNS changes`);
-                        return internalNginx.bulkGenerateConfigs('proxy_host', proxy_hosts)
-                            .then(internalNginx.reload);
-                    }
-                    return Promise.resolve();
-                })
-                .then(() => {
-                    logger.info('Finished checking for DDNS updates');
-                    ddnsResolver._processingDDNSUpdate = false;
-                });
-        } else {
-            logger.info('Skipping since previous DDNS update check is in progress');
-        }
-    },
+					if (promises.length) {
+						return Promise.all(promises);
+					}
+					return Promise.resolve();
+				})
+				.then(() => {
+					logger.info(`${updatedAddresses.size} DDNS IP(s) updated.`);
+					const updatedRows = new Map();
+					const proxy_hosts = [];
+					for (const rows of updatedAddresses.values()) {
+						for (const row of rows) {
+							if (!updatedRows.has(row.id)) {
+								updatedRows.set(row.id, 1);
+								proxy_hosts.push(...row.proxy_hosts);
+							}
+						}
+					}
+					if (proxy_hosts.length) {
+						logger.info(`Updating ${proxy_hosts.length} proxy host(s) affected by DDNS changes`);
+						return internalNginx.bulkGenerateConfigs('proxy_host', proxy_hosts)
+							.then(internalNginx.reload);
+					}
+					return Promise.resolve();
+				})
+				.then(() => {
+					logger.info('Finished checking for DDNS updates');
+					ddnsResolver._processingDDNSUpdate = false;
+				});
+		} else {
+			logger.info('Skipping since previous DDNS update check is in progress');
+		}
+	},
 
-    _getAccessLists: () => {
-        const fakeAccess = {
-            can: (capabilityStr) => {
-                return Promise.resolve({
-                    permission_visibility: 'all'
-                })
-            }
-        };
+	_getAccessLists: () => {
+		const fakeAccess = {
+			can: (/*role*/) => {
+				return Promise.resolve({
+					permission_visibility: 'all'
+				});
+			}
+		};
         
-        return internalAccessList.getAll(fakeAccess)
-            .then((rows) => {
-                const promises = [];
-                for (const row of rows) {
-                    const p = internalAccessList.get(fakeAccess, {
-                        id:     row.id,
-                        expand: ['owner', 'items', 'clients', 'proxy_hosts.[certificate,access_list.[clients,items]]']
-                    }, true /* <- skip masking */);
-                    promises.push(p);
-                }
-                if (promises.length) {
-                    return Promise.all(promises);
-                }
-                return Promise.resolve([]);
-            });
-    }
+		return internalAccessList.getAll(fakeAccess)
+			.then((rows) => {
+				const promises = [];
+				for (const row of rows) {
+					const p = internalAccessList.get(fakeAccess, {
+						id:     row.id,
+						expand: ['owner', 'items', 'clients', 'proxy_hosts.[certificate,access_list.[clients,items]]']
+					}, true /* <- skip masking */);
+					promises.push(p);
+				}
+				if (promises.length) {
+					return Promise.all(promises);
+				}
+				return Promise.resolve([]);
+			});
+	}
 };
 
 module.exports = ddnsResolver;

--- a/backend/lib/ddns_resolver/ddns_resolver.js
+++ b/backend/lib/ddns_resolver/ddns_resolver.js
@@ -1,0 +1,308 @@
+const error                 = require('../error')
+const logger                = require('../../logger').global;
+const internalAccessList    = require('../../internal/access-list');
+const internalNginx         = require('../../internal/nginx');
+const spawn                 = require('child_process').spawn;
+
+const cmdHelper = {
+    /**
+     * Run the given command. Safer than using exec since args are passed as a list instead of in shell mode as a single string.
+     * @param {string} cmd The command to run
+     * @param {string} args The args to pass to the command
+     * @returns Promise that resolves to stdout or an object with error code and stderr if there's an error
+     */
+    run: (cmd, args) => {
+        return new Promise((resolve, reject) => {
+            let stdout = '';
+            let stderr = '';
+            const proc = spawn(cmd, args);
+            proc.stdout.on('data', (data) => {
+                stdout += data;
+            });
+            proc.stderr.on('data', (data) => {
+                stderr += data;
+            });
+
+            proc.on('close', (exitCode) => {
+                if (!exitCode) {
+                    resolve(stdout.trim());
+                } else {
+                    reject({
+                        exitCode: exitCode,
+                        stderr: stderr
+                    });
+                }
+            });
+        });
+    }
+};
+
+const ddnsResolver = {
+    /**
+     * Starts a timer to periodically check for ddns updates
+     */
+    initTimer: () => {
+        ddnsResolver._initialize();
+        ddnsResolver._interval = setInterval(ddnsResolver._checkForDDNSUpdates, ddnsResolver._updateIntervalMs);
+        logger.info(`DDNS Update Timer initialized (interval: ${Math.floor(ddnsResolver._updateIntervalMs / 1000)}s)`);
+        // Trigger a run so that initial cache is populated and hosts can be updated - delay by 10s to give server time to boot up
+        setTimeout(ddnsResolver._checkForDDNSUpdates, 10 * 1000);
+    },
+
+    /**
+     * Checks whether the address requires resolution (i.e. starts with ddns:)
+     * @param {String} address 
+     * @returns {boolean}
+     */
+    requiresResolution: (address) => {
+        if (typeof address !== 'undefined' && address && address.toLowerCase().startsWith('ddns:')) {
+			return true;
+		}
+		return false;
+    },
+
+    /**
+     * Resolves the given address to its IP
+     * @param {String} address 
+     * @param {boolean} forceUpdate: whether to force resolution instead of using the cached value
+     */
+    resolveAddress: (address, forceUpdate=false) => {
+        if (!forceUpdate && ddnsResolver._cache.has(address)) {
+            // Check if it is still valid
+            const value = ddnsResolver._cache.get(address);
+            const ip = value[0];
+            const lastUpdated = value[1];
+            const nowSeconds = Date.now();
+            const delta = nowSeconds - lastUpdated;
+            if (delta < ddnsResolver._updateIntervalMs) {
+                return Promise.resolve(ip);
+            }
+        }
+        ddnsResolver._cache.delete(address);
+        // Reach here only if cache value doesn't exist or needs to be updated 
+        let host = address.toLowerCase();
+        if (host.startsWith('ddns:')) {
+            host = host.substring(5);
+        }
+        return ddnsResolver._queryHost(host)
+            .then((resolvedIP) => {
+                ddnsResolver._cache.set(address, [resolvedIP, Date.now()]);
+                return resolvedIP;
+            })
+            .catch((_error) => {
+                // return input address in case of failure
+                return address;
+            });
+    },
+
+    
+    /** Private **/
+    // Properties
+    _initialized: false,
+    _updateIntervalMs: 1000 * 60 * 60, // 1 hr default (overriden with $DDNS_UPDATE_INTERVAL env var)
+    /**
+     * cache mapping host to (ip address, last updated time)
+     */
+    _cache: new Map(),
+    _interval: null, // reference to created interval id
+    _processingDDNSUpdate: false,
+    
+    _originalGenerateConfig: null, // Used for patching config generation to resolve hosts
+
+    // Methods
+
+    _initialize: () => {
+        if (ddnsResolver._initialized) {
+            return;
+        }
+        // Init the resolver
+        // Read and set custom update interval from env if needed
+        if (typeof process.env.DDNS_UPDATE_INTERVAL !== 'undefined') {
+            const interval = Number(process.env.DDNS_UPDATE_INTERVAL.toLowerCase());
+            if (!isNaN(interval)) {
+                // Interval value from env is in seconds. Set min to 60s.
+                ddnsResolver._updateIntervalMs = Math.max(interval * 1000, 60 * 1000);
+            } else {
+                logger.warn(`[DDNS] invalid value for update interval: '${process.env.DDNS_UPDATE_INTERVAL}'`);
+            }
+        }
+        
+        // Patch nginx config generation if needed (check env var)
+        if (typeof process.env.DDNS_UPDATE_PATCH !== 'undefined') {
+            const enabled = Number(process.env.DDNS_UPDATE_PATCH.toLowerCase());
+            if (!isNaN(enabled) && enabled) {
+                logger.info('Patching nginx config generation');
+                ddnsResolver._originalGenerateConfig = internalNginx.generateConfig;
+                internalNginx.generateConfig = ddnsResolver._patchedGenerateConfig;
+            }
+        }
+        ddnsResolver._initialized = true;
+    },
+
+    /**
+     * 
+     * @param {String} host 
+     * @returns {Promise}
+     */
+    _queryHost: (host) => {
+        logger.info('Looking up IP for ', host);
+        return cmdHelper.run('getent', ['hosts', host])
+            .then((result) => {
+                if (result.length < 8) {
+                    logger.error('IP lookup returned invalid output: ', result);
+                    throw error.ValidationError('Invalid output from getent hosts');
+                }
+                const out = result.split(/\s+/);
+                logger.info(`Resolved ${host} to ${out[0]}`);
+                return out[0];
+            },
+            (error) => {
+                logger.error('Error looking up IP for ' + host + ': ', error);
+                throw error; 
+            });
+    },
+
+    _patchedGenerateConfig: (host_type, host) => {
+        const promises = [];
+        if (host_type === 'proxy_host') {
+            if (typeof host.access_list !== 'undefined' && typeof host.access_list.clients !== 'undefined') {
+                for (const client of host.access_list.clients) {
+                    if (ddnsResolver.requiresResolution(client.address)) {
+                        const p = ddnsResolver.resolveAddress(client.address)
+                            .then((resolvedIP) => {
+                                client.address = `${resolvedIP}; # ${client.address}`;
+                                return Promise.resolve();
+                            });
+                        promises.push(p);
+                    }
+                }
+            }
+        }
+        if (promises.length) {
+            return Promise.all(promises)
+                .then(() => {
+                    return ddnsResolver._originalGenerateConfig(host_type, host);
+                });
+        }
+        return ddnsResolver._originalGenerateConfig(host_type, host);
+    },
+
+    /**
+     * Triggered by a timer, will check for and update ddns hosts in access list clients
+    */
+    _checkForDDNSUpdates: () => {
+        logger.info('Checking for DDNS updates...');
+        if (!ddnsResolver._processingDDNSUpdate) {
+            ddnsResolver._processingDDNSUpdate = true;
+            
+            const updatedAddresses = new Map();
+
+            // Get all ddns hostnames in use
+            return ddnsResolver._getAccessLists()
+                .then((rows) => {
+                    // Build map of used addresses that require resolution
+                    const usedAddresses = new Map();
+                    for (const row of rows) {
+                        if (!row.proxy_host_count) {
+                            // Ignore rows (access lists) that are not associated to any hosts
+                            continue;
+                        }
+                        for (const client of row.clients) {
+                            if (!ddnsResolver.requiresResolution(client.address)) {
+                                continue;
+                            }
+                            if (!usedAddresses.has(client.address)) {
+                                usedAddresses.set(client.address, [row]);
+                            } else {
+                                usedAddresses.get(client.address).push(row);
+                            }
+                        }
+                    }
+                    logger.info(`Found ${usedAddresses.size} address(es) in use.`);
+                    // Remove unused addresses
+                    const addressesToRemove = [];
+                    for (const address of ddnsResolver._cache.keys()) {
+                        if (!usedAddresses.has(address)) {
+                            addressesToRemove.push(address);
+                        }
+                    }
+                    addressesToRemove.forEach((address) => { ddnsResolver._cache.delete(address); });
+
+                    const promises = [];
+
+                    for (const [address, rows] of usedAddresses) {
+                        let oldIP = '';
+                        if (ddnsResolver._cache.has(address)) {
+                            oldIP = ddnsResolver._cache.get(address)[0];
+                        }
+                        const p = ddnsResolver.resolveAddress(address, true)
+                        .then((resolvedIP) => {
+                                if (resolvedIP !== address && resolvedIP !== oldIP) {
+                                    // Mark this as an updated address
+                                    updatedAddresses.set(address, rows);
+                                }
+                            });
+                        promises.push(p);
+                    }
+
+                    if (promises.length) {
+                        return Promise.all(promises);
+                    }
+                    return Promise.resolve();
+                })
+                .then(() => {
+                    logger.info(`${updatedAddresses.size} DDNS IP(s) updated.`);
+                    const updatedRows = new Map();
+                    const proxy_hosts = [];
+                    for (const rows of updatedAddresses.values()) {
+                        for (const row of rows) {
+                            if (!updatedRows.has(row.id)) {
+                                updatedRows.set(row.id, 1);
+                                proxy_hosts.push(...row.proxy_hosts);
+                            }
+                        }
+                    }
+                    if (proxy_hosts.length) {
+                        logger.info(`Updating ${proxy_hosts.length} proxy host(s) affected by DDNS changes`);
+                        return internalNginx.bulkGenerateConfigs('proxy_host', proxy_hosts)
+                            .then(internalNginx.reload);
+                    }
+                    return Promise.resolve();
+                })
+                .then(() => {
+                    logger.info('Finished checking for DDNS updates');
+                    ddnsResolver._processingDDNSUpdate = false;
+                });
+        } else {
+            logger.info('Skipping since previous DDNS update check is in progress');
+        }
+    },
+
+    _getAccessLists: () => {
+        const fakeAccess = {
+            can: (capabilityStr) => {
+                return Promise.resolve({
+                    permission_visibility: 'all'
+                })
+            }
+        };
+        
+        return internalAccessList.getAll(fakeAccess)
+            .then((rows) => {
+                const promises = [];
+                for (const row of rows) {
+                    const p = internalAccessList.get(fakeAccess, {
+                        id:     row.id,
+                        expand: ['owner', 'items', 'clients', 'proxy_hosts.[certificate,access_list.[clients,items]]']
+                    }, true /* <- skip masking */);
+                    promises.push(p);
+                }
+                if (promises.length) {
+                    return Promise.all(promises);
+                }
+                return Promise.resolve([]);
+            });
+    }
+};
+
+module.exports = ddnsResolver;

--- a/backend/lib/ddns_resolver/ddns_resolver.js
+++ b/backend/lib/ddns_resolver/ddns_resolver.js
@@ -1,0 +1,85 @@
+const error  = require('../error');
+const logger = require('../../logger').ddns;
+const utils  = require('../utils');
+
+const ddnsResolver = {
+	/**
+     * Checks whether the address requires resolution (i.e. starts with ddns:)
+     * @param {String} address 
+     * @returns {boolean}
+     */
+	requiresResolution: (address) => {
+		if (typeof address !== 'undefined' && address && address.toLowerCase().startsWith('ddns:')) {
+			return true;
+		}
+		return false;
+	},
+
+	/**
+     * Resolves the given address to its IP
+     * @param {String} address 
+     * @param {boolean} forceUpdate: whether to force resolution instead of using the cached value
+     */
+	resolveAddress: (address, forceUpdate=false) => {
+		if (!forceUpdate && ddnsResolver._cache.has(address)) {
+			// Check if it is still valid
+			const value       = ddnsResolver._cache.get(address);
+			const ip          = value[0];
+			const lastUpdated = value[1];
+			const nowSeconds  = Date.now();
+			const delta       = nowSeconds - lastUpdated;
+			if (delta < ddnsResolver._updateIntervalMs) {
+				return Promise.resolve(ip);
+			}
+		}
+		ddnsResolver._cache.delete(address);
+		// Reach here only if cache value doesn't exist or needs to be updated 
+		let host = address.toLowerCase();
+		if (host.startsWith('ddns:')) {
+			host = host.substring(5);
+		}
+		return ddnsResolver._queryHost(host)
+			.then((resolvedIP) => {
+				ddnsResolver._cache.set(address, [resolvedIP, Date.now()]);
+				return resolvedIP;
+			})
+			.catch((/*error*/) => {
+				// return input address in case of failure
+				return address;
+			});
+	},
+
+    
+	/** Private **/
+	// Properties
+	/**
+     * cache mapping host to (ip address, last updated time)
+     */
+	_cache: new Map(),
+
+	// Methods
+	/**
+     * 
+     * @param {String} host 
+     * @returns {Promise}
+     */
+	_queryHost: (host) => {
+		logger.info('Looking up IP for ', host);
+		return utils.execSafe('getent', ['hosts', host])
+			.then((result) => {
+				if (result.length < 8) {
+					logger.error('IP lookup returned invalid output: ', result);
+					throw error.ValidationError('Invalid output from getent hosts');
+				}
+				const out = result.split(/\s+/);
+				logger.info(`Resolved ${host} to ${out[0]}`);
+				return out[0];
+			},
+			(error) => {
+				logger.error('Error looking up IP for ' + host + ': ', error);
+				throw error; 
+			});
+	},
+};
+
+module.exports = ddnsResolver;

--- a/backend/lib/ddns_resolver/ddns_resolver.js
+++ b/backend/lib/ddns_resolver/ddns_resolver.js
@@ -64,15 +64,13 @@ const ddnsResolver = {
      * @returns {Promise}
      */
 	_queryHost: (host) => {
-		logger.info('Looking up IP for ', host);
 		return utils.execSafe('getent', ['hosts', host])
 			.then((result) => {
 				if (result.length < 8) {
-					logger.error('IP lookup returned invalid output: ', result);
+					logger.error(`IP lookup for ${host} returned invalid output: ${result}`);
 					throw error.ValidationError('Invalid output from getent hosts');
 				}
 				const out = result.split(/\s+/);
-				logger.info(`Resolved ${host} to ${out[0]}`);
 				return out[0];
 			},
 			(error) => {

--- a/backend/lib/ddns_resolver/ddns_updater.js
+++ b/backend/lib/ddns_resolver/ddns_updater.js
@@ -113,7 +113,11 @@ const ddnsUpdater = {
 						for (const row of rows) {
 							if (!updatedRows.has(row.id)) {
 								updatedRows.set(row.id, 1);
-								proxy_hosts.push(...row.proxy_hosts);
+								for (const host of row.proxy_hosts) {
+									if (host.enabled) {
+										proxy_hosts.push(host);
+									}
+								}
 							}
 						}
 					}

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -51,7 +51,7 @@ module.exports = {
 				} else {
 					reject({
 						exitCode: exitCode,
-						stderr: stderr
+						stderr:   stderr
 					});
 				}
 			});

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -4,6 +4,7 @@ const execFile   = require('child_process').execFile;
 const { Liquid } = require('liquidjs');
 const logger     = require('../logger').global;
 const error      = require('./error');
+const spawn      = require('child_process').spawn;
 
 module.exports = {
 
@@ -24,6 +25,37 @@ module.exports = {
 			});
 		});
 		return stdout;
+	},
+
+	/**
+	 * Run the given command. Safer than using exec since args are passed as a list instead of in shell mode as a single string.
+	 * @param {string} cmd The command to run
+	 * @param {string} args The args to pass to the command
+	 * @returns Promise that resolves to stdout or an object with error code and stderr if there's an error
+	 */
+	execSafe: (cmd, args) => {
+		return new Promise((resolve, reject) => {
+			let stdout = '';
+			let stderr = '';
+			const proc = spawn(cmd, args);
+			proc.stdout.on('data', (data) => {
+				stdout += data;
+			});
+			proc.stderr.on('data', (data) => {
+				stderr += data;
+			});
+
+			proc.on('close', (exitCode) => {
+				if (!exitCode) {
+					resolve(stdout.trim());
+				} else {
+					reject({
+						exitCode: exitCode,
+						stderr: stderr
+					});
+				}
+			});
+		});
 	},
 
 	/**

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -128,6 +128,9 @@ module.exports = {
 		 */
 		renderEngine.registerFilter('nginxAccessRule', (v) => {
 			if (typeof v.directive !== 'undefined' && typeof v.address !== 'undefined' && v.directive && v.address) {
+				if (typeof v.resolvedAddress !== 'undefined' && v.resolvedAddress) {
+					return `${v.directive} ${v.resolvedAddress}; # ${v.address}`;
+				}
 				return `${v.directive} ${v.address};`;
 			}
 			return '';

--- a/backend/logger.js
+++ b/backend/logger.js
@@ -10,5 +10,6 @@ module.exports = {
 	certbot:   new Signale({scope: 'Certbot  '}),
 	import:    new Signale({scope: 'Importer '}),
 	setup:     new Signale({scope: 'Setup    '}),
-	ip_ranges: new Signale({scope: 'IP Ranges'})
+	ip_ranges: new Signale({scope: 'IP Ranges'}),
+	ddns:      new Signale({scope: 'DDNS     '})
 };

--- a/backend/schema/endpoints/access-lists.json
+++ b/backend/schema/endpoints/access-lists.json
@@ -36,6 +36,10 @@
 				{
 					"type": "string",
 					"pattern": "^all$"
+				},
+				{
+					"type": "string",
+					"pattern": "^ddns:[\\w\\.]+$"
 				}
 			]
 		},

--- a/backend/schema/endpoints/access-lists.json
+++ b/backend/schema/endpoints/access-lists.json
@@ -39,7 +39,7 @@
 				},
 				{
 					"type": "string",
-					"pattern": "^ddns:[\\w\\.]+$"
+					"pattern": "^ddns:[\\w\\.-]+$"
 				}
 			]
 		},


### PR DESCRIPTION
Added support for `ddns:somedomain.whateverddns.com` address format in the client access lists.

This allows users to specify domain names instead of IP addresses for allow/deny lists, thereby allowing dynamic allow/deny lists.

This is useful if users have a service exposed to the public internet via a ddns domain, and they want to limit it so that only users from the local network can access the service on the ddns domain. 

In theory, this is probably already possible by using custom DNS server to prevent any local network request to the domain name from going outside to the internet (and then setting allow list to local subnet in proxy manager), but not everyone can (or will) use a custom DNS server for their setup.

The new ddns support makes it trivially easy for anyone to limit to local network if they are using ddns without having to mess with custom DNS servers or network configuration. Also, if users want to expose their service to a fixed number of external users, then the ddns lookup can be used with the allow list provided the external users are using a ddns service. E.g. if I want to share a service on my network to 2 friends, and each friend uses a ddns that points to their public IP (friend1.domain.com, friend2.domain.com), then I can just add `ddns:friend1.domain.com` and `ddns:friend2.domain.com` to my allow list in proxy manager and they will continue to have access even if their public IP changes. I won't have to manually go an update the access list every time the IP changes.

This should address #1708 and #2240 .

Compared to some of the existing solutions mentioned in the above issues, this implementation should be the simplest with minimal overhead and no other dependencies (e.g. no cron, env vars, etc needed). Can directly specify the domains in the normal allow list UI.

Usage:
- Prefix the dynamic domain/host you want to use for the access list with `ddns:`
e.g. If you want to add the dynamic hosts `yourdomain.ddns.com` and `yourdomain2.ddns.com` to your allow list, do the following:
![image](https://github.com/NginxProxyManager/nginx-proxy-manager/assets/651665/7c3327c8-ed4d-4a35-a768-7e8b96b63877)
- Upon saving the access list, any associated hosts will automatically be updated to use the resolved IP of the dynamic domain/host in the access list (and this will trigger a nginx reload so that changes take effect).
- The proxy manager will also periodically poll the dynamic domains, and update any proxy hosts that are using those domains if there is an IP address update. Default interval is 1 hour, can be configured by setting the `DDNS_UPDATE_INTERVAL` env var to the desired number of seconds (minimum 60).
On start up, all used domains will be resolved and any associated hosts will be updated in nginx about 10s after the proxy manager starts (10s buffer ensures server has enough time to finish loading).


Disclaimers:
- I haven't used js in almost 6 years, do not be surprised if the code is inefficient / not following best practices. Suggestions for cleaning up and refactoring the code to make it more efficient/readable are welcome!
- I'm using `getent hosts <hostname>` to look up the IP of the user defined domains - if there is a better way, please let me know and I can update the PR. I've tried to make it safe by using spawn instead of exec to prevent issues with unsanitized user inputs, however I'm not doing any custom sanitization.
