### PR TITLE
Update certbot-dns-eurodns plugin from 0.0.4 to 1.8.1

### DIFF
--- a/global/certbot-dns-plugins.json
+++ b/global/certbot-dns-plugins.json
@@ -218,9 +218,9 @@
 	"eurodns": {
 		"name": "EuroDNS",
 		"package_name": "certbot-dns-eurodns",
-		"version": "~=0.0.4",
+		"version": "~=1.8.1",
 		"dependencies": "",
-		"credentials": "dns_eurodns_applicationId = myuser\ndns_eurodns_apiKey = mysecretpassword\ndns_eurodns_endpoint = https://rest-api.eurodns.com/user-api-gateway/proxy",
+		"credentials": "dns_eurodns_applicationId = myuser\ndns_eurodns_apiKey = mysecretpassword\ndns_eurodns_endpoint = https://rest-api.eurodns.com/user-api/dns-zones/",
 		"full_plugin_name": "dns-eurodns"
 	},
 	"firstdomains": {


### PR DESCRIPTION
## Changes
- Update `certbot-dns-eurodns` from version 0.0.4 to 1.8.1

## Problem Solved
- Fixes EuroDNS DNS challenge failures due to deprecated API endpoints
- Version 0.0.4 was using old `rest-api.eurodns.com/user-api-gateway/proxy/` endpoints that return 403 errors

## Testing
- [X] Tested locally with EuroDNS DNS challenge
- [X] Certificate generation works with updated plugin
- [X] Tested build

## Related Issues
- Addresses DNS challenge failures with EuroDNS provider
- Updates deprecated API endpoint introduced in commit a2dde00

## Breaking Changes
- None - maintains same configuration interface