### PR TITLE
Fix Container Bootloop if Stream is used for http/https ports

### DIFF
--- a/backend/schema/components/stream-object.json
+++ b/backend/schema/components/stream-object.json
@@ -19,7 +19,9 @@
 		"incoming_port": {
 			"type": "integer",
 			"minimum": 1,
-			"maximum": 65535
+			"maximum": 65535,
+			"if": {"properties": {"tcp_forwarding": {"const": true}}},
+			"then": {"not": {"oneOf": [{"const": 80}, {"const": 443}]}}
 		},
 		"forwarding_host": {
 			"anyOf": [


### PR DESCRIPTION
There is no way to disable the default site, and therefore no way to disable listening on port 80/443.
If a stream is created for port 80 then the container will bootloop without an easy path to recovery due to duplicate ports in use.

Unless we can disable the default site, ie "stream only" mode for NGINX, we should not allow these ports to be set.