### PR TITLE
Update certbot-dns-plugins.json

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -92,7 +92,7 @@
 		"package_name": "certbot-dns-cpanel",
 		"version": "~=0.2.2",
 		"dependencies": "",
-		"credentials": "cpanel_url = https://cpanel.example.com:2083\ncpanel_username = user\ncpanel_password = hunter2",
+		"credentials": "cpanel_url = https://cpanel.example.com:2083\ncpanel_username = user\ncpanel_password = hunter2\ncpanel_api_token = token",
 		"full_plugin_name": "cpanel"
 	},
 	"desec": {


### PR DESCRIPTION
Fix for bug #4429 add cpanel_api_token entry to credentials check. Will still need to update the documentation that the user will need to retrieve the api token from their cPanel.