### PR TITLE
Revert certbot-dns-plugins.json changes to credentials placeholder

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -68,7 +68,7 @@
 		"package_name": "certbot-dns-cloudflare",
 		"version": "=={{certbot-version}}",
 		"dependencies": "cloudflare==4.0.* acme=={{certbot-version}}",
-		"credentials": "# Cloudflare API credentials used by Certbot\ndns_cloudflare_email = cloudflare@example.com\ndns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234",
+		"credentials": "# Cloudflare API token\ndns_cloudflare_api_token=0123456789abcdef0123456789abcdef01234567",
 		"full_plugin_name": "dns-cloudflare"
 	},
 	"cloudns": {


### PR DESCRIPTION
Storing user/password instead of an API token is not a good idea and specifically not recommended by [certbot-dns-cloudflare documentation](https://certbot-dns-cloudflare.readthedocs.io/en/stable/index.html#certbot-cloudflare-token-ini).
Spaces were intentionally removed in the past by #3781.
`dns_cloudflare_api_token=abc123` was/is working fine for me.