### PR TITLE
fix: update certbot-dns-transip to latest version

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -418,7 +418,7 @@
 	"transip": {
 		"name": "TransIP",
 		"package_name": "certbot-dns-transip",
-		"version": "~=0.4.3",
+		"version": "~=0.5.2",
 		"dependencies": "",
 		"credentials": "dns_transip_username = my_username\ndns_transip_key_file = /etc/letsencrypt/transip-rsa.key",
 		"full_plugin_name": "dns-transip"


### PR DESCRIPTION
This updates the `certbot-dns-transip` package to the latest version, since the current version is incompatible with certbot 2.0.