### PR TITLE
fix(i18n): replace "Dodaj" with "Nowy" for better Polish grammar and typo Role

### DIFF
--- a/frontend/src/locale/src/pl.json
+++ b/frontend/src/locale/src/pl.json
@@ -417,7 +417,7 @@
 		"defaultMessage": "{object} #{id}"
 	},
 	"object.add": {
-		"defaultMessage": "Dodaj {object}"
+		"defaultMessage": "Nowy {object}"
 	},
 	"object.delete": {
 		"defaultMessage": "Usuń {object}"


### PR DESCRIPTION
fix(i18n): replace "Dodaj" with "Nowy" for better Polish grammar

Changed Polish UI pattern from imperative verb to adjective form:
- Before: "Dodaj [object]" (Add  {{ object }})
- After: "Nowy {{ object }}"

Rationale:
In Polish, the imperative "Dodaj" requires accusative case, which works 
for some nouns but sounds unnatural for others:

Works: "Dodaj host" (accusative: host -> host, no change)
Awkward: "Dodaj użytkownik" (needs "użytkownika" in accusative)

Using "Nowy" (adjective) solves this by requiring nominative case,
which is consistent across all nouns:

- "Nowy host"
- "Nowy użytkownik" 
-  "Nowy certyfikat"
-  "Nowa rola"

This pattern is more natural and commonly used in Polish UI/UX.