### PR TITLE
fix: improve text selection visibility in dark code editor on light theme

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -110,6 +110,11 @@ label.row {
 	position: static;
 }
 
+/* Fix text selection visibility in dark code editor on light theme */
+[data-bs-theme="light"] .w-tc-editor-text::selection {
+	background-color: #264f78;
+}
+
 /* Fix for Tabler scrollbar compensation */
 @media (min-width: 992px) {
   :host, :root {


### PR DESCRIPTION
## Summary
- When using the **light theme**, text selected (highlighted with mouse) in the Custom Nginx Configuration editor is nearly invisible because the browser's light-mode `::selection` color blends with the dark editor background
- Added an explicit `::selection` style (`#264f78`) for the `.w-tc-editor-text` textarea when `data-bs-theme="light"` is active
- The fix applies to all five components using the dark code editor: `NginxConfigField`, `LocationsFields`, `DNSProviderFields`, `EventDetailsModal`, and `DefaultSite`

## Root cause
The code editor (`@uiw/react-textarea-code-editor`) uses `data-color-mode="dark"` to force a dark background, but the app's `color-scheme: light` CSS property (set in `App.css` for the light theme) causes the browser to use light-mode default selection colors. This results in light-colored selection highlights on a dark background with light text — making selections invisible.

## Test plan
- [ ] Switch to **light theme** in NPM settings
- [ ] Open any Proxy Host → Edit → Custom Nginx Configuration
- [ ] Select text with mouse — selection should now be clearly visible (blue highlight)
- [ ] Verify the same fix works in Custom Locations advanced config, DNS Provider credentials, Event Details modal, and Default Site custom HTML editor
- [ ] Switch to **dark theme** and verify text selection still works correctly (unaffected by this change)
