### PR TITLE
docs(setup): Remove deprecated version from docker-compose.yml

### DIFF
--- a/docs/src/advanced-config/index.md
+++ b/docs/src/advanced-config/index.md
@@ -50,7 +50,6 @@ networks:
 Let's look at a Portainer example:
 
 ```yml
-version: '3.8'
 services:
 
   portainer:
@@ -92,8 +91,6 @@ This image supports the use of Docker secrets to import from files and keep sens
 You can set any environment variable from a file by appending `__FILE` (double-underscore FILE) to the environmental variable name.
 
 ```yml
-version: '3.8'
-
 secrets:
   # Secrets are single-line text files where the sole content is the secret
   # Paths in this example assume that secrets are kept in local folder called ".secrets"

--- a/docs/src/setup/index.md
+++ b/docs/src/setup/index.md
@@ -9,7 +9,6 @@ outline: deep
 Create a `docker-compose.yml` file:
 
 ```yml
-version: '3.8'
 services:
   app:
     image: 'jc21/nginx-proxy-manager:latest'
@@ -55,7 +54,6 @@ are going to use.
 Here is an example of what your `docker-compose.yml` will look like when using a MariaDB container:
 
 ```yml
-version: '3.8'
 services:
   app:
     image: 'jc21/nginx-proxy-manager:latest'


### PR DESCRIPTION
You can see the following warning when using the provided docker-compose.yml from the setup instructions:
```
WARN[0000] ~/nginx-proxy-manager/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

Since the version is deprecated, it can be removed from the manifest.