### PR TITLE
Fix EuroDNS API endpoint URL

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -226,7 +226,7 @@
 	"eurodns": {
 		"name": "EuroDNS",
 		"package_name": "certbot-dns-eurodns",
-		"version": "~=0.0.4",
+		"version": "~=1.8.2",
 		"dependencies": "",
 		"credentials": "dns_eurodns_applicationId = myuser\ndns_eurodns_apiKey = mysecretpassword\ndns_eurodns_endpoint = https://rest-api.eurodns.com/",
 		"full_plugin_name": "dns-eurodns"

--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -228,7 +228,7 @@
 		"package_name": "certbot-dns-eurodns",
 		"version": "~=0.0.4",
 		"dependencies": "",
-		"credentials": "dns_eurodns_applicationId = myuser\ndns_eurodns_apiKey = mysecretpassword\ndns_eurodns_endpoint = https://rest-api.eurodns.com/user-api-gateway/proxy",
+		"credentials": "dns_eurodns_applicationId = myuser\ndns_eurodns_apiKey = mysecretpassword\ndns_eurodns_endpoint = https://rest-api.eurodns.com/",
 		"full_plugin_name": "dns-eurodns"
 	},
 	"firstdomains": {


### PR DESCRIPTION
Update the dns_eurodns_endpoint variable to the correct production address to ensure successful API requests.