### PR TITLE
Changing `log_format proxy` default location

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/include/log.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/log.conf
@@ -1,0 +1,4 @@
+log_format proxy '[$time_local] $upstream_cache_status $upstream_status $status - $request_method $scheme $host "$request_uri" [Client $remote_addr] [Length $body_bytes_sent] [Gzip $gzip_ratio] [Sent-to $server] "$http_user_agent" "$http_referer"';
+log_format standard '[$time_local] $status - $request_method $scheme $host "$request_uri" [Client $remote_addr] [Length $body_bytes_sent] [Gzip $gzip_ratio] "$http_user_agent" "$http_referer"';
+
+access_log /data/logs/fallback_access.log proxy;

--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -43,10 +43,8 @@ http {
 	proxy_cache_path              /var/lib/nginx/cache/public  levels=1:2 keys_zone=public-cache:30m max_size=192m;
 	proxy_cache_path              /var/lib/nginx/cache/private levels=1:2 keys_zone=private-cache:5m max_size=1024m;
 
-	log_format proxy '[$time_local] $upstream_cache_status $upstream_status $status - $request_method $scheme $host "$request_uri" [Client $remote_addr] [Length $body_bytes_sent] [Gzip $gzip_ratio] [Sent-to $server] "$http_user_agent" "$http_referer"';
-	log_format standard '[$time_local] $status - $request_method $scheme $host "$request_uri" [Client $remote_addr] [Length $body_bytes_sent] [Gzip $gzip_ratio] "$http_user_agent" "$http_referer"';
-
-	access_log /data/logs/fallback_access.log proxy;
+	# Log format and fallback log file
+	include /etc/nginx/conf.d/include/log.conf;
 
 	# Dynamically generated resolvers file
 	include /etc/nginx/conf.d/include/resolvers.conf;


### PR DESCRIPTION
This is useful when some user would want to change the default log format for each of the service, without the need of creating a new `log_format custom` and changing the `access_log` for each service.

The reason why I've added a `log.conf` in the `/etc/nginx/conf.d/include` directory is that it is easily overridable using a docker mount, like

```
volumes:
  - ./custom_log.conf:/etc/nginx/conf.d/include/log.conf:ro
``` 

close #714 