### PR TITLE
Update DomainOffensive certbot plugin

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -153,11 +153,11 @@
 	},
 	"domainoffensive": {
 		"name": "DomainOffensive (do.de)",
-		"package_name": "certbot-dns-do",
-		"version": "~=0.31.0",
+		"package_name": "certbot-dns-domainoffensive",
+		"version": "~=2.0.0",
 		"dependencies": "",
 		"credentials": "dns_do_api_token = YOUR_DO_DE_AUTH_TOKEN",
-		"full_plugin_name": "dns-do"
+		"full_plugin_name": "dns-domainoffensive"
 	},
 	"domeneshop": {
 		"name": "Domeneshop",


### PR DESCRIPTION
### Summary

This PR replaces the current DomainOffensive (do.de) cert bot with the new [official version](https://github.com/domainoffensive/certbot-dns-domainoffensive).
The current [do certbot repo](https://github.com/georgeto/certbot-dns-do) has been forked by DomainOffensive and seems to be the official bot now.

### Changes

Basically i have replaced the current certbot-dns-plugins config with the new repository and python [package](https://pypi.org/project/certbot-dns-domainoffensive/).
Looking into the new repository of DomainOffensive, i don't see any new additions or changes, yet i think using the official certbot seems to be a good thing for future versions.