### PR TITLE
Read initial admin email and password from env vars

### DIFF
--- a/backend/setup.js
+++ b/backend/setup.js
@@ -21,9 +21,10 @@ const setupDefaultUser = () => {
 		.then((row) => {
 			if (!row.count) {
 				// Create a new user and set password
-				let email = process.env.INITIAL_ADMIN_EMAIL || 'admin@example.com';
+				let email    = process.env.INITIAL_ADMIN_EMAIL || 'admin@example.com';
 				let password = process.env.INITIAL_ADMIN_PASSWORD || 'changeme';
-				logger.info('Creating a new user: admin@example.com with password: changeme');
+				
+				logger.info('Creating a new user: ' + email + ' with password: ' + password);
 
 				let data = {
 					is_deleted: 0,

--- a/backend/setup.js
+++ b/backend/setup.js
@@ -21,11 +21,13 @@ const setupDefaultUser = () => {
 		.then((row) => {
 			if (!row.count) {
 				// Create a new user and set password
+				let email = process.env.INITIAL_ADMIN_EMAIL || 'admin@example.com';
+				let password = process.env.INITIAL_ADMIN_PASSWORD || 'changeme';
 				logger.info('Creating a new user: admin@example.com with password: changeme');
 
 				let data = {
 					is_deleted: 0,
-					email:      'admin@example.com',
+					email:      email,
 					name:       'Administrator',
 					nickname:   'Admin',
 					avatar:     '',
@@ -41,7 +43,7 @@ const setupDefaultUser = () => {
 							.insert({
 								user_id: user.id,
 								type:    'password',
-								secret:  'changeme',
+								secret:  password,
 								meta:    {},
 							})
 							.then(() => {


### PR DESCRIPTION
For easier deployment, I need to change the default admin e-mail and password of `admin@example.com` / `changeme`, to a unique combination.

Instead of having hard-coded default admin e-mail and password of `admin@example.com` / `changeme`, allow environment variables `INITIAL_ADMIN_EMAIL` and `INITIAL_ADMIN_PASSWORD` to be specified. These are read during `setupDefaultUser`.

```yaml
    environment:
      - INITIAL_ADMIN_EMAIL=john.doe@mail.com
      - INITIAL_ADMIN_PASSWORD=P@ssw0rd
```

When not specifying these environment variables, a fallback to the default behavior takes place.