### PR TITLE
Fixed error in sqlite installation compose file

### DIFF
--- a/docs/src/setup/index.md
+++ b/docs/src/setup/index.md
@@ -21,7 +21,7 @@ services:
       # Add any other Stream port you want to expose
       # - '21:21' # FTP
 
-    environment:
+    #environment:
       # Uncomment this if you want to change the location of
       # the SQLite DB file within the container
       # DB_SQLITE_FILE: "/data/database.sqlite"


### PR DESCRIPTION
If people copy and paste the sqlite installation without commenting environment docker compose will throw an error because environment will be null.