### PR TITLE
Fix DomainOffensive certbot plugin

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -164,7 +164,7 @@
 		"package_name": "certbot-dns-domainoffensive",
 		"version": "~=2.0.0",
 		"dependencies": "",
-		"credentials": "dns_do_api_token = YOUR_DO_DE_AUTH_TOKEN",
+		"credentials": "dns_domainoffensive_api_token = YOUR_DO_DE_AUTH_TOKEN",
 		"full_plugin_name": "dns-domainoffensive"
 	},
 	"domeneshop": {


### PR DESCRIPTION
In https://github.com/NginxProxyManager/nginx-proxy-manager/pull/4235 the certbot plugin for do.de (Domain Offensive) was updated to use the more official version. One necessary line modification was missed, resulting in an error when creating a new certificate.

Also see the comments on the above mentioned PR in case you came here because cert renewal is broken.