### PR TITLE
Return generic auth error to prevent user enumeration attacks

### DIFF
--- a/backend/internal/token.js
+++ b/backend/internal/token.js
@@ -5,6 +5,8 @@ const authModel  = require('../models/auth');
 const helpers    = require('../lib/helpers');
 const TokenModel = require('../models/token');
 
+const ERROR_MESSAGE_INVALID_AUTH = 'Invalid email or password';
+
 module.exports = {
 
 	/**
@@ -69,15 +71,15 @@ module.exports = {
 													};
 												});
 										} else {
-											throw new error.AuthError('Invalid password');
+											throw new error.AuthError(ERROR_MESSAGE_INVALID_AUTH);
 										}
 									});
 							} else {
-								throw new error.AuthError('No password auth for user');
+								throw new error.AuthError(ERROR_MESSAGE_INVALID_AUTH);
 							}
 						});
 				} else {
-					throw new error.AuthError('No relevant user found');
+					throw new error.AuthError(ERROR_MESSAGE_INVALID_AUTH);
 				}
 			});
 	},


### PR DESCRIPTION
When authentication fails, the generic error message "Invalid email or password" is returned. Thereby, no information about the existence of the user is given.

This prevents user enumeration attacks because the response for both scenarios is identical.

Fixes #3873