### PR TITLE
Update certbot-dns-duckdns version (fix #2994)

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -90,7 +90,7 @@
 	"duckdns": {
 		"name": "DuckDNS",
 		"package_name": "certbot-dns-duckdns",
-		"version": "~=0.9",
+		"version": "~=1.0",
 		"dependencies": "",
 		"credentials": "dns_duckdns_token=your-duckdns-token",
 		"full_plugin_name": "dns-duckdns"


### PR DESCRIPTION
So this fixes #2994, a version conflict that can be solved by updating the duckdns certbot version