### PR TITLE
move advanced_config section of /app/templates/_location.conf to top of default config

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,4 +1,6 @@
   location {{ path }} {
+    {{ advanced_config }}
+
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;
     proxy_set_header X-Forwarded-Proto  $scheme;
@@ -17,8 +19,5 @@
     proxy_set_header Connection $http_connection;
     proxy_http_version 1.1;
     {% endif %}
-
-
-    {{ advanced_config }}
   }
 


### PR DESCRIPTION
I found that custom configurations cannot override the default configurations because nginx prioritizes the configurations appearing earlier. Therefore, I moved the advanced_config section of /app/templates/_location.conf to top of default config。

config：
![image](https://github.com/NginxProxyManager/nginx-proxy-manager/assets/7664669/8dc8dcce-9394-4cf2-b17f-4cb256b90b9a)

before nginx proxy file:
![image](https://github.com/NginxProxyManager/nginx-proxy-manager/assets/7664669/d225b7fa-a4ab-49b4-9170-f8d698d0f74f)

after nginx proxy file:
![image](https://github.com/NginxProxyManager/nginx-proxy-manager/assets/7664669/a9956be6-1c52-40df-b38a-ac0f8ffc5843)

see this issue:
https://github.com/NginxProxyManager/nginx-proxy-manager/issues/2675#issuecomment-2081407884
