### PR TITLE
Fixing "the map directive is not allowed here" at the validation stage

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,4 +1,3 @@
-  {% include "_hsts_map.conf" %}
 
   location {{ path }} {
     proxy_set_header Host $host;


### PR DESCRIPTION
### TLDR:
The map directive is only allowed in the http context. 
See https://nginx.org/en/docs/http/ngx_http_map_module.html

### Longer Description:

This map block was introduced in [this commit](https://github.com/NginxProxyManager/nginx-proxy-manager/commit/289e438c59ed707f6335404da2e4b15589583075)


If the code in [_hsts_map.conf](https://github.com/NginxProxyManager/nginx-proxy-manager/blob/0353051436f96ce3025043d874bc3783e895bed4/backend/templates/_hsts_map.conf) is included in the [_location.conf](https://github.com/NginxProxyManager/nginx-proxy-manager/blob/0353051436f96ce3025043d874bc3783e895bed4/backend/templates/_location.conf#L4), it will be rendered inside of the server context, which produces an error at the nginx validation stage. This is because the map directive is only allowed in the http context.

I used the docker version nginx-proxy-manager:latest (a3a54016e85f)

To get to the fail (Offline) state:

- add a proxy host
- add a certificate and activate HSTS
- add a custom location
- save

Now the new proxy-host should fail and be offline.

