### PR TITLE
Map volumes to persistent paths in example compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ services:
       - '81:81'
       - '443:443'
     volumes:
-      - ./data:/data
-      - ./letsencrypt:/etc/letsencrypt
+      - /srv/nginx-proxy-manager/data:/data
+      - /srv/nginx-proxy-manager/letsencrypt:/etc/letsencrypt
 ```
 
 This is the bare minimum configuration required. See the [documentation](https://nginxproxymanager.com/setup/) for more.

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -121,8 +121,8 @@ services:
       # Uncomment this if IPv6 is not enabled on your host
       # DISABLE_IPV6: 'true'
     volumes:
-      - ./data:/data
-      - ./letsencrypt:/etc/letsencrypt
+      - /srv/nginx-proxy-manager/data:/data
+      - /srv/nginx-proxy-manager/letsencrypt:/etc/letsencrypt
     secrets:
       - MYSQL_PWD
     depends_on:

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -28,8 +28,8 @@ services:
       # DISABLE_IPV6: 'true'
 
     volumes:
-      - ./data:/data
-      - ./letsencrypt:/etc/letsencrypt
+      - /srv/nginx-proxy-manager/data:/data
+      - /srv/nginx-proxy-manager/letsencrypt:/etc/letsencrypt
 ```
 
 Then:
@@ -73,8 +73,8 @@ services:
       # Uncomment this if IPv6 is not enabled on your host
       # DISABLE_IPV6: 'true'
     volumes:
-      - ./data:/data
-      - ./letsencrypt:/etc/letsencrypt
+      - /srv/nginx-proxy-manager/data:/data
+      - /srv/nginx-proxy-manager/letsencrypt:/etc/letsencrypt
     depends_on:
       - db
 


### PR DESCRIPTION
The documentation currently includes example `docker-compose.yml` files that will clear users' NPM data when the server is re-deployed, which can confuse, e.g., [this Reddit post](https://www.reddit.com/r/nginxproxymanager/comments/v8i7ju/nginx_proxymanager_data_removing_always_aftest/).

This pull request makes the example compose files instead save to a persistent location, `/srv/nginx-proxy-manager`.