### PR TITLE
Fix silent nginx config corruption in 50-ipv6.sh

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/prepare/50-ipv6.sh
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/prepare/50-ipv6.sh
@@ -25,7 +25,13 @@ process_folder () {
 	for FILE in $FILES
 	do
 		echo "- ${FILE}"
-		echo "$(sed -E "$SED_REGEX" "$FILE")" > $FILE
+		TMPFILE="${FILE}.tmp"
+		if sed -E "$SED_REGEX" "$FILE" > "$TMPFILE" && [ -s "$TMPFILE" ]; then
+			mv "$TMPFILE" "$FILE"
+		else
+			echo "WARNING: skipping ${FILE} — sed produced empty output" >&2
+			rm -f "$TMPFILE"
+		fi
 	done
 
 	# ensure the files are still owned by the npm user


### PR DESCRIPTION
## Problem

The `50-ipv6.sh` prepare script silently corrupts nginx `.conf` files when run on NFS-backed volumes during container recreation (e.g., by Watchtower).

The current write pattern:
```bash
echo "$(sed -E "$SED_REGEX" "$FILE")" > $FILE
```

If `sed` reads a file that is momentarily empty or unreadable (NFS transient issue during container recreation), it produces no output. The `echo ""` then writes exactly **1 byte** (a newline) to the config file, silently destroying its contents. No errors are logged.

### Impact

- Affected proxy hosts silently stop working — requests fall through to NPM's default "Congratulations" page
- The NPM database still shows all hosts as "enabled", so the API reports everything is fine
- The only indication is that individual `.conf` files in `/data/nginx/proxy_host/` are 1 byte instead of ~1000 bytes
- This is completely silent — no errors in logs, no warnings, no health check failures

### Steps to reproduce

1. Run NPM with `/data` on an NFS volume
2. Have Watchtower (or similar) recreate the container
3. During the brief window where the old container is stopped and the new one starts, if any `.conf` file is momentarily unreadable from NFS, it gets corrupted

## Fix

Replace the unsafe in-place write with an atomic temp-file-and-rename pattern:

```bash
TMPFILE="${FILE}.tmp"
if sed -E "$SED_REGEX" "$FILE" > "$TMPFILE" && [ -s "$TMPFILE" ]; then
    mv "$TMPFILE" "$FILE"
else
    echo "WARNING: skipping ${FILE} — sed produced empty output" >&2
    rm -f "$TMPFILE"
fi
```

This:
- Writes `sed` output to a temp file first
- Checks the temp file is non-empty (`[ -s ]`)
- Only then atomically replaces the original via `mv`
- If `sed` produces empty output, the original file is preserved and a warning is logged