### PR TITLE
Add support for custom certificate key types via environment variables

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -857,6 +857,13 @@ const internalCertificate = {
 			certificate.domain_names.join(','),
 		];
 
+		if (process.env.CERT_KEY_TYPE) {
+			args.push('--key-type', process.env.CERT_KEY_TYPE);
+		}
+		if (process.env.CERT_ELLIPTIC_CURVE) {
+			args.push('--elliptic-curve', process.env.CERT_ELLIPTIC_CURVE);
+		}
+
 		const adds = internalCertificate.getAdditionalCertbotArgs(certificate.id);
 		args.push(...adds.args);
 
@@ -906,6 +913,13 @@ const internalCertificate = {
 			'--authenticator',
 			dnsPlugin.full_plugin_name,
 		];
+
+		if (process.env.CERT_KEY_TYPE) {
+			args.push('--key-type', process.env.CERT_KEY_TYPE);
+		}
+		if (process.env.CERT_ELLIPTIC_CURVE) {
+			args.push('--elliptic-curve', process.env.CERT_ELLIPTIC_CURVE);
+		}
 
 		if (hasConfigArg) {
 			args.push(`--${dnsPlugin.full_plugin_name}-credentials`, credentialsLocation);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,9 @@ ENV SUPPRESS_NO_CONFIG_WARNING=1 \
 	NPM_BUILD_VERSION="${BUILD_VERSION}" \
 	NPM_BUILD_COMMIT="${BUILD_COMMIT}" \
 	NPM_BUILD_DATE="${BUILD_DATE}" \
-	NODE_OPTIONS="--openssl-legacy-provider"
+	NODE_OPTIONS="--openssl-legacy-provider" \
+	CERT_KEY_TYPE="" \
+	CERT_ELLIPTIC_CURVE=""
 
 RUN echo "fs.file-max = 65535" > /etc/sysctl.conf \
 	&& apt-get update \


### PR DESCRIPTION
Adds support for custom certificate key types through `CERT_KEY_TYPE` and `CERT_ELLIPTIC_CURVE` environment variables, optionally also passed to the Dockerfile, to enables ECDSA P-256 certificates and other key types beyond the default.

Maintains backward compatibility when environment variables are empty or not set (i.e. no impact to current behaviour when the vars are not set).