### PR TITLE
fixed what seems to be a typo

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -104,7 +104,7 @@ services:
     image: jc21/dnsrouter
     container_name: npm2dev.dnsrouter
     volumes:
-      - ./dev/dnsrouter-config.json.tmp:/dnsrouter-config.json:ro
+      - ./dev/dnsrouter-config.json:/dnsrouter-config.json:ro
     networks:
       - nginx_proxy_manager
 


### PR DESCRIPTION
While trying to setup the dev environment, I realized the docker-compose file was trying to mount a file that doesn't exist.

Was it missed somewhere?