### PR TITLE
use latest certbot-dns-cpanel version

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -74,9 +74,9 @@
 	"cpanel": {
 		"name": "cPanel",
 		"package_name": "certbot-dns-cpanel",
-		"version": "~=0.2.2",
+		"version": "~=0.4.0",
 		"dependencies": "",
-		"credentials": "cpanel_url = https://cpanel.example.com:2083\ncpanel_username = user\ncpanel_password = hunter2",
+		"credentials": "cpanel_url = https://cpanel.example.com:2083\ncpanel_username = your_username\ncpanel_password = your_password\ncpanel_token = your_api_token",
 		"full_plugin_name": "cpanel"
 	},
 	"desec": {


### PR DESCRIPTION
this allows to use token for authentication

Because an old version of the `certbot-dns-cpanel` is used, its now possible to use tokens for authentication

https://github.com/NginxProxyManager/nginx-proxy-manager/discussions/3057#discussioncomment-10805031