### PR TITLE
Add sakuracloud dns provider

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -588,7 +588,7 @@
 		"package_name": "certbot-dns-sakuracloud",
 		"version": "~=5.2.2",
 		"dependencies": "",
-		"credentials": "# Sakura Cloud API credentials used by Certbot\ndns_sakuracloud_api_token = YOUR_API_TOKEN\ndns_sakuracloud_api_secret = YOUR_API_SECRET",
+		"credentials": "# Sakura Cloud API credentials\ndns_sakuracloud_api_token = YOUR_API_TOKEN\ndns_sakuracloud_api_secret = YOUR_API_SECRET",
 		"full_plugin_name": "dns-sakuracloud"
 	},
 	"timeweb": {

--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -583,6 +583,14 @@
                 "credentials": "dns_selectel_api_v2_account_id = your_account_id\ndns_selectel_api_v2_project_name = your_project\ndns_selectel_api_v2_username = your_username\ndns_selectel_api_v2_password = your_password",
                 "full_plugin_name": "dns-selectel-api-v2"
         },
+	"sakuracloud": {
+		"name": "Sakura Cloud",
+		"package_name": "certbot-dns-sakuracloud",
+		"version": "~=5.2.2",
+		"dependencies": "",
+		"credentials": "# Sakura Cloud API credentials used by Certbot\ndns_sakuracloud_api_token = YOUR_API_TOKEN\ndns_sakuracloud_api_secret = YOUR_API_SECRET",
+		"full_plugin_name": "dns-sakuracloud"
+	},
 	"timeweb": {
 		"name": "Timeweb Cloud",
 		"package_name": "certbot-dns-timeweb",


### PR DESCRIPTION
Added support for [Sakura Cloud](https://cloud.sakura.ad.jp/) DNS provider ( https://pypi.org/project/certbot-dns-sakuracloud/ )
