### PR TITLE
feat: change htpasswd to openssl

### DIFF
--- a/backend/internal/access-list.js
+++ b/backend/internal/access-list.js
@@ -507,8 +507,13 @@ const internalAccessList = {
 								if (typeof item.password !== 'undefined' && item.password.length) {
 									logger.info('Adding: ' + item.username);
 
-									utils.execFile('/usr/bin/htpasswd', ['-b', htpasswd_file, item.username, item.password])
-										.then((/*result*/) => {
+									utils.execFile('openssl', ['passwd', '-apr1', item.password])
+										.then((res) => {
+											try {
+												fs.appendFileSync(htpasswd_file, item.username + ':' + res + '\n', {encoding: 'utf8'});
+											} catch (err) {
+												reject(err);
+											}
 											next();
 										})
 										.catch((err) => {


### PR DESCRIPTION
use openssl instead of htpasswd for easier manual installation without Docker. Installing apache2-utils only for htpasswd is not a good idea.