### PR TITLE
Clarify network_mode: host ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ services:
 
 This is the bare minimum configuration required. See the [documentation](https://nginxproxymanager.com/setup/) for more.
 
+If you plan on using `network_mode: host`, make sure not only port 80, 81 and 443 are not used but also port 3000, which serves the backend API.
+
 3. Bring up your stack by running
 
 ```bash


### PR DESCRIPTION
Just deployed npm on a machine, where an orphaned grafana server was serving on port 3000. When switching to `network_mode: host` the npm API-service would silently fail and the frontend loaded the grafana frontend instead. To help people running other services possibly occupying port 3000 and therefor the npm API, I added the short line in the quick setup.
Might be a good addition to the docs as well.