### PR TITLE
Parse certificate expiration date and domains for custom API certificates

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -848,7 +848,7 @@ const internalCertificate = {
 							// Parse DNS names from SAN line: "DNS:example.com, DNS:www.example.com"
 							const dnsMatches = sanLine.match(/DNS:([^,\s]+)/g);
 							if (dnsMatches) {
-								dnsMatches.forEach(match => {
+								dnsMatches.forEach((match) => {
 									const domain = match.replace('DNS:', '');
 									altNames.push(domain);
 								});

--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -135,7 +135,7 @@ const internalCertificate = {
 								
 								// Add Subject Alternative Names
 								if (cert_info.altNames && cert_info.altNames.length) {
-									cert_info.altNames.forEach(function(san) {
+									cert_info.altNames.forEach((san) => {
 										if (domain_names.indexOf(san) === -1) {
 											domain_names.push(san);
 										}

--- a/backend/schema/components/certificate-object.json
+++ b/backend/schema/components/certificate-object.json
@@ -53,6 +53,10 @@
 					"type": "string",
 					"minLength": 1
 				},
+				"intermediate_certificate": {
+					"type": "string",
+					"description": "Intermediate/CA certificate for custom certificates"
+				},
 				"dns_challenge": {
 					"type": "boolean"
 				},
@@ -69,7 +73,8 @@
 					"type": "object"
 				},
 				"letsencrypt_email": {
-					"$ref": "../common.json#/properties/email"
+					"type": "string",
+					"format": "email"
 				},
 				"propagation_seconds": {
 					"type": "integer",


### PR DESCRIPTION
fix: Parse certificate expiration date and domains for custom certificates

  - Extract actual expiration date from certificate before database insertion
  - Add SAN extraction to getCertificateInfo() function
  - Prevent expires_on defaulting to current timestamp for API uploads
  - Fix domain_names extraction from certificate CN and SAN fields

  Extended GitHub Summary:
  ## Problem
  When uploading custom certificates via API, NPM was incorrectly setting the expiration date to the current timestamp instead of parsing it from
  the certificate. This caused certificates to show as "already expired" even when they were valid for years. Additionally, domain names were not
  being properly extracted from certificates.

  ## Root Cause
  The certificate model's `$beforeInsert()` method sets `expires_on = now()` when the field is undefined. Since API payloads for "other" provider
  certificates don't include `expires_on`, all API-uploaded certificates received the current timestamp as their expiration date.

  ## Solution
  - Modified certificate creation flow to parse certificate expiration date before database insertion
  - Enhanced `getCertificateInfo()` function to extract Subject Alternative Names using `openssl x509 -text`
  - Added proper domain extraction logic that includes both Common Name and SAN domains
  - Ensures `expires_on` field is set to actual certificate expiration date for custom certificates

  ## Testing
  Verified with custom CA certificates that:
  - Expiration dates now show correct future dates (e.g., 2027) instead of current date
  - Domain names properly extracted from both CN and SAN fields
  - Certificates display as valid in NPM webUI