### PR TITLE
Fix initial email with uppercase

### DIFF
--- a/backend/setup.js
+++ b/backend/setup.js
@@ -21,7 +21,7 @@ const setupDefaultUser = () => {
 		.then((row) => {
 			if (!row || !row.id) {
 				// Create a new user and set password
-				const email    = process.env.INITIAL_ADMIN_EMAIL || 'admin@example.com';
+				const email    = (process.env.INITIAL_ADMIN_EMAIL || 'admin@example.com').toLowerCase();
 				const password = process.env.INITIAL_ADMIN_PASSWORD || 'changeme';
 
 				logger.info('Creating a new user: ' + email + ' with password: ' + password);


### PR DESCRIPTION
When using the **INITIAL_ADMIN_EMAIL** environment variable with an email address with upper case characters you are not allowed to login (_Invalid email or password_) because it expects to find the email address with only lower case characters in the database.

I have not tested this code change (but I guess it should work)