### PR TITLE
Add Hostinger DNS plugin configuration

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -327,6 +327,14 @@
 		"credentials": "dns_hetzner_cloud_api_token = your_api_token_here",
 		"full_plugin_name": "dns-hetzner-cloud"
     },
+	"hostinger": {
+    "name": "Hostinger",
+    "package_name": "certbot-dns-hostinger",
+    "version": "~=0.0.1",
+    "dependencies": "",
+    "credentials": "dns_hostinger_account_api_key = YOUR_HOSTINGER_API_KEY",
+    "full_plugin_name": "dns-hostinger"
+	},
 	"hostingnl": {
 		"name": "Hosting.nl",
 		"package_name": "certbot-dns-hostingnl",


### PR DESCRIPTION
### Added certbot-dns-hostinger 
Reference: https://pypi.org/project/certbot-dns-hostinger/


`
	"hostinger": {
		"name": "Hostinger",
		"package_name": "certbot-dns-hostinger",
		"version": "~=0.1.3",
		"dependencies": "",
		"credentials": "dns_hostinger_api_token = YOUR_HOSTINGER_API_TOKEN",
		"full_plugin_name": "dns-hostinger"
	},
`