### PR TITLE
Update certbot-dns-plugins.json

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -242,7 +242,7 @@
 	"infomaniak": {
 		"name": "Infomaniak",
 		"package_name": "certbot-dns-infomaniak",
-		"version": "~=0.1.12",
+		"version": "~=0.2.2",
 		"dependencies": "",
 		"credentials": "dns_infomaniak_token = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
 		"full_plugin_name": "dns-infomaniak"


### PR DESCRIPTION
Update [certbot-dns-infomaniak](https://github.com/Infomaniak/certbot-dns-infomaniak) plugin to version 0.2.2 as it doesn't work anymore in version 0.1.12.