### PR TITLE
Added support for DNS challenges with Simply.com

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -535,6 +535,14 @@
 		"credentials": "[default]\naws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		"full_plugin_name": "dns-route53"
 	},
+	"simply": {
+		"name": "Simply",
+		"package_name": "certbot-dns-simply",
+		"version": "~=0.1.2",
+		"dependencies": "",
+		"credentials": "dns_simply_account_name = UExxxxxx\ndns_simply_api_key = DsHJdsjh2812872sahj",
+		"full_plugin_name": "dns-simply"
+	},
 	"spaceship": {
 		"name": "Spaceship",
 		"package_name": "certbot-dns-spaceship",


### PR DESCRIPTION
According to the documentation found at https://www.simply.com/en/docs/api/, a certbot plugin for their API is implemented at https://github.com/JohNan/certbot-dns-simply. This PR adds an entry to `dns-plugins.json` to enable the use of this plugin. Functionality has been tested with a locally built image, and works with let's encrypt.