### PR TITLE
Set interval timeout for certificates via environment variable

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -29,7 +29,7 @@ function omissions() {
 const internalCertificate = {
 
 	allowedSslFiles:         ['certificate', 'certificate_key', 'intermediate_certificate'],
-	intervalTimeout:         1000 * 60 * 60, // 1 hour
+	intervalTimeout:         process.env.CERT_INTERVAL_TIMEOUT || 1000 * 60 * 60, // Value (ms) OR default of 1 hour
 	interval:                null,
 	intervalProcessing:      false,
 	renewBeforeExpirationBy: [30, 'days'],


### PR DESCRIPTION
There's no need to run certificate renewal every hour, making it at least configurable would at least allow people such as myself to configure this to a more suitable interval by defining the interval against the environment variable `CERT_INTERVAL_TIMEOUT` in milliseconds.

There's a further discussion about this over on #677

Note that with the current implementation using `setInterval` ([docs](https://developer.mozilla.org/en-US/docs/Web/API/setInterval)) there are limits to the maximum value of [just shy of 25 days](https://stackoverflow.com/questions/12633405/what-is-the-maximum-delay-for-setinterval) due to the value being a 32-bit signed integer.