### PR TITLE
Update Dockerfile to use ghcr.io/letsencrypt/pebble

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # This file assumes that the frontend has been built using ./scripts/frontend-build
 
 FROM nginxproxymanager/testca AS testca
-FROM letsencrypt/pebble AS pebbleca
+FROM ghcr.io/letsencrypt/pebble AS pebbleca
 FROM nginxproxymanager/nginx-full:certbot-node
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
The dockerhub letsencrypt/pebble image is deprecated and we will remove it in the future. This switches to the ghcr.io hosted version.