### PR TITLE
Update 'global/certbot-dns-plugins.json' to apply SSL certs for CloudFlare.

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -60,7 +60,7 @@
 		"package_name": "certbot-dns-cloudflare",
 		"version": "=={{certbot-version}}",
 		"dependencies": "cloudflare==4.0.* acme=={{certbot-version}}",
-		"credentials": "# Cloudflare API token\ndns_cloudflare_api_token = 0123456789abcdef0123456789abcdef01234567",
+		"credentials": "# Cloudflare API credentials used by Certbot\ndns_cloudflare_email = cloudflare@example.com\ndns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234",
 		"full_plugin_name": "dns-cloudflare"
 	},
 	"cloudns": {

--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -60,7 +60,7 @@
 		"package_name": "certbot-dns-cloudflare",
 		"version": "=={{certbot-version}}",
 		"dependencies": "cloudflare==4.0.* acme=={{certbot-version}}",
-		"credentials": "# Cloudflare API token\ndns_cloudflare_api_token=0123456789abcdef0123456789abcdef01234567",
+		"credentials": "# Cloudflare API token\ndns_cloudflare_api_token = 0123456789abcdef0123456789abcdef01234567",
 		"full_plugin_name": "dns-cloudflare"
 	},
 	"cloudns": {


### PR DESCRIPTION
Neither `dns_cloudflare_api_token=0123456789abcdef0123456789abcdef01234567` nor `dns_cloudflare_api_token = 0123456789abcdef0123456789abcdef01234567` were no longer working for CloudFlare SSL certificates applying. And I've modified it manually as below and it worked successfully.

```
# Cloudflare API credentials used by Certbot
dns_cloudflare_email = cloudflare@example.com
dns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234
```