### PR TITLE
Update certbot-dns-goddaddy

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -194,7 +194,7 @@
 	"godaddy": {
 		"name": "GoDaddy",
 		"package_name": "certbot-dns-godaddy",
-		"version": "=={{certbot-version}}",
+		"version": "==2.8.0",
 		"dependencies": "",
 		"credentials": "dns_godaddy_secret = 0123456789abcdef0123456789abcdef01234567\ndns_godaddy_key = abcdef0123456789abcdef01234567abcdef0123",
 		"full_plugin_name": "dns-godaddy"


### PR DESCRIPTION
certbot-dns-godaddy has no v2.9.0, so cannot be tied to current certbot version.
Pinned at the latest 2.8.0 which has dependancy: `certbot = ">=2.8.0"`