### PR TITLE
http2 directive migration

### DIFF
--- a/backend/templates/_listen.conf
+++ b/backend/templates/_listen.conf
@@ -5,11 +5,16 @@
   #listen [::]:80;
 {% endif %}
 {% if certificate -%}
-  listen 443 ssl{% if http2_support == 1 or http2_support == true %} http2{% endif %};
+  listen 443 ssl;
 {% if ipv6 -%}
-  listen [::]:443 ssl{% if http2_support == 1 or http2_support == true %} http2{% endif %};
+  listen [::]:443 ssl;
 {% else -%}
   #listen [::]:443;
 {% endif %}
 {% endif %}
   server_name {{ domain_names | join: " " }};
+{% if http2_support == 1 or http2_support == true %}
+  http2 on;
+{% else -%}
+  http2 off;
+{% endif %}


### PR DESCRIPTION
reducing noise in logs

N.B. to reduce the noise for existing hosts you'll have to edit every single host with http2 enabled and simply press save.