### PR TITLE
Fix typo in debug mode comment

### DIFF
--- a/backend/lib/config.js
+++ b/backend/lib/config.js
@@ -211,7 +211,7 @@ const isPostgres = () => {
 };
 
 /**
- * Are we running in debug mdoe?
+ * Are we running in debug mode?
  *
  * @returns {boolean}
  */


### PR DESCRIPTION
Correct the spelling of "mode" in the debug mode comment for clarity.