### PR TITLE
Fix unaligned flag on main screen when language is selected

### DIFF
--- a/frontend/src/components/LocalePicker.tsx
+++ b/frontend/src/components/LocalePicker.tsx
@@ -19,7 +19,7 @@ function LocalePicker() {
 	const cns = cn(...classes, getTheme() === "dark" ? "btn-ghost-dark" : "btn-ghost-light");
 
 	return (
-		<div className="dropdown">
+		<div className="dropdown align-content-center">
 			<button type="button" className={cns} data-bs-toggle="dropdown">
 				<Flag countryCode={getFlagCodeForLocale(locale)} />
 			</button>


### PR DESCRIPTION
Fixes this issue on the main screen, might've been better if I applied styles there, idk.
before and after:
<img width="120" height="60" alt="image" src="https://github.com/user-attachments/assets/cfa0d366-c32f-4fca-a8b8-d6b5eda6b973" />
<img width="120" height="60" alt="image" src="https://github.com/user-attachments/assets/f6c885ca-d173-4f97-b172-5c5d67e0c20f" />

