### PR TITLE
Add Hurricane Electric DDNS plugin configuration

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -295,6 +295,14 @@
 		"credentials": "dns_he_user = Me\ndns_he_pass = my HE password",
 		"full_plugin_name": "dns-he"
 	},
+	"he-ddns": {
+		"name": "Hurricane Electric - DDNS",
+		"package_name": "certbot-dns-he-ddns",
+		"version": "~=0.1.0",
+		"dependencies": "",
+		"credentials": "dns_he_ddns_password = verysecurepassword",
+		"full_plugin_name": "dns-he-ddns"
+	},
 	"hetzner": {
 		"name": "Hetzner",
 		"package_name": "certbot-dns-hetzner",


### PR DESCRIPTION
Default Hurricane Electric plugin requires 'root' username and password to the plugin which allows it full control over your account.  A new preferred method has been created that allows for the use of DDNS records instead which is more secure and delegates permission to specific records for DNS verification.  More information available here: https://github.com/mafredri/certbot-dns-he-ddns

Made changes to a local new install docker container and confirmed working.