### PR TITLE
Fix uploading of custom certificates

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -630,7 +630,7 @@ const internalCertificate = {
 	 * @param {String}  privateKey    This is the entire key contents as a string
 	 */
 	checkPrivateKey: async (privateKey) => {
-		const filepath = await tempWrite(privateKey, "/tmp");
+		const filepath = await tempWrite(privateKey);
 		const failTimeout = setTimeout(() => {
 			throw new error.ValidationError(
 				"Result Validation Error: Validation timed out. This could be due to the key being passphrase-protected.",
@@ -660,7 +660,7 @@ const internalCertificate = {
 	 * @param {Boolean} [throwExpired]  Throw when the certificate is out of date
 	 */
 	getCertificateInfo: async (certificate, throwExpired) => {
-		const filepath = await tempWrite(certificate, "/tmp");
+		const filepath = await tempWrite(certificate);
 		try {
 			const certData = await internalCertificate.getCertificateInfoFromFile(filepath, throwExpired);
 			fs.unlinkSync(filepath);


### PR DESCRIPTION
Fixes https://github.com/NginxProxyManager/nginx-proxy-manager/issues/5086

You do not have to specify a file path. In this case tmpWrite creates a temporary file with a random name and returns the path to that file. The file path is appended to the random path used by tmpWrite, so it must be relative. Something must have changed as it apparently worked before.

I created a test build with these changes and was able to successfully add a custom certificate.