### PR TITLE
Add set directives for proxied paths to keep nginx from crashing if upstream is down

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -6,7 +6,12 @@
     proxy_set_header X-Forwarded-Proto  $scheme;
     proxy_set_header X-Forwarded-For    $remote_addr;
     proxy_set_header X-Real-IP		$remote_addr;
-    proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
+
+    set $proxy_forward_scheme {{ forward_scheme }};
+    set $proxy_server         "{{ forward_host }}";
+    set $proxy_port           {{ forward_port }};
+
+    proxy_pass       $proxy_forward_scheme://$proxy_server:$proxy_port{{ forward_path }};
 
     {% include "_access.conf" %}
     {% include "_assets.conf" %}


### PR DESCRIPTION
If the upstream is down on a `/path` setting on a proxy setting it will cause nginx to crash. Adding `set` directives pointing to the upstream information allows nginx to startup even if the upstream is down and throw HTTP errors instead.