### PR TITLE
Update cloudflare dns plugin from 2.19.4 to 4.0.*

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -51,7 +51,7 @@
 		"name": "Cloudflare",
 		"package_name": "certbot-dns-cloudflare",
 		"version": "=={{certbot-version}}",
-		"dependencies": "cloudflare==2.19.* acme=={{certbot-version}}",
+		"dependencies": "cloudflare==4.0.* acme=={{certbot-version}}",
 		"credentials": "# Cloudflare API token\ndns_cloudflare_api_token=0123456789abcdef0123456789abcdef01234567",
 		"full_plugin_name": "dns-cloudflare"
 	},


### PR DESCRIPTION
Elo.

Got this error while trying to issue a wildcard certificate with cloudflare dns plugin.

Docker image used: latest               1e836ffe2bd6   3 weeks ago     1.09GB



```
CommandError: Saving debug log to /tmp/letsencrypt-log/letsencrypt.log
Error determining zone_id: 6003 Invalid request headers. Please confirm that you have supplied valid Cloudflare API credentials. (Did you copy your entire API token/key? To use Cloudflare tokens, you'll need the python package cloudflare>=2.3.1. This certbot is running cloudflare 2.19.4)
Ask for help or search for solutions at https://community.letsencrypt.org. See the logfile /tmp/letsencrypt-log/letsencrypt.log or re-run Certbot with -v for more details.

    at /app/lib/utils.js:16:13
    at ChildProcess.exithandler (node:child_process:430:5)
    at ChildProcess.emit (node:events:518:28)
    at maybeClose (node:internal/child_process:1104:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5)
```