### PR TITLE
Update the Gandi plugin.

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -209,8 +209,8 @@
 	},
 	"gandi": {
 		"name": "Gandi Live DNS",
-		"package_name": "certbot_plugin_gandi",
-		"version": "~=1.5.0",
+		"package_name": "certbot-dns-gandi",
+		"version": "~=1.6.1",
 		"dependencies": "",
 		"credentials": "# Gandi personal access token\ndns_gandi_token=PERSONAL_ACCESS_TOKEN",
 		"full_plugin_name": "dns-gandi"


### PR DESCRIPTION
The Gandi plugin has been renamed to [certbot-dns-gandi](https://pypi.org/project/certbot-dns-gandi/), and the `1.6.1` release fixes the missing `six` import error: https://github.com/obynio/certbot-plugin-gandi/pull/50

Fixes #4097 

