### PR TITLE
Fix syntax that causes errors (generateKeys log)

### DIFF
--- a/backend/lib/config.js
+++ b/backend/lib/config.js
@@ -93,7 +93,7 @@ const generateKeys = () => {
 	try {
 		fs.writeFileSync(keysFile, JSON.stringify(keys, null, 2));
 	} catch (err) {
-		logger.error('Could not write JWT key pair to config file: ' + keysFile + ': ' . err.message);
+		logger.error('Could not write JWT key pair to config file: ' + keysFile + ': ' + err.message);
 		process.exit(1);
 	}
 	logger.info('Wrote JWT key pair to config file: ' + keysFile);


### PR DESCRIPTION
Fixed a simple grammatical error that was causing an error.