### PR TITLE
client_max_body_size setting via UI

### DIFF
--- a/backend/migrations/20241209025008_client_max_body_size.js
+++ b/backend/migrations/20241209025008_client_max_body_size.js
@@ -1,0 +1,34 @@
+const migrate_name = 'client_max_body_size';
+const logger = require('../logger').migrate;
+
+/**
+ * Migrate
+ *
+ * @see http://knexjs.org/#Schema
+ *
+ * @param   {Object}  knex
+ * @param   {Promise} Promise
+ * @returns {Promise}
+ */
+exports.up = function (knex/*, Promise*/) {
+	logger.info('[' + migrate_name + '] Migrating Up...');
+
+	return knex.schema.table('proxy_host', function (proxy_host) {
+		proxy_host.integer('client_max_body_size').notNull().unsigned().defaultTo('1');
+	})
+		.then(() => {
+			logger.info('[' + migrate_name + '] proxy_host Table altered');
+		});
+};
+
+/**
+ * Undo Migrate
+ *
+ * @param   {Object}  knex
+ * @param   {Promise} Promise
+ * @returns {Promise}
+ */
+exports.down = function (knex, Promise) {
+	logger.warn('[' + migrate_name + '] You can\'t migrate down this one.');
+	return Promise.resolve(true);
+};

--- a/backend/schema/components/proxy-host-object.json
+++ b/backend/schema/components/proxy-host-object.json
@@ -9,6 +9,7 @@
 		"domain_names",
 		"forward_host",
 		"forward_port",
+		"client_max_body_size",
 		"access_list_id",
 		"certificate_id",
 		"ssl_forced",
@@ -51,6 +52,11 @@
 			"type": "integer",
 			"minimum": 1,
 			"maximum": 65535
+		},
+		"client_max_body_size": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4096
 		},
 		"access_list_id": {
 			"$ref": "../common.json#/properties/access_list_id"
@@ -111,6 +117,9 @@
 					},
 					"forward_port": {
 						"$ref": "#/properties/forward_port"
+					},
+					"client_max_body_size": {
+						"$ref": "#/properties/client_max_body_size"
 					},
 					"forward_path": {
 						"type": "string"

--- a/backend/schema/paths/nginx/proxy-hosts/get.json
+++ b/backend/schema/paths/nginx/proxy-hosts/get.json
@@ -34,6 +34,7 @@
 									"domain_names": ["test.example.com"],
 									"forward_host": "127.0.0.1",
 									"forward_port": 8989,
+									"client_max_body_size": 1,
 									"access_list_id": 0,
 									"certificate_id": 0,
 									"ssl_forced": false,

--- a/backend/schema/paths/nginx/proxy-hosts/hostID/get.json
+++ b/backend/schema/paths/nginx/proxy-hosts/hostID/get.json
@@ -34,6 +34,7 @@
 								"domain_names": ["test.example.com"],
 								"forward_host": "192.168.0.10",
 								"forward_port": 8989,
+								"client_max_body_size": 1,
 								"access_list_id": 0,
 								"certificate_id": 0,
 								"ssl_forced": false,

--- a/backend/schema/paths/nginx/proxy-hosts/hostID/put.json
+++ b/backend/schema/paths/nginx/proxy-hosts/hostID/put.json
@@ -41,6 +41,9 @@
 						"forward_port": {
 							"$ref": "../../../../components/proxy-host-object.json#/properties/forward_port"
 						},
+						"client_max_body_size": {
+							"$ref": "../../../../components/proxy-host-object.json#/properties/client_max_body_size"
+						},
 						"certificate_id": {
 							"$ref": "../../../../components/proxy-host-object.json#/properties/certificate_id"
 						},
@@ -100,6 +103,7 @@
 								"domain_names": ["test.example.com"],
 								"forward_host": "192.168.0.10",
 								"forward_port": 8989,
+								"client_max_body_size": 1,
 								"access_list_id": 0,
 								"certificate_id": 0,
 								"ssl_forced": false,

--- a/backend/schema/paths/nginx/proxy-hosts/post.json
+++ b/backend/schema/paths/nginx/proxy-hosts/post.json
@@ -29,6 +29,9 @@
 						"forward_port": {
 							"$ref": "../../../components/proxy-host-object.json#/properties/forward_port"
 						},
+						"client_max_body_size": {
+							"$ref": "../../../components/proxy-host-object.json#/properties/client_max_body_size"
+						},
 						"certificate_id": {
 							"$ref": "../../../components/proxy-host-object.json#/properties/certificate_id"
 						},
@@ -88,6 +91,7 @@
 								"domain_names": ["test.example.com"],
 								"forward_host": "127.0.0.1",
 								"forward_port": 8989,
+								"client_max_body_size": 1,
 								"access_list_id": 0,
 								"certificate_id": 0,
 								"ssl_forced": false,

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -47,6 +47,8 @@ proxy_http_version 1.1;
   }
 {% endif %}
 
+  client_max_body_size {{ client_max_body_size }}m;
+
   # Custom
   include /data/nginx/custom/server_proxy[.]conf;
 }

--- a/frontend/js/app/nginx/proxy/form.ejs
+++ b/frontend/js/app/nginx/proxy/form.ejs
@@ -81,7 +81,12 @@
                                 </label>
                             </div>
                         </div>
-
+                        <div class="col-sm-12 col-md-12">
+                            <div class="form-group">
+                                <label class="form-label"><%- i18n('proxy-hosts', 'client-max-body-size' ) %></label>
+                                <input name="client_max_body_size" type="number" class="form-control text-monospace" placeholder="1" value="<%- client_max_body_size %>" required>
+                            </div>
+                        </div>
                         <div class="col-sm-12 col-md-12">
                             <div class="form-group">
                                 <label class="form-label"><%- i18n('proxy-hosts', 'access-list') %></label>

--- a/frontend/js/app/nginx/proxy/form.js
+++ b/frontend/js/app/nginx/proxy/form.js
@@ -160,6 +160,7 @@ module.exports = Mn.View.extend({
 
             // Manipulate
             data.forward_port            = parseInt(data.forward_port, 10);
+            data.client_max_body_size    = parseInt(data.client_max_body_size, 10);
             data.block_exploits          = !!data.block_exploits;
             data.caching_enabled         = !!data.caching_enabled;
             data.allow_websocket_upgrade = !!data.allow_websocket_upgrade;

--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -125,6 +125,7 @@
       "forward-scheme": "Scheme",
       "forward-host": "Forward Hostname / IP",
       "forward-port": "Forward Port",
+      "client-max-body-size": "Max proxied upload size (Mb)",
       "delete": "Delete Proxy Host",
       "delete-confirm": "Are you sure you want to delete the Proxy host for: <strong>{domains}</strong>?",
       "help-title": "What is a Proxy Host?",

--- a/frontend/js/models/proxy-host.js
+++ b/frontend/js/models/proxy-host.js
@@ -12,6 +12,7 @@ const model = Backbone.Model.extend({
             forward_scheme:          'http',
             forward_host:            '',
             forward_port:            null,
+            client_max_body_size:    1,
             access_list_id:          0,
             certificate_id:          0,
             ssl_forced:              false,

--- a/test/cypress/e2e/api/ProxyHosts.cy.js
+++ b/test/cypress/e2e/api/ProxyHosts.cy.js
@@ -18,6 +18,7 @@ describe('Proxy Hosts endpoints', () => {
 				forward_scheme: 'http',
 				forward_host:   '1.1.1.1',
 				forward_port:   80,
+				client_max_body_size: 1,
 				access_list_id: '0',
 				certificate_id: 0,
 				meta:           {


### PR DESCRIPTION
Attempting to close ancient issue #914 

Probably not the ideal solution, potential improvements are to follow nginx [docs](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) and allow this settings on both 

1. server level
2. host level
3. location level

As of now it is _only_ on host level