### PR TITLE
docs: add NPM Auth Gateway to third-party integrations

### DIFF
--- a/docs/src/third-party/index.md
+++ b/docs/src/third-party/index.md
@@ -14,6 +14,7 @@ Known integrations:
 - [Proxmox Scripts](https://github.com/ej52/proxmox-scripts/tree/main/apps/nginx-proxy-manager)
 - [Proxmox VE Helper-Scripts](https://community-scripts.github.io/ProxmoxVE/scripts?id=nginxproxymanager)
 - [nginxproxymanagerGraf](https://github.com/ma-karai/nginxproxymanagerGraf)
+- [NPM Auth Gateway](https://github.com/Mark0025/npm-auth-gateway) — User-level access control with auto IP whitelisting via auth providers. [Details](/third-party/npm-auth-gateway)
 
 
 If you would like your integration of NPM listed, please open a

--- a/docs/src/third-party/npm-auth-gateway.md
+++ b/docs/src/third-party/npm-auth-gateway.md
@@ -1,0 +1,83 @@
+---
+outline: deep
+---
+
+# NPM Auth Gateway
+
+User-level access control for Nginx Proxy Manager with auto IP whitelisting.
+
+**Repository:** [github.com/Mark0025/npm-auth-gateway](https://github.com/Mark0025/npm-auth-gateway)
+
+## What It Does
+
+NPM Auth Gateway is a companion app that adds user management on top of NPM's access list system. Instead of manually adding IPs to access lists, users log in through an auth provider and their IP is automatically whitelisted on the access lists they've been assigned to.
+
+NPM remains fully in control — the gateway only reads and writes through NPM's REST API. All access enforcement stays in NPM's nginx config.
+
+## The Problem It Solves
+
+- **Manual IP management** — every time a user needs access, an admin manually adds their IP to an access list
+- **IP changes** — mobile users, VPNs, and travel mean IPs change constantly
+- **No user visibility** — access lists contain IPs, but there's no record of who each IP belongs to
+- **Scaling** — managing 10+ users across multiple access lists gets tedious
+
+## How It Works
+
+```
+Browser → NPM (SSL) → Auth Gateway → Auth Provider
+                                          ↓
+                                    NPM REST API (:81)
+                                    auto-add IP to access lists
+```
+
+1. Admin creates a user by email
+2. Admin assigns access — a table of proxy hosts with checkboxes showing which hosts each access list protects
+3. User logs in → IP detected → automatically added to their assigned NPM access lists
+4. User's IP changes → they log in again → new IP auto-added
+5. Admin revokes access → user's IPs removed from all access lists
+
+## Key Features
+
+- **Auto IP whitelisting** on login
+- **Per-host access control** with checkboxes (not abstract groups)
+- **Admin/user roles** — admin sees everything, users see only their assigned hosts
+- **Personalized dashboard** — users see their services as clickable cards
+- **Login logging** with IP history per user
+- **One-click revoke** — removes user's IPs from all access lists
+- **Searchable tables** for proxy hosts and users
+- **Survives gateway failure** — NPM keeps enforcing existing whitelists
+
+## Architecture
+
+| Responsibility | Who Handles It |
+|---|---|
+| SSL termination | **NPM** |
+| Proxy host configuration | **NPM** |
+| Access list enforcement | **NPM** |
+| IP whitelisting | **NPM** |
+| User identity | **Auth Provider** |
+| User → access list mapping | **Gateway** |
+| Auto IP whitelisting | **Gateway** |
+
+**No database required.** NPM stores all proxy/ACL config. User metadata lives in the auth provider. Zero state duplication.
+
+## NPM API Endpoints Used
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/tokens` | Authentication |
+| `GET /api/nginx/proxy-hosts` | List proxy hosts |
+| `GET /api/nginx/access-lists` | List access lists |
+| `PUT /api/nginx/access-lists/:id` | Update access list IPs |
+| `POST /api/nginx/access-lists` | Create access list |
+| `GET /api/nginx/certificates` | List SSL certificates |
+
+## Setup
+
+See the [repository README](https://github.com/Mark0025/npm-auth-gateway) for Docker deployment instructions.
+
+## Tech Stack
+
+Next.js / React / TypeScript / Docker
+
+The auth provider is swappable — the proof of concept uses Clerk, but any OIDC provider works (Auth0, Keycloak, Authentik, etc.).


### PR DESCRIPTION
## What This PR Does

Adds [NPM Auth Gateway](https://github.com/Mark0025/npm-auth-gateway) to the third-party integrations page, with a dedicated documentation page explaining what it does and how it works.

## Why

First — I want to say that Nginx Proxy Manager has been incredible for me. I'm self-hosting 91 Docker containers on a Hetzner homelab, and NPM is the backbone that makes all of it accessible. SSL, reverse proxy, access lists — it just works. I genuinely wouldn't have this setup without your project.

The one thing I kept hitting was **user management for access lists**. I build tools and want to share them with specific people — a contractor, a business partner, a friend. The workflow was always:

1. "Hey, what's your IP?"
2. They send it
3. I manually add it to the right access list in NPM
4. Their IP changes (coffee shop, VPN, phone) → repeat

So I built a companion app that solves this. It sits alongside NPM on the same Docker network and uses NPM's REST API to auto-manage IPs. Users log in through an auth provider, the app detects their IP, and adds it to the NPM access lists they've been assigned to.

**NPM stays the boss.** The app never stores proxy config or access list data — it reads and writes through NPM's API exclusively. If the companion app goes down, NPM keeps enforcing every existing IP whitelist. Zero state duplication.

## What's In This PR

- Added one line to `docs/src/third-party/index.md` (the integration list)
- Added `docs/src/third-party/npm-auth-gateway.md` (dedicated page with architecture, features, API endpoints used)

## Who Would Use This

Anyone running NPM who wants to share self-hosted services with other people without manually managing IPs:

- **Homelab users** sharing tools with family/friends
- **Small teams** giving contractors access to internal services
- **Developers** letting clients access staging environments
- **Anyone** tired of "what's your IP?" conversations

The app handles the tedious part (IP detection, ACL updates, login logging) while NPM handles the security part (actually enforcing the whitelists at the nginx level).

## Links

- **Public repo**: https://github.com/Mark0025/npm-auth-gateway
- **License**: MIT
- **Tech**: Next.js / React / TypeScript / Docker
- **In production**: 91 proxy hosts, running on Hetzner

Thank you for building NPM — it's one of those tools that makes self-hosting actually enjoyable.

— Mark Carpenter | [aireinvestor.com](https://aireinvestor.com)