### PR TITLE
fix(i18n): correct Irish locale flag and language label

### DIFF
--- a/frontend/check-locales.cjs
+++ b/frontend/check-locales.cjs
@@ -13,6 +13,7 @@ const allLocales = [
   ["es", "es-ES"],
   ["et", "et-EE"],
   ["fr", "fr-FR"],
+  ["ga", "ga-IE"],
   ["it", "it-IT"],
   ["ja", "ja-JP"],
   ["nl", "nl-NL"],

--- a/frontend/src/locale/IntlProvider.tsx
+++ b/frontend/src/locale/IntlProvider.tsx
@@ -72,6 +72,7 @@ const getFlagCodeForLocale = (locale?: string) => {
     vi: "vn", // Vietnam
     ko: "kr", // Korea
     cs: "cz", // Czechia
+    ga: "ie", // Ireland (Irish)
   };
 
   if (specialCases[thisLocale]) {

--- a/frontend/src/locale/Utils.test.tsx
+++ b/frontend/src/locale/Utils.test.tsx
@@ -1,4 +1,4 @@
-import { formatDateTime } from "src/locale";
+import { formatDateTime, getFlagCodeForLocale } from "src/locale";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 describe("DateFormatter", () => {
@@ -70,5 +70,30 @@ describe("DateFormatter", () => {
 		const value = "-100";
 		const text = formatDateTime(value);
 		expect(text).toBe("-100");
+	});
+});
+
+describe("getFlagCodeForLocale", () => {
+	it("returns correct flag code for standard locales", () => {
+		expect(getFlagCodeForLocale("en-US")).toBe("EN");
+		expect(getFlagCodeForLocale("de-DE")).toBe("DE");
+		expect(getFlagCodeForLocale("fr-FR")).toBe("FR");
+	});
+
+	it("returns correct flag code for special-case locales", () => {
+		expect(getFlagCodeForLocale("ja-JP")).toBe("JP");
+		expect(getFlagCodeForLocale("zh-CN")).toBe("CN");
+		expect(getFlagCodeForLocale("vi-VN")).toBe("VN");
+		expect(getFlagCodeForLocale("ko-KR")).toBe("KR");
+		expect(getFlagCodeForLocale("cs-CZ")).toBe("CZ");
+	});
+
+	it("returns IE (Ireland) for Irish locale, not GA (Gabon)", () => {
+		expect(getFlagCodeForLocale("ga-IE")).toBe("IE");
+	});
+
+	it("falls back to EN when no locale is provided", () => {
+		expect(getFlagCodeForLocale()).toBe("EN");
+		expect(getFlagCodeForLocale(undefined)).toBe("EN");
 	});
 });

--- a/frontend/src/locale/src/lang-list.json
+++ b/frontend/src/locale/src/lang-list.json
@@ -8,7 +8,7 @@
   "locale-et-EE": {
     "defaultMessage": "Eesti"
   },
-  "locale-ie-GA": {
+  "locale-ga-IE": {
     "defaultMessage": "Gaeilge"
   },
   "locale-de-DE": {


### PR DESCRIPTION
## Summary

Fixes #5354 - Irish locale (`ga-IE`) displays the Gabon flag and raw `locale-ga-IE` string instead of the Ireland flag and "Gaeilge" label.

### Root cause

Two issues were causing this:

1. **Locale key mismatch in `lang-list.json`**: The key was `"locale-ie-GA"` (language and country codes swapped) instead of `"locale-ga-IE"`. Since `IntlProvider` looks up the label using the format `locale-{fullCode}` where `fullCode` is `ga-IE`, the lookup failed and the raw message ID was displayed.

2. **Missing flag mapping in `getFlagCodeForLocale()`**: The function derives the country code from the first two characters of the locale (`ga`), which maps to Gabon (`GA`). Irish needs a special-case mapping (`ga -> ie`) similar to how Japanese (`ja -> jp`) and others are already handled.

### Changes

- **`frontend/src/locale/src/lang-list.json`**: Rename key from `locale-ie-GA` to `locale-ga-IE`
- **`frontend/src/locale/IntlProvider.tsx`**: Add `ga: "ie"` to `specialCases` in `getFlagCodeForLocale()`
- **`frontend/check-locales.cjs`**: Add `["ga", "ga-IE"]` to validation list (was missing)