### PR TITLE
Fixed issue where the HTTP2 support was always enabled in nginx config

### DIFF
--- a/backend/templates/_listen.conf
+++ b/backend/templates/_listen.conf
@@ -5,9 +5,9 @@
   #listen [::]:80;
 {% endif %}
 {% if certificate -%}
-  listen 443 ssl{% if http2_support %} http2{% endif %};
+  listen 443 ssl{% if http2_support == 1 or http2_support == true %} http2{% endif %};
 {% if ipv6 -%}
-  listen [::]:443 ssl{% if http2_support %} http2{% endif %};
+  listen [::]:443 ssl{% if http2_support == 1 or http2_support == true %} http2{% endif %};
 {% else -%}
   #listen [::]:443;
 {% endif %}


### PR DESCRIPTION
It was enabled even when disabled by the user.