### PR TITLE
query by domain endpoint

### DIFF
--- a/backend/internal/proxy-host.js
+++ b/backend/internal/proxy-host.js
@@ -276,7 +276,7 @@ const internalProxyHost = {
 				let query = proxyHostModel
 					.query()
 					.where('is_deleted', 0)
-					.andWhereRaw('domain_names::jsonb @> ?::jsonb', [JSON.stringify([data.domain])])
+					.andWhere(castJsonIfNeed('domain_names'), 'like', '%' + data.domain + '%')
 					.allowGraph('[owner,access_list.[clients,items],certificate]')
 					.modify(function(queryBuilder) {
 						if (data.expand) {

--- a/backend/internal/proxy-host.js
+++ b/backend/internal/proxy-host.js
@@ -259,6 +259,56 @@ const internalProxyHost = {
 	},
 
 	/**
+	 * @param  {Access}   access
+	 * @param  {Object}   data
+	 * @param  {String}   data.domain
+	 * @param  {Array}    [data.expand]
+	 * @param  {Array}    [data.omit]
+	 * @return {Promise}
+	 */
+	getByDomain: (access, data) => {
+		if (typeof data === 'undefined') {
+			data = {};
+		}
+
+		return access.can('proxy_hosts:get', data.domain)
+			.then((access_data) => {
+				let query = proxyHostModel
+					.query()
+					.where('is_deleted', 0)
+					.andWhereRaw("domain_names::jsonb @> ?::jsonb", [JSON.stringify([data.domain])])
+					.allowGraph('[owner,access_list.[clients,items],certificate]')
+					.modify(function(queryBuilder) {
+						if (data.expand) {
+							queryBuilder.withGraphFetched(`[${data.expand.join(', ')}]`);
+						}
+					})
+					.first();
+
+				if (access_data.permission_visibility !== 'all') {
+					query.andWhere('owner_user_id', access.token.getUserId(1));
+				}
+
+				if (typeof data.expand !== 'undefined' && data.expand !== null) {
+					query.withGraphFetched('[' + data.expand.join(', ') + ']');
+				}
+
+				return query.then(utils.omitRow(omissions()));
+			})
+			.then((row) => {
+				if (!row || !row.id) {
+					throw new error.ItemNotFoundError(data.id);
+				}
+				row = internalHost.cleanRowCertificateMeta(row);
+				// Custom omissions
+				if (typeof data.omit !== 'undefined' && data.omit !== null) {
+					row = _.omit(row, data.omit);
+				}
+				return row;
+			});
+	},
+
+	/**
 	 * @param {Access}  access
 	 * @param {Object}  data
 	 * @param {Number}  data.id

--- a/backend/internal/proxy-host.js
+++ b/backend/internal/proxy-host.js
@@ -276,7 +276,7 @@ const internalProxyHost = {
 				let query = proxyHostModel
 					.query()
 					.where('is_deleted', 0)
-					.andWhereRaw("domain_names::jsonb @> ?::jsonb", [JSON.stringify([data.domain])])
+					.andWhereRaw('domain_names::jsonb @> ?::jsonb', [JSON.stringify([data.domain])])
 					.allowGraph('[owner,access_list.[clients,items],certificate]')
 					.modify(function(queryBuilder) {
 						if (data.expand) {

--- a/backend/routes/nginx/proxy_hosts.js
+++ b/backend/routes/nginx/proxy_hosts.js
@@ -4,7 +4,6 @@ const jwtdecode         = require('../../lib/express/jwt-decode');
 const apiValidator      = require('../../lib/validator/api');
 const internalProxyHost = require('../../internal/proxy-host');
 const schema            = require('../../schema');
-const {castJsonIfNeed}  = require('../../lib/helpers');
 
 let router = express.Router({
 	caseSensitive: true,

--- a/backend/routes/nginx/proxy_hosts.js
+++ b/backend/routes/nginx/proxy_hosts.js
@@ -4,6 +4,7 @@ const jwtdecode         = require('../../lib/express/jwt-decode');
 const apiValidator      = require('../../lib/validator/api');
 const internalProxyHost = require('../../internal/proxy-host');
 const schema            = require('../../schema');
+const {castJsonIfNeed}  = require('../../lib/helpers');
 
 let router = express.Router({
 	caseSensitive: true,
@@ -104,6 +105,50 @@ router
 			.then((data) => {
 				return internalProxyHost.get(res.locals.access, {
 					id:     parseInt(data.host_id, 10),
+					expand: data.expand
+				});
+			})
+			.then((row) => {
+				res.status(200)
+					.send(row);
+			})
+			.catch(next);
+	})
+
+/**
+ * Specific proxy-host
+ *
+ * /api/nginx/proxy-hosts/domain/:domain
+ */
+router
+	.route('/domain/:domain')
+	.options((req, res) => {
+		res.sendStatus(204);
+	})
+	.all(jwtdecode())
+
+	/**
+	 * GET /api/nginx/proxy-hosts/domain/:domain
+	 *
+	 * Retrieve a specific proxy-host by domain
+	 */
+	.get((req, res, next) => {
+		validator({
+			required: ['domain'],
+			additionalProperties: false,
+			properties:           {
+				domain: {type: "string"},
+				expand: {
+					$ref: 'common#/properties/expand'
+				}
+			}
+		}, {
+			domain: req.params.domain,
+			expand:  (typeof req.query.expand === 'string' ? req.query.expand.split(',') : null)
+		})
+			.then((data) => {
+				return internalProxyHost.getByDomain(res.locals.access, {
+					domain: data.domain,
 					expand: data.expand
 				});
 			})

--- a/backend/routes/nginx/proxy_hosts.js
+++ b/backend/routes/nginx/proxy_hosts.js
@@ -112,7 +112,7 @@ router
 					.send(row);
 			})
 			.catch(next);
-	})
+	});
 
 /**
  * Specific proxy-host
@@ -133,10 +133,12 @@ router
 	 */
 	.get((req, res, next) => {
 		validator({
-			required: ['domain'],
+			required:             ['domain'],
 			additionalProperties: false,
 			properties:           {
-				domain: {type: "string"},
+				domain: {
+					type: 'string'
+				},
 				expand: {
 					$ref: 'common#/properties/expand'
 				}
@@ -156,7 +158,7 @@ router
 					.send(row);
 			})
 			.catch(next);
-	})
+	});
 
 	/**
 	 * PUT /api/nginx/proxy-hosts/123

--- a/backend/routes/nginx/proxy_hosts.js
+++ b/backend/routes/nginx/proxy_hosts.js
@@ -117,6 +117,84 @@ router
 /**
  * Specific proxy-host
  *
+ * /api/nginx/proxy-hosts/123
+ */
+router
+	.route('/:host_id')
+	.options((req, res) => {
+		res.sendStatus(204);
+	})
+	.all(jwtdecode())
+
+	/**
+	 * GET /api/nginx/proxy-hosts/123
+	 *
+	 * Retrieve a specific proxy-host
+	 */
+	.get((req, res, next) => {
+		validator({
+			required:             ['host_id'],
+			additionalProperties: false,
+			properties:           {
+				host_id: {
+					$ref: 'common#/properties/id'
+				},
+				expand: {
+					$ref: 'common#/properties/expand'
+				}
+			}
+		}, {
+			host_id: req.params.host_id,
+			expand:  (typeof req.query.expand === 'string' ? req.query.expand.split(',') : null)
+		})
+			.then((data) => {
+				return internalProxyHost.get(res.locals.access, {
+					id:     parseInt(data.host_id, 10),
+					expand: data.expand
+				});
+			})
+			.then((row) => {
+				res.status(200)
+					.send(row);
+			})
+			.catch(next);
+	})
+
+	/**
+	 * PUT /api/nginx/proxy-hosts/123
+	 *
+	 * Update and existing proxy-host
+	 */
+	.put((req, res, next) => {
+		apiValidator(schema.getValidationSchema('/nginx/proxy-hosts/{hostID}', 'put'), req.body)
+			.then((payload) => {
+				payload.id = parseInt(req.params.host_id, 10);
+				return internalProxyHost.update(res.locals.access, payload);
+			})
+			.then((result) => {
+				res.status(200)
+					.send(result);
+			})
+			.catch(next);
+	})
+
+	/**
+	 * DELETE /api/nginx/proxy-hosts/123
+	 *
+	 * Update and existing proxy-host
+	 */
+	.delete((req, res, next) => {
+		internalProxyHost.delete(res.locals.access, {id: parseInt(req.params.host_id, 10)})
+			.then((result) => {
+				res.status(200)
+					.send(result);
+			})
+			.catch(next);
+	});
+
+/**
+ * Specific proxy-host by domain
+ *
  * /api/nginx/proxy-hosts/domain/:domain
  */
 router
@@ -156,38 +234,6 @@ router
 			.then((row) => {
 				res.status(200)
 					.send(row);
-			})
-			.catch(next);
-	});
-
-	/**
-	 * PUT /api/nginx/proxy-hosts/123
-	 *
-	 * Update and existing proxy-host
-	 */
-	.put((req, res, next) => {
-		apiValidator(schema.getValidationSchema('/nginx/proxy-hosts/{hostID}', 'put'), req.body)
-			.then((payload) => {
-				payload.id = parseInt(req.params.host_id, 10);
-				return internalProxyHost.update(res.locals.access, payload);
-			})
-			.then((result) => {
-				res.status(200)
-					.send(result);
-			})
-			.catch(next);
-	})
-
-	/**
-	 * DELETE /api/nginx/proxy-hosts/123
-	 *
-	 * Update and existing proxy-host
-	 */
-	.delete((req, res, next) => {
-		internalProxyHost.delete(res.locals.access, {id: parseInt(req.params.host_id, 10)})
-			.then((result) => {
-				res.status(200)
-					.send(result);
 			})
 			.catch(next);
 	});

--- a/backend/routes/nginx/proxy_hosts.js
+++ b/backend/routes/nginx/proxy_hosts.js
@@ -145,7 +145,7 @@ router
 			}
 		}, {
 			domain: req.params.domain,
-			expand:  (typeof req.query.expand === 'string' ? req.query.expand.split(',') : null)
+			expand: (typeof req.query.expand === 'string' ? req.query.expand.split(',') : null)
 		})
 			.then((data) => {
 				return internalProxyHost.getByDomain(res.locals.access, {

--- a/backend/routes/nginx/proxy_hosts.js
+++ b/backend/routes/nginx/proxy_hosts.js
@@ -112,52 +112,6 @@ router
 					.send(row);
 			})
 			.catch(next);
-	});
-
-/**
- * Specific proxy-host
- *
- * /api/nginx/proxy-hosts/123
- */
-router
-	.route('/:host_id')
-	.options((req, res) => {
-		res.sendStatus(204);
-	})
-	.all(jwtdecode())
-
-	/**
-	 * GET /api/nginx/proxy-hosts/123
-	 *
-	 * Retrieve a specific proxy-host
-	 */
-	.get((req, res, next) => {
-		validator({
-			required:             ['host_id'],
-			additionalProperties: false,
-			properties:           {
-				host_id: {
-					$ref: 'common#/properties/id'
-				},
-				expand: {
-					$ref: 'common#/properties/expand'
-				}
-			}
-		}, {
-			host_id: req.params.host_id,
-			expand:  (typeof req.query.expand === 'string' ? req.query.expand.split(',') : null)
-		})
-			.then((data) => {
-				return internalProxyHost.get(res.locals.access, {
-					id:     parseInt(data.host_id, 10),
-					expand: data.expand
-				});
-			})
-			.then((row) => {
-				res.status(200)
-					.send(row);
-			})
-			.catch(next);
 	})
 
 	/**


### PR DESCRIPTION
We have automated script that run outside of NPM. These scripts use the backend api to add and remove proxies, as well as query for existing proxies.

We have scripts the need to pull specific proxies by domain, rather than proxy_id.

Pulling the entire list of proxies to search for a proxy by domain is extremely slow, especially if a large amount of proxies exist.

This pull request will add an endpoint to the backend API to allow the query of proxies by domain name.