### PR TITLE
fix(modal): make textarea font actually monospace

### DIFF
--- a/frontend/scss/tabler-extra.scss
+++ b/frontend/scss/tabler-extra.scss
@@ -167,4 +167,5 @@ $pink: #f66d9b;
 
 textarea.form-control.text-monospace {
     font-size: 12px;
+    font-family: monospace;
 }


### PR DESCRIPTION
Modal `textarea` element has this class `text-monospace`, but there is actually no CSS definition that sets the monospace font for it (neither in custom SCSS files, nor in included libs). This commit fixes the issue by setting `monospace` `font-family` for the `textarea`, greatly enhancing UX of configuration editing in UI.