### PR TITLE
fix: update certbot-dns-strato to latest version

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -402,7 +402,7 @@
 	"strato": {
 		"name": "Strato",
 		"package_name": "certbot-dns-strato",
-		"version": "~=0.1.1",
+		"version": "~=0.2.1",
 		"dependencies": "",
 		"credentials": "dns_strato_username = user\ndns_strato_password = pass\n# uncomment if youre using two factor authentication:\n# dns_strato_totp_devicename = 2fa_device\n# dns_strato_totp_secret = 2fa_secret\n#\n# uncomment if domain name contains special characters\n# insert domain display name as seen on your account page here\n# dns_strato_domain_display_name = my-punicode-url.de\n#\n# if youre not using strato.de or another special endpoint you can customise it below\n# you will probably only need to adjust the host, but you can also change the complete endpoint url\n# dns_strato_custom_api_scheme = https\n# dns_strato_custom_api_host = www.strato.de\n# dns_strato_custom_api_port = 443\n# dns_strato_custom_api_path = \"/apps/CustomerService\"",
 		"full_plugin_name": "dns-strato"


### PR DESCRIPTION
Updates `certbot-dns-strato` to the latest version (`2.1.0`) to be compatible with the [new Strato package ID format](https://github.com/FlixMa/certbot-dns-strato/commit/3148d6dc696983cdea0f36ff5792cb3a87db9c8f)