### PR TITLE
Fix type for token.expires

### DIFF
--- a/backend/schema/components/token-object.json
+++ b/backend/schema/components/token-object.json
@@ -5,10 +5,9 @@
 	"additionalProperties": false,
 	"properties": {
 		"expires": {
-			"description": "Token Expiry Unix Time",
-			"example": 1566540249,
-			"minimum": 1,
-			"type": "number"
+			"description": "Token Expiry ISO Time String",
+			"example": "2025-02-04T20:40:46.340Z",
+			"type": "string"
 		},
 		"token": {
 			"description": "JWT Token",

--- a/backend/schema/paths/tokens/get.json
+++ b/backend/schema/paths/tokens/get.json
@@ -15,7 +15,7 @@
 					"examples": {
 						"default": {
 							"value": {
-								"expires": 1566540510,
+								"expires": "2025-02-04T20:40:46.340Z",
 								"token": "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.ey...xaHKYr3Kk6MvkUjcC4"
 							}
 						}

--- a/backend/schema/paths/tokens/post.json
+++ b/backend/schema/paths/tokens/post.json
@@ -38,7 +38,7 @@
 						"default": {
 							"value": {
 								"result": {
-									"expires": 1566540510,
+									"expires": "2025-02-04T20:40:46.340Z",
 									"token": "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.ey...xaHKYr3Kk6MvkUjcC4"
 								}
 							}


### PR DESCRIPTION
Currently, the `token.expires` property is advertised as an interger in the api schema, but the API returns a ISO string. I updated the schema to match the actual API.

https://github.com/NginxProxyManager/nginx-proxy-manager/blob/b4f49969d64c673acaa2f2a672f934ac84a66c5d/backend/internal/token.js#L70

https://github.com/NginxProxyManager/nginx-proxy-manager/blob/b4f49969d64c673acaa2f2a672f934ac84a66c5d/backend/internal/token.js#L131

https://github.com/NginxProxyManager/nginx-proxy-manager/blob/b4f49969d64c673acaa2f2a672f934ac84a66c5d/backend/internal/token.js#L159
