### PR TITLE
Remove variable usage from proxy_pass directive to fix resolution issues

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -11,7 +11,7 @@
     set $proxy_server         "{{ forward_host }}";
     set $proxy_port           {{ forward_port }};
 
-    proxy_pass       $proxy_forward_scheme://$proxy_server:$proxy_port{{ forward_path }};
+    proxy_pass       {{ forward_scheme }}:{{ forward_host }}:{{ forward_port }}{{ forward_path }};
 
     {% include "_access.conf" %}
     {% include "_assets.conf" %}

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -7,10 +7,6 @@
     proxy_set_header X-Forwarded-For    $remote_addr;
     proxy_set_header X-Real-IP		$remote_addr;
 
-    set $proxy_forward_scheme {{ forward_scheme }};
-    set $proxy_server         "{{ forward_host }}";
-    set $proxy_port           {{ forward_port }};
-
     proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
 
     {% include "_access.conf" %}

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -11,7 +11,7 @@
     set $proxy_server         "{{ forward_host }}";
     set $proxy_port           {{ forward_port }};
 
-    proxy_pass       {{ forward_scheme }}:{{ forward_host }}:{{ forward_port }}{{ forward_path }};
+    proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
 
     {% include "_access.conf" %}
     {% include "_assets.conf" %}


### PR DESCRIPTION
This change addresses issues described in [issue #4102](https://github.com/NginxProxyManager/nginx-proxy-manager/issues/4102), where users experienced 404 errors and misconfigurations due to dynamic URL resolution failures. By switching to static values for backend addresses, this ensures more stable and predictable behavior when routing requests through the proxy.
