### PR TITLE
Add Added the option to use different access lists for custom locations

### DIFF
--- a/backend/schema/components/access-list-object.json
+++ b/backend/schema/components/access-list-object.json
@@ -1,7 +1,7 @@
 {
 	"type": "object",
 	"description": "Access List object",
-	"required": ["id", "created_on", "modified_on", "owner_user_id", "name", "meta", "satisfy_any", "pass_auth", "proxy_host_count"],
+	"required": ["id", "created_on", "modified_on", "owner_user_id", "name", "meta", "satisfy_any", "pass_auth", "proxy_host_count", "location_count"],
 	"properties": {
 		"id": {
 			"$ref": "../common.json#/properties/id"
@@ -36,6 +36,11 @@
 			"type": "integer",
 			"minimum": 0,
 			"example": 3
+		},
+		"location_count": {
+			"type": "integer",
+			"minimum": 0,
+			"example": 1
 		}
 	}
 }

--- a/backend/schema/components/proxy-host-object.json
+++ b/backend/schema/components/proxy-host-object.json
@@ -123,6 +123,26 @@
 					},
 					"advanced_config": {
 						"type": "string"
+					},
+					"use_parent_access_list": {
+						"type": "boolean",
+						"default": true,
+						"description": "Whether to use the parent proxy host's access list or a custom one"
+					},
+					"access_list_id": {
+						"$ref": "../common.json#/properties/access_list_id"
+					},
+					"access_list": {
+						"oneOf": [
+							{
+								"type": "null",
+								"example": null
+							},
+							{
+								"$ref": "./access-list-object.json"
+							}
+						],
+						"example": null
 					}
 				}
 			},

--- a/backend/schema/paths/nginx/access-lists/get.json
+++ b/backend/schema/paths/nginx/access-lists/get.json
@@ -39,7 +39,8 @@
 						"meta": {},
 						"satisfy_any": true,
 						"pass_auth": false,
-						"proxy_host_count": 0
+						"proxy_host_count": 0,
+						"location_count": 0
 					},
 					"schema": {
 						"$ref": "../../../components/access-list-object.json"

--- a/backend/schema/paths/nginx/access-lists/listID/get.json
+++ b/backend/schema/paths/nginx/access-lists/listID/get.json
@@ -40,7 +40,8 @@
                                 "meta": {},
                                 "satisfy_any": false,
                                 "pass_auth": false,
-                                "proxy_host_count": 1
+                                "proxy_host_count": 1,
+                                "location_count": 0
                             }
                         }
                     },

--- a/backend/schema/paths/nginx/access-lists/listID/put.json
+++ b/backend/schema/paths/nginx/access-lists/listID/put.json
@@ -84,6 +84,7 @@
 								"satisfy_any": true,
 								"pass_auth": false,
 								"proxy_host_count": 0,
+								"location_count": 0,
 								"owner": {
 									"id": 1,
 									"created_on": "2024-10-07T22:43:55.000Z",

--- a/backend/schema/paths/nginx/access-lists/post.json
+++ b/backend/schema/paths/nginx/access-lists/post.json
@@ -75,6 +75,7 @@
 								"satisfy_any": true,
 								"pass_auth": false,
 								"proxy_host_count": 0,
+								"location_count": 0,
 								"owner": {
 									"id": 1,
 									"created_on": "2024-10-07T22:43:55.000Z",

--- a/frontend/src/api/backend/models.ts
+++ b/frontend/src/api/backend/models.ts
@@ -54,6 +54,7 @@ export interface AccessList {
 	satisfyAny: boolean;
 	passAuth: boolean;
 	proxyHostCount?: number;
+	locationCount?: number;
 	// Expansions:
 	owner?: User;
 	items?: AccessListItem[];
@@ -103,6 +104,10 @@ export interface ProxyLocation {
 	forwardScheme: string;
 	forwardHost: string;
 	forwardPort: number;
+	useParentAccessList?: boolean;
+	accessListId?: number;
+	// Expansions:
+	accessList?: AccessList;
 }
 
 export interface ProxyHost {

--- a/frontend/src/locale/src/bg.json
+++ b/frontend/src/locale/src/bg.json
@@ -398,6 +398,18 @@
 	"loading": {
 		"defaultMessage": "Зареждане…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Използвайте списъка за достъп на родителския прокси хост"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Когато е изключено, можете да изберете различен списък за достъп за това конкретно място"
+	},
+	"locations": {
+		"defaultMessage": "Маршрути"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {маршрути} other {маршрут}}"
+	},
 	"login.title": {
 		"defaultMessage": "Вход в акаунта"
 	},

--- a/frontend/src/locale/src/de.json
+++ b/frontend/src/locale/src/de.json
@@ -383,6 +383,18 @@
 	"loading": {
 		"defaultMessage": "Laden…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Zugriffsliste des übergeordneten Proxy-Hosts verwenden"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Wenn deaktiviert, können Sie eine andere Zugriffsliste für diesen spezifischen Pfad auswählen"
+	},
+	"locations": {
+		"defaultMessage": "Pfade"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Pfad} other {Pfade}}"
+	},
 	"login.title": {
 		"defaultMessage": "Anmelden"
 	},

--- a/frontend/src/locale/src/en.json
+++ b/frontend/src/locale/src/en.json
@@ -455,6 +455,18 @@
 	"loading": {
 		"defaultMessage": "Loading…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Use parent proxy host access list"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "When unchecked, you can select a different access list for this specific location"
+	},
+	"locations": {
+		"defaultMessage": "Locations"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Location} other {Locations}}"
+	},
 	"login.2fa-code": {
 		"defaultMessage": "Verification Code"
 	},

--- a/frontend/src/locale/src/es.json
+++ b/frontend/src/locale/src/es.json
@@ -398,6 +398,18 @@
 	"loading": {
 		"defaultMessage": "Cargando…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Usar lista de acceso del proxy host principal"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Cuando está desmarcado, puede seleccionar una lista de acceso diferente para esta ubicación específica"
+	},
+	"locations": {
+		"defaultMessage": "Ubicaciones"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Ubicación} other {Ubicaciones}}"
+	},
 	"login.title": {
 		"defaultMessage": "Inicia sesión en tu cuenta"
 	},

--- a/frontend/src/locale/src/fr.json
+++ b/frontend/src/locale/src/fr.json
@@ -371,6 +371,18 @@
 	"loading": {
 		"defaultMessage": "Chargement…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Utiliser la liste d'accès du proxy hôte parent"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Lorsque décoché, vous pouvez sélectionner une liste d'accès différente pour cet emplacement spécifique"
+	},
+	"locations": {
+		"defaultMessage": "Emplacements"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Emplacement} other {Emplacements}}"
+	},
 	"login.title": {
 		"defaultMessage": "Connectez-vous à votre compte"
 	},

--- a/frontend/src/locale/src/ga.json
+++ b/frontend/src/locale/src/ga.json
@@ -386,6 +386,18 @@
 	"loading": {
 		"defaultMessage": "Ag lódáil…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Bain úsáid as liosta rochtana óstach seachfhreastalaí tuismitheora"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Nuair atá sé dí-sheiceáilte, is féidir leat liosta rochtana difriúil a roghnú don suíomh sonrach seo"
+	},
+	"locations": {
+		"defaultMessage": "Suíomhanna"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Suíomh} other {Suíomhanna}}"
+	},
 	"login.title": {
 		"defaultMessage": "Logáil isteach i do chuntas"
 	},

--- a/frontend/src/locale/src/hu.json
+++ b/frontend/src/locale/src/hu.json
@@ -455,6 +455,18 @@
 	"loading": {
 		"defaultMessage": "Betöltés…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Szülő proxy host hozzáférési listájának használata"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Ha nincs bejelölve, különböző hozzáférési listát választhat ehhez a konkrét helyhez"
+	},
+	"locations": {
+		"defaultMessage": "Útvonalak"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} útvonal"
+	},
 	"login.2fa-code": {
 		"defaultMessage": "Ellenőrző kód"
 	},

--- a/frontend/src/locale/src/id.json
+++ b/frontend/src/locale/src/id.json
@@ -386,6 +386,18 @@
 	"loading": {
 		"defaultMessage": "Memuat…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Gunakan daftar akses proxy host induk"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Ketika tidak dicentang, Anda dapat memilih daftar akses yang berbeda untuk lokasi spesifik ini"
+	},
+	"locations": {
+		"defaultMessage": "Lokasi"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} Lokasi"
+	},
 	"login.title": {
 		"defaultMessage": "Masuk ke akun Anda"
 	},

--- a/frontend/src/locale/src/it.json
+++ b/frontend/src/locale/src/it.json
@@ -383,6 +383,18 @@
 	"loading": {
 		"defaultMessage": "Caricamento…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Usa lista di accesso del proxy host principale"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Quando deselezionato, è possibile selezionare una lista di accesso diversa per questa posizione specifica"
+	},
+	"locations": {
+		"defaultMessage": "Posizioni"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Posizione} other {Posizioni}}"
+	},
 	"login.title": {
 		"defaultMessage": "Accedi al tuo account"
 	},

--- a/frontend/src/locale/src/ja.json
+++ b/frontend/src/locale/src/ja.json
@@ -383,6 +383,18 @@
 	"loading": {
 		"defaultMessage": "Loading…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "親プロキシホストのアクセスリストを使用"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "チェックを外すと、この特定のロケーションに別のアクセスリストを選択できます"
+	},
+	"locations": {
+		"defaultMessage": "ロケーション"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} ロケーション"
+	},
 	"login.title": {
 		"defaultMessage": "アカウントにログイン"
 	},

--- a/frontend/src/locale/src/ko.json
+++ b/frontend/src/locale/src/ko.json
@@ -398,6 +398,18 @@
 	"loading": {
 		"defaultMessage": "불러오는 중…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "상위 프록시 호스트의 액세스 목록 사용"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "선택 해제하면 이 특정 위치에 대해 다른 액세스 목록을 선택할 수 있습니다"
+	},
+	"locations": {
+		"defaultMessage": "위치"
+	},
+	"locations.count": {
+		"defaultMessage": "{count}개 위치"
+	},
 	"login.title": {
 		"defaultMessage": "로그인"
 	},

--- a/frontend/src/locale/src/nl.json
+++ b/frontend/src/locale/src/nl.json
@@ -383,6 +383,18 @@
 	"loading": {
 		"defaultMessage": "Laden…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Gebruik toegangslijst van bovenliggende proxy host"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Wanneer uitgevinkt, kunt u een andere toegangslijst selecteren voor deze specifieke locatie"
+	},
+	"locations": {
+		"defaultMessage": "Locaties"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Locatie} other {Locaties}}"
+	},
 	"login.title": {
 		"defaultMessage": "Inloggen"
 	},

--- a/frontend/src/locale/src/pl.json
+++ b/frontend/src/locale/src/pl.json
@@ -389,6 +389,18 @@
 	"loading": {
 		"defaultMessage": "Ładowanie…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Użyj listy dostępu nadrzędnego hosta proxy"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Po odznaczeniu możesz wybrać inną listę dostępu dla tej konkretnej lokalizacji"
+	},
+	"locations": {
+		"defaultMessage": "Lokalizacje"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Lokalizacja} few {Lokalizacje} other {Lokalizacji}}"
+	},
 	"login.title": {
 		"defaultMessage": "Zaloguj się na swoje konto"
 	},

--- a/frontend/src/locale/src/pt.json
+++ b/frontend/src/locale/src/pt.json
@@ -386,6 +386,18 @@
 	"loading": {
 		"defaultMessage": "A carregar…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Usar lista de acesso do proxy host pai"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Quando desmarcado, pode selecionar uma lista de acesso diferente para esta localização específica"
+	},
+	"locations": {
+		"defaultMessage": "Localizações"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Localização} other {Localizações}}"
+	},
 	"login.title": {
 		"defaultMessage": "Iniciar sessão na sua conta"
 	},

--- a/frontend/src/locale/src/ru.json
+++ b/frontend/src/locale/src/ru.json
@@ -383,6 +383,18 @@
 	"loading": {
 		"defaultMessage": "Загрузка…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Использовать список доступа родительского прокси-хоста"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Когда отключено, вы можете выбрать другой список доступа для этого конкретного местоположения"
+	},
+	"locations": {
+		"defaultMessage": "Маршруты"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {маршрут} few {маршрута} other {маршрутов}}"
+	},
 	"login.title": {
 		"defaultMessage": "Авторизация"
 	},

--- a/frontend/src/locale/src/sk.json
+++ b/frontend/src/locale/src/sk.json
@@ -383,6 +383,18 @@
 	"loading": {
 		"defaultMessage": "Načítava sa…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Použiť zoznam prístupu rodičovského proxy hostu"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Keď je nezakrtnuté, môžete vybrať iný zoznam prístupu pre túto konkrétnu lokalitu"
+	},
+	"locations": {
+		"defaultMessage": "Umiestnenia"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} {count, plural, one {Umiestnenie} few {Umiestnenia} other {Umiestnení}}"
+	},
 	"login.title": {
 		"defaultMessage": "Prihláste sa do svojho účtu"
 	},

--- a/frontend/src/locale/src/tr.json
+++ b/frontend/src/locale/src/tr.json
@@ -386,6 +386,18 @@
 	"loading": {
 		"defaultMessage": "Yükleniyor…"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Üst proxy host erişim listesini kullan"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "İşaret kaldırıldığında, bu belirli konum için farklı bir erişim listesi seçebilirsiniz"
+	},
+	"locations": {
+		"defaultMessage": "Konumlar"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} Konum"
+	},
 	"login.title": {
 		"defaultMessage": "Hesabınıza giriş yapın"
 	},

--- a/frontend/src/locale/src/vi.json
+++ b/frontend/src/locale/src/vi.json
@@ -383,6 +383,18 @@
 	"loading": {
 		"defaultMessage": "Đang tải..."
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "Sử dụng danh sách truy cập của proxy host cha"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "Khi bỏ chọn, bạn có thể chọn danh sách truy cập khác cho vị trí cụ thể này"
+	},
+	"locations": {
+		"defaultMessage": "Vị trí"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} Vị trí"
+	},
 	"login.title": {
 		"defaultMessage": "Đăng nhập vào tài khoản của bạn"
 	},

--- a/frontend/src/locale/src/zh.json
+++ b/frontend/src/locale/src/zh.json
@@ -383,6 +383,18 @@
 	"loading": {
 		"defaultMessage": "加载中···"
 	},
+	"location.use-parent-access-list": {
+		"defaultMessage": "使用父代理主机的访问列表"
+	},
+	"location.use-parent-access-list-hint": {
+		"defaultMessage": "取消选中时，您可以为此特定位置选择不同的访问列表"
+	},
+	"locations": {
+		"defaultMessage": "位置 (Locations)"
+	},
+	"locations.count": {
+		"defaultMessage": "{count} 个位置"
+	},
 	"login.title": {
 		"defaultMessage": "登录您的账户"
 	},

--- a/frontend/src/pages/Access/Table.tsx
+++ b/frontend/src/pages/Access/Table.tsx
@@ -56,6 +56,11 @@ export default function Table({ data, isFetching, isFiltered, onEdit, onDelete, 
 				header: intl.formatMessage({ id: "proxy-hosts" }),
 				cell: (info: any) => <T id="proxy-hosts.count" data={{ count: info.getValue() }} />,
 			}),
+			columnHelper.accessor((row: any) => row.locationCount, {
+				id: "locationCount",
+				header: intl.formatMessage({ id: "locations" }),
+				cell: (info: any) => <T id="locations.count" data={{ count: info.getValue() }} />,
+			}),
 			columnHelper.display({
 				id: "id",
 				cell: (info: any) => {


### PR DESCRIPTION
## Summary

This PR adds support for custom access lists (ACLs) per proxy host location, allowing users to override the parent proxy host's ACL for specific locations.

## Problem Context

In nginx-proxy-manager v2.3.1 (very old version that we are using now), users could achieve similar functionality through advanced config by pasting ACL rules into location advanced config. However, when we decide to upgrade to newer versions, we noticed that this approach became problematic because:

- The new version always adds the parent proxy host's ACL with a `deny all` rule at the end
- This `deny all` rule is rendered before any advanced config at location block, making all other ACL rules ineffective
- Users lost the ability to have different access controls for different locations within the same proxy host

## Solution

Instead of relying on advanced config workarounds, this PR implements a proper UI-driven approach that allows users to:
- Enable/disable inheritance of the parent proxy host's ACL for each custom location
- Select a different ACL specifically for that location when inheritance is disabled

## Changes Made

### Backend Changes

**Schema Updates:**
- Added `location_count` to access list schema for separate counting of access list usage across custom locations of proxy hosts
- Updated proxy host location schema to include `use_parent_access_list`, `access_list_id`, and `access_list` properties

**Core Logic (`backend/internal/`):**
- `access-list.js`: Split ACL counting into `proxy_host_count` and `location_count` for better visibility/auditability
- `nginx.js`: Fixed ACL rendering logic to properly apply location-specific ACLs with correct precedence
- `proxy-host.js`: Added location normalization and ACL enrichment functions

### Frontend Changes

**UI Components:**
- `LocationsFields.tsx`: Added checkbox to toggle parent ACL inheritance and AccessField dropdown for custom ACL selection
- `Table.tsx`: Added separate "Locations" column showing location-specific ACL usage counts

**API Models:**
- `models.ts`: Added `locationCount` property to AccessList interface

**Translations:**
- Added "locations" and "locations.count" keys to all 18 supported languages

### API Schema Updates
- Updated all access list endpoint schemas to include the new `location_count` property

## Testing

- All existing functionality remains intact
- New feature works correctly with proper ACL inheritance and overrides
- ACL usage counts are accurately split between proxy hosts and locations
- ACL edits/deletes properly re-render affected locations
- Schema validation passes for all endpoints

## Notes

This is my first contribution to the nginx-proxy-manager project. I'm very open to any criticism and code reviews - please let me know if there are any improvements, bugs, or better approaches to implement this feature. The code has been tested in the development environment and appears to work correctly (at least i hope 🤞), but I'm happy to make any necessary adjustments.