### PR TITLE
Fix to prevent certbot cmd request to add propagation seconds if route53 is used for dns challenge

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -892,7 +892,7 @@ const internalCertificate = {
 					: ''
 			) +
 			(
-				certificate.meta.propagation_seconds !== undefined
+				certificate.meta.propagation_seconds !== undefined && certificate.meta.dns_provider !== 'route53'
 					? `--${dnsPlugin.full_plugin_name}-propagation-seconds '${certificate.meta.propagation_seconds}' `
 					: ''
 			) +


### PR DESCRIPTION
Fixes #4702 