### PR TITLE
feat: fix upstream host resolution edge case and support PEM paste in custom certificates

### DIFF
--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import _ from "lodash";
@@ -8,6 +10,7 @@ import { debug, nginx as logger } from "../logger.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const TRUE_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 
 const internalNginx = {
 	/**
@@ -172,6 +175,8 @@ const internalNginx = {
 						locationCopy.forward_path = `/${splitted.join("/")}`;
 					}
 
+					locationCopy.forward_host = await internalNginx.preResolveUpstreamHost(locationCopy.forward_host);
+
 					renderedLocations += await renderEngine.parseAndRender(template, locationCopy);
 				}
 			};
@@ -238,10 +243,14 @@ const internalNginx = {
 				locationsPromise = Promise.resolve();
 			}
 
+			const forwardHostPromise = internalNginx.preResolveUpstreamHost(host.forward_host).then((resolvedHost) => {
+				host.forward_host = resolvedHost;
+			});
+
 			// Set the IPv6 setting for the host
 			host.ipv6 = internalNginx.ipv6Enabled();
 
-			locationsPromise.then(() => {
+			Promise.all([locationsPromise, forwardHostPromise]).then(() => {
 				renderEngine
 					.parseAndRender(template, host)
 					.then((config_text) => {
@@ -258,8 +267,8 @@ const internalNginx = {
 						reject(new errs.ConfigurationError(err.message));
 					});
 			});
-		});
-	},
+			});
+		},
 
 	/**
 	 * This generates a temporary nginx config listening on port 80 for the domain names listed
@@ -420,6 +429,63 @@ const internalNginx = {
 	 * @returns {boolean}
 	 */
 	advancedConfigHasDefaultLocation: (cfg) => !!cfg.match(/^(?:.*;)?\s*?location\s*?\/\s*?{/im),
+
+	/**
+	 * @returns {boolean}
+	 */
+	preResolveUpstreamHostEnabled: () => {
+		if (typeof process.env.NPM_PRE_RESOLVE_UPSTREAM_HOSTS === "undefined") {
+			return false;
+		}
+		return TRUE_ENV_VALUES.has(String(process.env.NPM_PRE_RESOLVE_UPSTREAM_HOSTS).trim().toLowerCase());
+	},
+
+	/**
+	 * @param   {String}  host
+	 * @returns {boolean}
+	 */
+	canPreResolveUpstreamHost: (host) => {
+		if (typeof host !== "string") {
+			return false;
+		}
+		const candidate = host.trim();
+		if (candidate === "") {
+			return false;
+		}
+		if (candidate.includes("$") || candidate.includes("/") || candidate.includes(":")) {
+			return false;
+		}
+		return isIP(candidate) === 0;
+	},
+
+	/**
+	 * @param   {String}  host
+	 * @returns {Promise<String>}
+	 */
+	preResolveUpstreamHost: async (host) => {
+		if (!internalNginx.preResolveUpstreamHostEnabled()) {
+			return host;
+		}
+		if (typeof host !== "string") {
+			return host;
+		}
+		const candidate = host.trim();
+		if (!internalNginx.canPreResolveUpstreamHost(candidate)) {
+			return host;
+		}
+
+		try {
+			const resolved = await lookup(candidate, { family: 0, all: false, verbatim: false });
+			if (resolved?.address) {
+				debug(logger, `Pre-resolved upstream host "${candidate}" to "${resolved.address}"`);
+				return resolved.address;
+			}
+		} catch (err) {
+			debug(logger, `Could not pre-resolve upstream host "${candidate}": ${err.message}`);
+		}
+
+		return host;
+	},
 
 	/**
 	 * @returns {boolean}

--- a/docs/src/advanced-config/index.md
+++ b/docs/src/advanced-config/index.md
@@ -168,6 +168,30 @@ By default, NPM fetches IP ranges from CloudFront and Cloudflare during applicat
       IP_RANGES_FETCH_ENABLED: 'false'
 ```
 
+## Pre-resolving Upstream Hostnames
+
+By default, proxy upstream hostnames are resolved by Nginx's configured DNS resolver.
+In some Docker setups, hostnames such as `host.docker.internal` may only be available
+through the container's system resolver path (for example `extra_hosts`) and may not be
+resolvable by Nginx runtime DNS resolution.
+
+To enable optional pre-resolution in NPM while generating proxy configs:
+
+```yml
+    environment:
+      NPM_PRE_RESOLVE_UPSTREAM_HOSTS: 'true'
+```
+
+When enabled, NPM attempts to resolve eligible upstream hostnames via the system resolver
+before writing Nginx config and stores the resolved IP in generated upstream targets.
+If resolution fails, NPM keeps the original hostname.
+
+Notes:
+
+- Default is disabled (`false`) to preserve existing behavior.
+- Resolution happens when configs are generated/re-generated, not per request at runtime.
+- If upstream IPs change, regenerate or reload the related proxy host config.
+
 ## Custom Nginx Configurations
 
 If you are a more advanced user, you might be itching for extra Nginx customizability.

--- a/frontend/src/modals/CustomCertificateModal.tsx
+++ b/frontend/src/modals/CustomCertificateModal.tsx
@@ -15,6 +15,17 @@ const showCustomCertificateModal = () => {
 	EasyModal.show(CustomCertificateModal);
 };
 
+const buildPemFile = (file: File | null, content: string, filename: string) => {
+	if (file) {
+		return file;
+	}
+	const pemContent = typeof content === "string" ? content.trim() : "";
+	if (!pemContent) {
+		return null;
+	}
+	return new File([pemContent], filename, { type: "application/x-pem-file" });
+};
+
 const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModalProps) => {
 	const queryClient = useQueryClient();
 	const [errorMsg, setErrorMsg] = useState<ReactNode | null>(null);
@@ -26,13 +37,42 @@ const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModal
 		setErrorMsg(null);
 
 		try {
-			const { niceName, provider, certificate, certificateKey, intermediateCertificate } = values;
+			const {
+				niceName,
+				provider,
+				certificate,
+				certificateText,
+				certificateKey,
+				certificateKeyText,
+				intermediateCertificate,
+				intermediateCertificateText,
+			} = values;
 			const formData = new FormData();
 
-			formData.append("certificate", certificate);
-			formData.append("certificate_key", certificateKey);
-			if (intermediateCertificate !== null) {
-				formData.append("intermediate_certificate", intermediateCertificate);
+			const certFile = buildPemFile(certificate, certificateText, "certificate.pem");
+			const certKeyFile = buildPemFile(certificateKey, certificateKeyText, "certificate-key.pem");
+			const intermediateFile = buildPemFile(
+				intermediateCertificate,
+				intermediateCertificateText,
+				"intermediate.pem",
+			);
+
+			if (!certFile || !certKeyFile) {
+				setErrorMsg(
+					<>
+						<T id="certificate.custom-certificate" /> / <T id="certificate.custom-certificate-key" />:{" "}
+						<T id="error.required" />
+					</>,
+				);
+				setIsSubmitting(false);
+				setSubmitting(false);
+				return;
+			}
+
+			formData.append("certificate", certFile);
+			formData.append("certificate_key", certKeyFile);
+			if (intermediateFile !== null) {
+				formData.append("intermediate_certificate", intermediateFile);
 			}
 
 			// Validate
@@ -64,8 +104,11 @@ const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModal
 						niceName: "",
 						provider: "other",
 						certificate: null,
+						certificateText: "",
 						certificateKey: null,
+						certificateKeyText: "",
 						intermediateCertificate: null,
+						intermediateCertificateText: "",
 					} as any
 				}
 				onSubmit={onSubmit}
@@ -110,103 +153,140 @@ const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModal
 												) : null}
 											</div>
 										)}
-									</Field>
-									<Field name="certificateKey">
-										{({ field, form }: any) => (
-											<div className="mb-3">
-												<label htmlFor="certificateKey" className="form-label">
-													<T id="certificate.custom-certificate-key" />
-												</label>
-												<input
-													id="certificateKey"
-													type="file"
-													required
-													autoComplete="off"
-													className="form-control"
-													onChange={(event) => {
-														form.setFieldValue(
-															field.name,
-															event.currentTarget.files?.length
-																? event.currentTarget.files[0]
-																: null,
-														);
-													}}
-												/>
-												{form.errors.certificateKey ? (
-													<div className="invalid-feedback">
+										</Field>
+										<Field name="certificateKey">
+											{({ field, form }: any) => (
+												<div className="mb-3">
+													<label htmlFor="certificateKey" className="form-label">
+														<T id="certificate.custom-certificate-key" />
+													</label>
+													<input
+														id="certificateKey"
+														type="file"
+														autoComplete="off"
+														className="form-control"
+														onChange={(event) => {
+															form.setFieldValue(
+																field.name,
+																event.currentTarget.files?.length
+																	? event.currentTarget.files[0]
+																	: null,
+															);
+														}}
+													/>
+													{form.errors.certificateKey ? (
+														<div className="invalid-feedback">
 														{form.errors.certificateKey && form.touched.certificateKey
 															? form.errors.certificateKey
 															: null}
-													</div>
-												) : null}
-											</div>
-										)}
-									</Field>
-									<Field name="certificate">
-										{({ field, form }: any) => (
-											<div className="mb-3">
-												<label htmlFor="certificate" className="form-label">
-													<T id="certificate.custom-certificate" />
-												</label>
-												<input
-													id="certificate"
-													type="file"
-													required
-													autoComplete="off"
-													className="form-control"
-													onChange={(event) => {
-														form.setFieldValue(
-															field.name,
-															event.currentTarget.files?.length
-																? event.currentTarget.files[0]
-																: null,
-														);
-													}}
-												/>
-												{form.errors.certificate ? (
-													<div className="invalid-feedback">
-														{form.errors.certificate && form.touched.certificate
-															? form.errors.certificate
-															: null}
-													</div>
-												) : null}
-											</div>
-										)}
-									</Field>
-									<Field name="intermediateCertificate">
-										{({ field, form }: any) => (
-											<div className="mb-3">
-												<label htmlFor="intermediateCertificate" className="form-label">
-													<T id="certificate.custom-intermediate" />
-												</label>
-												<input
-													id="intermediateCertificate"
-													type="file"
-													autoComplete="off"
-													className="form-control"
-													onChange={(event) => {
-														form.setFieldValue(
-															field.name,
-															event.currentTarget.files?.length
-																? event.currentTarget.files[0]
-																: null,
-														);
-													}}
-												/>
-												{form.errors.intermediateCertificate ? (
-													<div className="invalid-feedback">
-														{form.errors.intermediateCertificate &&
-														form.touched.intermediateCertificate
-															? form.errors.intermediateCertificate
-															: null}
-													</div>
-												) : null}
-											</div>
-										)}
-									</Field>
+														</div>
+													) : null}
+												</div>
+											)}
+										</Field>
+										<Field name="certificateKeyText">
+											{({ field }: any) => (
+												<div className="mb-3">
+													<textarea
+														id="certificateKeyText"
+														className="form-control"
+														rows={6}
+														placeholder="-----BEGIN PRIVATE KEY-----"
+														{...field}
+													/>
+												</div>
+											)}
+										</Field>
+										<Field name="certificate">
+											{({ field, form }: any) => (
+												<div className="mb-3">
+													<label htmlFor="certificate" className="form-label">
+														<T id="certificate.custom-certificate" />
+													</label>
+													<input
+														id="certificate"
+														type="file"
+														autoComplete="off"
+														className="form-control"
+														onChange={(event) => {
+															form.setFieldValue(
+																field.name,
+																event.currentTarget.files?.length
+																	? event.currentTarget.files[0]
+																	: null,
+															);
+														}}
+													/>
+													{form.errors.certificate ? (
+														<div className="invalid-feedback">
+															{form.errors.certificate && form.touched.certificate
+																? form.errors.certificate
+																: null}
+														</div>
+													) : null}
+												</div>
+											)}
+										</Field>
+										<Field name="certificateText">
+											{({ field }: any) => (
+												<div className="mb-3">
+													<textarea
+														id="certificateText"
+														className="form-control"
+														rows={6}
+														placeholder="-----BEGIN CERTIFICATE-----"
+														{...field}
+													/>
+												</div>
+											)}
+										</Field>
+										<Field name="intermediateCertificate">
+											{({ field, form }: any) => (
+												<div className="mb-3">
+													<label htmlFor="intermediateCertificate" className="form-label">
+														<T id="certificate.custom-intermediate" />
+													</label>
+													<input
+														id="intermediateCertificate"
+														type="file"
+														autoComplete="off"
+														className="form-control"
+														onChange={(event) => {
+															form.setFieldValue(
+																field.name,
+																event.currentTarget.files?.length
+																	? event.currentTarget.files[0]
+																	: null,
+															);
+														}}
+													/>
+													{form.errors.intermediateCertificate ? (
+														<div className="invalid-feedback">
+															{form.errors.intermediateCertificate &&
+															form.touched.intermediateCertificate
+																? form.errors.intermediateCertificate
+																: null}
+														</div>
+													) : null}
+												</div>
+											)}
+										</Field>
+										<Field name="intermediateCertificateText">
+											{({ field }: any) => (
+												<div className="mb-3">
+													<textarea
+														id="intermediateCertificateText"
+														className="form-control"
+														rows={6}
+														placeholder="-----BEGIN CERTIFICATE-----"
+														{...field}
+													/>
+												</div>
+											)}
+										</Field>
+									</div>
 								</div>
-							</div>
-						</Modal.Body>
+							</Modal.Body>
 						<Modal.Footer>
 							<Button data-bs-dismiss="modal" onClick={remove} disabled={isSubmitting}>
 								<T id="cancel" />


### PR DESCRIPTION
This PR addresses two issues:

- Closes #5344
- Closes #5347

### 1) Optional upstream pre-resolution for `forward_host` (issue #5344)

Problem:
Nginx variable-based upstream resolution may fail for hostnames that are only resolvable through container/system resolver paths (for example `extra_hosts` mappings like `host.docker.internal`).

What changed:
- Added optional env flag: `NPM_PRE_RESOLVE_UPSTREAM_HOSTS` (default: disabled)
- During Nginx config generation, NPM can pre-resolve eligible upstream hostnames via system resolver (`dns.lookup`)
- Applied to both proxy host `forward_host` and custom location `forward_host`
- If resolution fails, it safely falls back to the original hostname

Behavior:
- No behavior change unless the new flag is explicitly enabled

### 2) Allow direct PEM paste in Custom Certificate modal (issue #5347)

Problem:
Custom certificate flow previously required local file selection, which is inconvenient in remote/mobile/thin-client workflows.

What changed:
- Added textarea inputs for:
  - Certificate PEM
  - Certificate Key PEM
  - Intermediate Certificate PEM (optional)
- Kept existing file upload inputs unchanged
- Submit logic now accepts either:
  - uploaded files, or
  - pasted PEM text (converted to `File` objects client-side)
- Existing backend `validate` and `upload` multipart APIs are reused without contract changes

Behavior:
- Backward compatible with existing file upload workflow

### Docs
- Added advanced config documentation for `NPM_PRE_RESOLVE_UPSTREAM_HOSTS`
