### PR TITLE
Fix Japanese translate

### DIFF
--- a/frontend/src/locale/src/ja.json
+++ b/frontend/src/locale/src/ja.json
@@ -570,7 +570,7 @@
 		"defaultMessage": "ストリーム"
 	},
 	"stream.forward-host": {
-		"defaultMessage": "転送ポート"
+		"defaultMessage": "転送ホスト"
 	},
 	"stream.incoming-port": {
 		"defaultMessage": "受信ポート"


### PR DESCRIPTION
The translation for "forward-host" was the same as "forward-port(転送ポート)".
Corrected to the proper translation(転送ホスト).
