### PR TITLE
fix(backend): Replace deprecated http2 directive

### DIFF
--- a/backend/templates/_listen.conf
+++ b/backend/templates/_listen.conf
@@ -6,16 +6,13 @@
 {% endif %}
 {% if certificate -%}
   listen 443 ssl;
-  {% if http2_support == 1 or http2_support == true %}
-  http2;
-  {% endif %}
 {% if ipv6 -%}/
   listen [::]:443 ssl;
-  {% if http2_support == 1 or http2_support == true %}
-  http2;
-  {% endif %}
 {% else -%}
   #listen [::]:443;
 {% endif %}
+{% endif %}
+{% if http2_support == 1 or http2_support == true %}
+  http2 on;
 {% endif %}
   server_name {{ domain_names | join: " " }};

--- a/backend/templates/_listen.conf
+++ b/backend/templates/_listen.conf
@@ -5,9 +5,15 @@
   #listen [::]:80;
 {% endif %}
 {% if certificate -%}
-  listen 443 ssl{% if http2_support == 1 or http2_support == true %} http2{% endif %};
-{% if ipv6 -%}
-  listen [::]:443 ssl{% if http2_support == 1 or http2_support == true %} http2{% endif %};
+  listen 443 ssl;
+  {% if http2_support == 1 or http2_support == true %}
+  http2;
+  {% endif %}
+{% if ipv6 -%}/
+  listen [::]:443 ssl;
+  {% if http2_support == 1 or http2_support == true %}
+  http2;
+  {% endif %}
 {% else -%}
   #listen [::]:443;
 {% endif %}


### PR DESCRIPTION
Fixes #4060 

This PR replaces the `listen ... http2` directive with the new and not deprecated directive `http2 on`. This prevents warnings in the log output.