### PR TITLE
Add hostingnl DNS Challenge provider

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -247,6 +247,14 @@
 		"credentials": "dns_hetzner_api_token = 0123456789abcdef0123456789abcdef",
 		"full_plugin_name": "dns-hetzner"
 	},
+	"hostingnl": {
+		"name": "Hosting.nl",
+		"package_name": "certbot-dns-hostingnl",
+		"version": "~=0.1.5",
+		"dependencies": "",
+		"credentials": "dns_hostingnl_api_key = 0123456789abcdef0123456789abcdef",
+		"full_plugin_name": "dns-hostingnl"
+	},
 	"hover": {
 		"name": "Hover",
 		"package_name": "certbot-dns-hover",


### PR DESCRIPTION
Adds a DNS challenge provider for hosting.nl.

repo: https://github.com/TECH7Fox/certbot-dns-hostingnl
PyPI: https://pypi.org/project/certbot-dns-hostingnl

Closes #4214 