### PR TITLE
Update year to 2024 in footer

### DIFF
--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -60,7 +60,7 @@
     },
     "footer": {
       "fork-me": "Fork me on Github",
-      "copy": "&copy; 2023 <a href=\"{url}\" target=\"_blank\">jc21.com</a>.",
+      "copy": "&copy; 2024 <a href=\"{url}\" target=\"_blank\">jc21.com</a>.",
       "theme": "Theme by <a href=\"{url}\" target=\"_blank\">Tabler</a>"
     },
     "dashboard": {


### PR DESCRIPTION
I noticed that in v2.10.4 the year in the footer was updated to 2023, it's now time to bump that again :)