### PR TITLE
Fix: increase max number of domains to 100 (match with Let's Encrypt)

### DIFF
--- a/backend/schema/definitions.json
+++ b/backend/schema/definitions.json
@@ -172,7 +172,7 @@
       "description": "Domain Names separated by a comma",
       "example": "*.jc21.com,blog.jc21.com",
       "type": "array",
-      "maxItems": 30,
+      "maxItems": 100,
       "uniqueItems": true,
       "items": {
         "type": "string",

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,5 +1,3 @@
-  {% include "_hsts_map.conf" %}
-
   location {{ path }} {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;

--- a/frontend/js/app/nginx/certificates/form.js
+++ b/frontend/js/app/nginx/certificates/form.js
@@ -265,7 +265,7 @@ module.exports = Mn.View.extend({
         this.ui.domain_names.selectize({
             delimiter:    ',',
             persist:      false,
-            maxOptions:   30,
+            maxOptions:   100,
             create:       function (input) {
                 return {
                     value: input,

--- a/frontend/js/app/nginx/dead/form.js
+++ b/frontend/js/app/nginx/dead/form.js
@@ -233,7 +233,7 @@ module.exports = Mn.View.extend({
         this.ui.domain_names.selectize({
             delimiter:    ',',
             persist:      false,
-            maxOptions:   30,
+            maxOptions:   100,
             create:       function (input) {
                 return {
                     value: input,

--- a/frontend/js/app/nginx/proxy/form.js
+++ b/frontend/js/app/nginx/proxy/form.js
@@ -271,7 +271,7 @@ module.exports = Mn.View.extend({
         this.ui.domain_names.selectize({
             delimiter:    ',',
             persist:      false,
-            maxOptions:   30,
+            maxOptions:   100,
             create:       function (input) {
                 return {
                     value: input,

--- a/frontend/js/app/nginx/redirection/form.js
+++ b/frontend/js/app/nginx/redirection/form.js
@@ -235,7 +235,7 @@ module.exports = Mn.View.extend({
         this.ui.domain_names.selectize({
             delimiter:    ',',
             persist:      false,
-            maxOptions:   30,
+            maxOptions:   100,
             create:       function (input) {
                 return {
                     value: input,


### PR DESCRIPTION
CC @jc21 

Let's make the limit of domains count equal to the Let's Encrypt limit, as suggested here https://github.com/NginxProxyManager/nginx-proxy-manager/pull/3382#issuecomment-1854005778, when the limit was raised from 15 to 30 in last December.

In my use case, I have a big SAN cert - lots of subdomains and "www." is needed to be supported too, so everything twice; I am not able to configure this in nginx-proxy-manager at the moment.

ref: https://github.com/NginxProxyManager/nginx-proxy-manager/issues/3218, https://github.com/NginxProxyManager/nginx-proxy-manager/pull/3382

I would be glad if you could approve & merge this change :)
Thx and have a nice day,

D.