### PR TITLE
Simplify SSL redirection logic in Nginx config

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/include/force-ssl.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/force-ssl.conf
@@ -1,10 +1,7 @@
-set $test "";
-if ($scheme = "http") {
-	set $test "H";
+if ($request_uri ~ ^/\.well-known/acme-challenge/) {
+    break;
 }
-if ($request_uri = /.well-known/acme-challenge/test-challenge) {
-	set $test "${test}T";
-}
-if ($test = H) {
-	return 301 https://$host$request_uri;
+
+if ($scheme = http) {
+    return 301 https://$host$request_uri;
 }


### PR DESCRIPTION
Force SSL logic to determine acme challenges is wrong which makes all http requests (including acme challenges) redirect to https counterpart. A simplification to this include file fixes this.

I have tested with overwriting the file by adding this line to docker-compose.yml:
```
volumes:
  - ./force-ssl.conf:/etc/nginx/conf.d/include/force-ssl.conf
 ```

Fixes #3979