### PR TITLE
Remove infinite requests loop

### DIFF
--- a/frontend/js/app/dashboard/main.js
+++ b/frontend/js/app/dashboard/main.js
@@ -50,7 +50,8 @@ module.exports = Mn.View.extend({
     onRender: function () {
         let view = this;
 
-        Api.Reports.getHostStats()
+        if (typeof view.stats.hosts === 'undefined') {
+            Api.Reports.getHostStats()
                 .then(response => {
                     if (!view.isDestroyed()) {
                         view.stats.hosts = response;
@@ -60,6 +61,7 @@ module.exports = Mn.View.extend({
                 .catch(err => {
                     console.log(err);
                 });
+        }
     },
 
     /**


### PR DESCRIPTION
This reverts commit d26e8c1d0c44a5fbeb1264f8fe713bdac0f5e703.

This reopens #4204 

The reverted commit is responsible for an infinite loop of requests to /hosts, which makes buttons unresponsive on the main page another way to invalidate the cache needs to be found

this infinite requests loop happens first on d26e8c1d0c44a5fbeb1264f8fe713bdac0f5e703
and on the docker image: `nginxproxymanager/nginx-proxy-manager-dev:pr-4206`
the docker image is attaced to the pr #4206  which merges the mentioned commit

the current develop branch has this as well

the requests loop happens both in gecko and V8