### PR TITLE
Add DNS plugin for All-Inkl provider

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -378,7 +378,7 @@
 	"kas": {
         "name": "All-Inkl",
         "package_name": "certbot-dns-kas",
-        "version": "==0.1.1",
+        "version": "~=0.1.1",
         "dependencies": "kasserver",
         "credentials": "dns_kas_user = your_kas_user\ndns_kas_password = your_kas_password",
         "full_plugin_name": "dns-kas"


### PR DESCRIPTION
So far there was no certbot Plugin for the big German provider All-Inkl.
I [built that plugin](https://github.com/mobilandi/certbot-dns-kas) and tested it for Cert Requests via DNS-Challenge. Everything worked fine for new.
I thought it would be nice to add this to the main project. It's my first python project and also my first git PR. So feel free to criticize if something else needs to be done. Thank you. 
