### PR TITLE
Use `$proxy_add_x_forwarded_for` for custom locations

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -4,7 +4,7 @@
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;
     proxy_set_header X-Forwarded-Proto  $scheme;
-    proxy_set_header X-Forwarded-For    $remote_addr;
+    proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP		$remote_addr;
 
     proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};


### PR DESCRIPTION
Use `$proxy_add_x_forwarded_for` when setting `X-Forwarded-For` in custom locations to match how it is set for default location.

The proxy settings included in the default location uses `$proxy_add_x_forwarded_for` instead of `$remote_addr` since 052cb8f, which handles when NPM is behind multiple reverse proxies.

This commit makes sure the same setting is used when creating custom location blocks for a proxy host.