### PR TITLE
Make auto-renew use built-in renew function

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -26,10 +26,11 @@ function omissions() {
 
 const internalCertificate = {
 
-	allowedSslFiles:    ['certificate', 'certificate_key', 'intermediate_certificate'],
-	intervalTimeout:    1000 * 60 * 60, // 1 hour
-	interval:           null,
-	intervalProcessing: false,
+	allowedSslFiles:         ['certificate', 'certificate_key', 'intermediate_certificate'],
+	intervalTimeout:         1000 * 60 * 60, // 1 hour
+	interval:                null,
+	intervalProcessing:      false,
+	renewBeforeExpirationBy: [7, 'days'],
 
 	initTimer: () => {
 		logger.info('Let\'s Encrypt Renewal Timer initialized');
@@ -46,58 +47,41 @@ const internalCertificate = {
 			internalCertificate.intervalProcessing = true;
 			logger.info('Renewing SSL certs close to expiry...');
 
-			const cmd = certbotCommand + ' renew --non-interactive --quiet ' +
-				'--config "' + letsencryptConfig + '" ' +
-				'--work-dir "/tmp/letsencrypt-lib" ' +
-				'--logs-dir "/tmp/letsencrypt-log" ' +
-				'--preferred-challenges "dns,http" ' +
-				'--disable-hook-validation ' +
-				(letsencryptStaging ? '--staging' : '');
+			const expirationThreshold = moment().add(internalCertificate.renewBeforeExpirationBy[0], internalCertificate.renewBeforeExpirationBy[1]).format('YYYY-MM-DD HH:mm:ss');
 
-			return utils.exec(cmd)
-				.then((result) => {
-					if (result) {
-						logger.info('Renew Result: ' + result);
+			// Fetch all the letsencrypt certs from the db that will expire within 7 days
+			certificateModel
+				.query()
+				.where('is_deleted', 0)
+				.andWhere('provider', 'letsencrypt')
+				.andWhere('expires_on', '<', expirationThreshold)
+				.then((certificates) => {
+					if (!certificates || !certificates.length) {
+						return null;
 					}
 
-					return internalNginx.reload()
-						.then(() => {
-							logger.info('Renew Complete');
-							return result;
-						});
-				})
-				.then(() => {
-					// Now go and fetch all the letsencrypt certs from the db and query the files and update expiry times
-					return certificateModel
-						.query()
-						.where('is_deleted', 0)
-						.andWhere('provider', 'letsencrypt')
-						.then((certificates) => {
-							if (certificates && certificates.length) {
-								let promises = [];
+					let promises = [];
 
-								certificates.map(function (certificate) {
-									promises.push(
-										internalCertificate.getCertificateInfoFromFile('/etc/letsencrypt/live/npm-' + certificate.id + '/fullchain.pem')
-											.then((cert_info) => {
-												return certificateModel
-													.query()
-													.where('id', certificate.id)
-													.andWhere('provider', 'letsencrypt')
-													.patch({
-														expires_on: moment(cert_info.dates.to, 'X').format('YYYY-MM-DD HH:mm:ss')
-													});
-											})
-											.catch((err) => {
-												// Don't want to stop the train here, just log the error
-												logger.error(err.message);
-											})
-									);
-								});
+					certificates.forEach(function (certificate) {
+						const promise = internalCertificate
+							.renew(
+								{
+									can: () =>
+										Promise.resolve({
+											permission_visibility: 'all',
+										}),
+								},
+								{ id: certificate.id },
+							)
+							.catch((err) => {
+								// Don't want to stop the train here, just log the error
+								logger.error(err.message);
+							});
 
-								return Promise.all(promises);
-							}
-						});
+						promises.push(promise);
+					});
+
+					return Promise.all(promises);
 				})
 				.then(() => {
 					internalCertificate.intervalProcessing = false;


### PR DESCRIPTION
As a complete newcomer to this project, this is my attempt to fix certificate auto-renew issues #1916 where manual renew works, but automatic renew does not. This changes proposes we replace the functionality inside automatic renewal with a call to the same function used for manual renewal.

Specifically, I have replaced the certbot 'renew everything' command with a DB-driven one-by-one renewal. Determining which certificates need renewal is a pretty naive time based DB query, and access control is completely bypassed with `Promise.resolve({ permission_visibility: 'all' }` because I assume it isn't needed for a background job.

I'm not sure yet how to best contribute to this project, and I'm sure there are some issues with this so please do guide me as I'm brand new here.