### PR TITLE
Fix certificates shown as Inactive when used for redirection

### DIFF
--- a/frontend/js/app/nginx/certificates/list/item.js
+++ b/frontend/js/app/nginx/certificates/list/item.js
@@ -52,8 +52,8 @@ module.exports = Mn.View.extend({
             },
             dns_providers: dns_providers,
             active_domain_names: function () {
-                const { proxy_hosts = [], redirect_hosts = [], dead_hosts = [] } = this;
-                return [...proxy_hosts, ...redirect_hosts, ...dead_hosts].reduce((acc, host) => {
+                const { proxy_hosts = [], redirection_hosts = [], dead_hosts = [] } = this;
+                return [...proxy_hosts, ...redirection_hosts, ...dead_hosts].reduce((acc, host) => {
                     acc.push(...(host.domain_names || []));
                     return acc;
                 }, []);


### PR DESCRIPTION
`frontend/js/app/nginx/certificates/list/item.js` contains a typo: `redirect_hosts` instead of `redirection_hosts`.

This causes the STATUS column on the "SSL Certificates" page to break, as redirect hosts are not detected and are therefore shown as Inactive.

See #4455 for more information.

Fixes #4455 