### PR TITLE
Update _access.conf to fix access_list.pass_auth logic

### DIFF
--- a/backend/templates/_access.conf
+++ b/backend/templates/_access.conf
@@ -4,7 +4,7 @@
     auth_basic            "Authorization required";
     auth_basic_user_file  /data/access/{{ access_list_id }};
 
-    {% if access_list.pass_auth == 1 or access_list.pass_auth == true %}
+    {% if access_list.pass_auth == 0 or access_list.pass_auth == false %}
     proxy_set_header Authorization "";
     {% endif %}
 


### PR DESCRIPTION
Wrong logic to pass auth as header: when disabled (pass_auth=0) credentials are included in Authorization header. However as soon as you enable (pass_auth=1) they are not.