### PR TITLE
Switch from X-Real-IP to X-Forwarded-For in nginx.conf

### DIFF
--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -66,7 +66,7 @@ http {
 	# NPM generated CDN ip ranges:
 	include conf.d/include/ip_ranges.conf;
 	# always put the following 2 lines after ip subnets:
-	real_ip_header X-Real-IP;
+	real_ip_header X-Forwarded-For;
 	real_ip_recursive on;
 
 	# Custom


### PR DESCRIPTION
X-Forwarded-For is more commonly used across various proxies and load balancers, including Cloudflare, which does not use X-Real-IP.

This should fix #3582 #3267 #1358 #1230