### PR TITLE
Force SSL Options Prevents Let's Encrypt Renewals

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/include/force-ssl.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/force-ssl.conf
@@ -2,7 +2,7 @@ set $test "";
 if ($scheme = "http") {
 	set $test "H";
 }
-if ($request_uri = /.well-known/acme-challenge/test-challenge) {
+if ($request_uri ~* /.well-known/acme-challenge/) {
 	set $test "${test}T";
 }
 if ($test = H) {


### PR DESCRIPTION
The force-ssl.conf file does the following:
1. Checks if the request is HTTP and sets $test to H if so
2. Checks if the request is to "test-challenge" in the normal Let's Encrypt challenge directory and appends T to $test if so
3. If $test = H (and only H) upgrades the request to HTTPS

This works but only for "test-challenge". All other Let's Encrypt renewals/challenges will fall through and be upgraded to HTTPS which causes them to fail (not sure why, see thoughts below). By modifying step two to catch all Let's Encrypt challenges and not upgrade those connections, renewals succeed.

It looks like Let's Encrypt should work without the modification since letsencrypt-acme-challenge.conf is included in the server with both the listen 80 and listen 443 directives. Either way, this has never worked for me. I've already implemented this change in my environment by mounting the modified force-ssl.conf file directly and it fixed the issue immedeatly. 