### PR TITLE
replaced chown with find -not -user -execdir chown

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/prepare/30-ownership.sh
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/prepare/30-ownership.sh
@@ -25,4 +25,4 @@ chown -R "$PUID:$PGID" /etc/nginx/conf.d
 
 # Prevents errors when installing python certbot plugins when non-root
 chown "$PUID:$PGID" /opt/certbot /opt/certbot/bin
-chown -R "$PUID:$PGID" /opt/certbot/lib/python*/site-packages
+find /opt/certbot/lib/python*/site-packages -not -user "$PUID" -execdir chown "$PUID:$PGID" {} \+


### PR DESCRIPTION
chown -R tries to chown all files. find -not -user -execdir only chowns files not owned by PUID.
This should fix #2991 especially on high io delay systems