### PR TITLE
Fix typo in logrotate config path

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -204,7 +204,7 @@ You can customise the logrotate configuration through a mount (if your custom co
 ```yml
   volumes:
     ...
-    - ./logrotate.custom:/etc/logrotate.d/nginx-proxy/manager
+    - ./logrotate.custom:/etc/logrotate.d/nginx-proxy-manager
 ```
 
 For reference, the default configuration can be found [here](https://github.com/NginxProxyManager/nginx-proxy-manager/blob/develop/docker/rootfs/etc/logrotate.d/nginx-proxy-manager).


### PR DESCRIPTION
As mentioned in #3422, there is a typo in my previous PR to add docs on customising logrotate.