### PR TITLE
Remove spaces around Cloudflare API Credential

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -36,7 +36,7 @@
 		"package_name": "certbot-dns-cloudflare",
 		"version": "=={{certbot-version}}",
 		"dependencies": "cloudflare==2.19.* acme=={{certbot-version}}",
-		"credentials": "# Cloudflare API token\ndns_cloudflare_api_token = 0123456789abcdef0123456789abcdef01234567",
+		"credentials": "# Cloudflare API token\ndns_cloudflare_api_token=0123456789abcdef0123456789abcdef01234567",
 		"full_plugin_name": "dns-cloudflare"
 	},
 	"cloudns": {


### PR DESCRIPTION
I've run into [this same issue](https://github.com/NginxProxyManager/nginx-proxy-manager/issues/1862#issuecomment-1599770115) multiple times, as the common practice is to simply replace the placeholder token. However, doing so is incorrect syntax.

Proposal is to remove spaces around the `=` such that overwriting the placeholder API key with the user's "just works". 