### PR TITLE
Add custom configuration to 404 hosts

### DIFF
--- a/backend/templates/dead_host.conf
+++ b/backend/templates/dead_host.conf
@@ -22,5 +22,7 @@ server {
   }
 {% endif %}
 
+  # Custom
+  include /data/nginx/custom/server_dead[.]conf;
 }
 {% endif %}

--- a/docs/src/advanced-config/index.md
+++ b/docs/src/advanced-config/index.md
@@ -181,6 +181,7 @@ You can add your custom configuration snippet files at `/data/nginx/custom` as f
  - `/data/nginx/custom/server_stream.conf`: Included at the end of every stream server block
  - `/data/nginx/custom/server_stream_tcp.conf`: Included at the end of every TCP stream server block
  - `/data/nginx/custom/server_stream_udp.conf`: Included at the end of every UDP stream server block
+ - `/data/nginx/custom/server_dead.conf`: Included at the end of every 404 server block
 
 Every file is optional.
 


### PR DESCRIPTION
Just like every other server type, support custom configuration files in 404 hosts.