### PR TITLE
Display proxy ID following the Creation date in proxy list

### DIFF
--- a/frontend/js/app/nginx/proxy/list/item.ejs
+++ b/frontend/js/app/nginx/proxy/list/item.ejs
@@ -20,6 +20,7 @@
     </div>
     <div class="small text-muted">
         <%- i18n('str', 'created-on', {date: formatDbDate(created_on, 'Do MMMM YYYY')}) %>
+        (#<%- id %>)
     </div>
 </td>
 <td>


### PR DESCRIPTION
Whenever you need to consult logs or manually modify a configuration on the server, the ID is a key element. Of course, it's possible to find information in the files, but having this information prominently displayed in the list would be a real plus.