### PR TITLE
Add Glesys certbot plugin

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -255,6 +255,14 @@
 		"credentials": "dns_gcore_apitoken = 0123456789abcdef0123456789abcdef01234567",
 		"full_plugin_name": "dns-gcore"
 	},
+	"glesys": {
+		"name": "Glesys",
+		"package_name": "certbot-dns-glesys",
+		"version": "~=2.1.0",
+		"dependencies": "",
+		"credentials": "dns_glesys_user = CL00000\ndns_glesys_password = apikeyvalue",
+		"full_plugin_name": "dns-glesys"
+	},
 	"godaddy": {
 		"name": "GoDaddy",
 		"package_name": "certbot-dns-godaddy",


### PR DESCRIPTION
Adds support for issuing certificates via DNS challenge on [Glesys](https://glesys.com/) using [certbot-dns-glesys](https://github.com/runfalk/certbot-dns-glesys).

Tested to be working with a locally built image.