### PR TITLE
Typo fixed in api.swagger.json

### DIFF
--- a/backend/doc/api.swagger.json
+++ b/backend/doc/api.swagger.json
@@ -1233,7 +1233,7 @@
 			},
 			"ProxyHostsList": {
 				"type": "array",
-				"description": "Proxyn Hosts list",
+				"description": "Proxy Hosts list",
 				"items": {
 					"$ref": "#/components/schemas/ProxyHostObject"
 				}


### PR DESCRIPTION
I believe it's self-explanatory 🙃