### PR TITLE
Add admin as an allowed token scope in api schema

### DIFF
--- a/backend/schema/paths/tokens/post.json
+++ b/backend/schema/paths/tokens/post.json
@@ -17,7 +17,7 @@
 						"scope": {
 							"minLength": 1,
 							"type": "string",
-							"enum": ["user"]
+							"enum": ["user", "admin"]
 						},
 						"secret": {
 							"minLength": 1,


### PR DESCRIPTION
Before 2.12.0, `admin` was an allowed scope in the token POST request, but was removed when the API schema was moved to swagger in [dfe2588
](https://github.com/NginxProxyManager/nginx-proxy-manager/commit/dfe2588523a602dd275fb6aadebfe37701dcbb36)

Currently, the base admin user cannot retrieve another user's roles via the API:
```
BEARER=$(curl -s -X POST http://localhost:81/api/tokens --data "{\"identity\":\"admin@example.com\",\"secret\":\"changeme\"}" -H 'Content-Type: application/json' | jq -r '.token')
curl -s -H "Authorization: Bearer $BEARER" "http://localhost:81/api/users/2" | jq
```
```json
{
  "id": 2,
  "created_on": "2025-03-30 19:57:03",
  "modified_on": "2025-03-30 19:57:03",
  "is_disabled": false,
  "email": "test@test.com",
  "name": "test",
  "nickname": "test",
  "avatar": "//www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?default=mm"
}
```

And requesting the `admin` token scope is not allowed, despite the user having the role:
```
curl -s -H "Authorization: Bearer $BEARER" "http://localhost:81/api/users/1" | jq
```
```json
{
  "id": 1,
  "created_on": "2025-03-30 19:55:48",
  "modified_on": "2025-03-30 19:55:48",
  "is_disabled": false,
  "email": "admin@example.com",
  "name": "Administrator",
  "nickname": "Admin",
  "avatar": "",
  "roles": [
    "admin"
  ]
}
```
```
curl -s -X POST http://localhost:81/api/tokens --data "{\"identity\":\"admin@example.com\",\"secret\":\"changeme\", \"scope\": \"admin\"}" -H 'Content-Type: application/json'
```
```json
{
  "error": {
    "code": 400,
    "message": "data/scope must be equal to one of the allowed values"
  }
}
```