### PR TITLE
Polish Translation Fixes

### DIFF
--- a/frontend/src/locale/src/pl.json
+++ b/frontend/src/locale/src/pl.json
@@ -159,7 +159,7 @@
 		"defaultMessage": "Wyniki testu"
 	},
 	"certificates.http.warning": {
-		"defaultMessage": "Te domeny muszą być już skonfigurowane tak, aby wskazywały na ten serwer www"
+		"defaultMessage": "Te domeny muszą być już skonfigurowane tak, aby wskazywały na ten serwer"
 	},
 	"certificates.request.subtitle": {
 		"defaultMessage": "z Let's Encrypt"


### PR DESCRIPTION
Polish Translation Fixes
This PR fixes Polish translations to work better with the app's template system.



"Host proxy" → "host proxy"
"Certyfikat" → "certyfikat"

Simplified menu names:

"Hosty proxy" → "Proxy"
"Hosty 404" → "404"
"Logi audytu" → "Logi"

Improved clarity:
"Buforuj zasoby" → "Buforuj(cache) zasoby statyczne"
"Zamów nowy certyfikat" → "Wygeneruj nowy certyfikat"
Added missing buttons: "Zezwól" (Allow) and "Odrzuć" (Deny)

**Why**
Polish grammar uses different word endings depending on context (cases/declension). The templates can't handle all these variations, so the translations now use forms that work everywhere.