### PR TITLE
Added IP_RANGES_FETCH_ENABLED environment variable

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -20,11 +20,9 @@ async function appStart () {
 				logger.info('IP Ranges fetch is enabled');
 				return internalIpRanges.fetch().catch((err) => {
 					logger.error('IP Ranges fetch failed, continuing anyway:', err.message);
-					return Promise.resolve();
 				});
 			} else {
 				logger.info('IP Ranges fetch is disabled by environment variable');
-				return Promise.resolve();
 			}
 		})
 		.then(() => {

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,7 +18,7 @@ async function appStart () {
 		.then(() => {
 			if (IP_RANGES_FETCH_ENABLED) {
 				logger.info('IP Ranges fetch is enabled');
-				return internalIpRanges.fetch().catch(err => {
+				return internalIpRanges.fetch().catch((err) => {
 					logger.error('IP Ranges fetch failed, continuing anyway:', err.message);
 					return Promise.resolve();
 				});

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,8 @@
 const schema = require('./schema');
 const logger = require('./logger').global;
 
+const IP_RANGES_FETCH_ENABLED = process.env.IP_RANGES_FETCH_ENABLED !== 'false';
+
 async function appStart () {
 	const migrate             = require('./migrate');
 	const setup               = require('./setup');
@@ -13,7 +15,18 @@ async function appStart () {
 	return migrate.latest()
 		.then(setup)
 		.then(schema.getCompiledSchema)
-		.then(internalIpRanges.fetch)
+		.then(() => {
+			if (IP_RANGES_FETCH_ENABLED) {
+				logger.info('IP Ranges fetch is enabled');
+				return internalIpRanges.fetch().catch(err => {
+					logger.error('IP Ranges fetch failed, continuing anyway:', err.message);
+					return Promise.resolve();
+				});
+			} else {
+				logger.info('IP Ranges fetch is disabled by environment variable');
+				return Promise.resolve();
+			}
+		})
 		.then(() => {
 			internalCertificate.initTimer();
 			internalIpRanges.initTimer();

--- a/docs/src/advanced-config/index.md
+++ b/docs/src/advanced-config/index.md
@@ -161,6 +161,14 @@ The easy fix is to add a Docker environment variable to the Nginx Proxy Manager 
       DISABLE_IPV6: 'true'
 ```
 
+## Disabling IP Ranges Fetch
+
+By default, NPM fetches IP ranges from CloudFront and Cloudflare during application startup. In environments with limited internet access or to speed up container startup, this fetch can be disabled:
+
+```yml
+    environment:
+      IP_RANGES_FETCH_ENABLED: 'false'
+```
 
 ## Custom Nginx Configurations
 


### PR DESCRIPTION
fixes #4186
fixes  #3965
fixes  #3157
fixes  #3602
This change adds a new environment variable to control whether IP ranges are fetched during application startup. When set to 'false', the initial fetch will be skipped, which can:

1. Speed up application startup
2. Avoid connectivity issues in environments with restricted internet access
3. Prevent startup failures when CloudFront or CloudFlare services are unreachable