### PR TITLE
Fix Cloudflare DNS Auth

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -35,7 +35,7 @@
 		"name": "Cloudflare",
 		"package_name": "certbot-dns-cloudflare",
 		"version": "=={{certbot-version}}",
-		"dependencies": "cloudflare acme=={{certbot-version}}",
+		"dependencies": "cloudflare==2.19.* acme=={{certbot-version}}",
 		"credentials": "# Cloudflare API token\ndns_cloudflare_api_token = 0123456789abcdef0123456789abcdef01234567",
 		"full_plugin_name": "dns-cloudflare"
 	},


### PR DESCRIPTION
## Fix Cloudflare DNS Auth
Pin version as requested by dependency

### Related #3763 #3762 #3756

See #3756 :

```
2024-05-16 09:46:20 self.cf = CloudFlare.CloudFlare(token=api_token)
2024-05-16 09:46:20 /opt/certbot/lib/python3.11/site-packages/certbot_dns_cloudflare/_internal/dns_cloudflare.py:107: PendingDeprecationWarning:
2024-05-16 09:46:20 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
2024-05-16 09:46:20 !! You're seeing this warning because you've upgraded the Python package 'cloudflare' to version !!
2024-05-16 09:46:20 !! 2.20.* via an automated upgrade without version pinning. Version 2.20.0 exists to catch any !!
2024-05-16 09:46:20 !! of these upgrades before Cloudflare releases a new major release under the release number 3.x. !!
2024-05-16 09:46:20 !! !!
2024-05-16 09:46:20 !! Should you determine that you need to revert this upgrade and pin to v2.19.* it is recommended !!
2024-05-16 09:46:20 !! you do the following: pip install --upgrade cloudflare==2.19.* or equivilant. !!
2024-05-16 09:46:20 !! !!
2024-05-16 09:46:20 !! Or you can upgrade to v3.x. NOTE: Release 3.x will not be code-compatible or call-compatible !!
2024-05-16 09:46:20 !! with previous releases. To see more about upgrading to next major version, please see: !!
2024-05-16 09:46:20 !! https://github.com/cloudflare/python-cloudflare/discussions/191 !!
2024-05-16 09:46:20 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

**May want to look into how to upgrade to 3.x.x long term**