### PR TITLE
Docs: Fix PostgreSQL volume mapping to prevent data loss

### DIFF
--- a/docs/src/setup/index.md
+++ b/docs/src/setup/index.md
@@ -150,7 +150,7 @@ services:
       POSTGRES_PASSWORD: 'npmpass'
       POSTGRES_DB: 'npm'
     volumes:
-      - ./postgresql:/var/lib/postgresql
+      - ./postgres_data:/var/lib/postgresql/data
 ```
 
 ::: warning


### PR DESCRIPTION
After testing, I found a critical error in the configuration documentation regarding the PostgreSQL database volume mapping. The current configuration prevents data from persisting correctly during container restarts or migrations, leading to data loss. Below are the details of the fix.

## The Issue

The current `docker-compose.yml` **example** for PostgreSQL uses `./postgresql:/var/lib/postgresql` as a volume mapping. 

According to the [official PostgreSQL Docker image documentation](https://hub.docker.com/_/postgres), the data directory is located at `/var/lib/postgresql/data`. Mapping the parent directory instead of the specific `data` subdirectory is a "hidden trap" that leads to:
1. **Data Persistence Failures:** The database may fail to re-attach to existing data after a container recreation.
2. **Permission Conflicts:** Mapping the parent directory often causes permission issues on the host side, leading to initialization loops (as I experienced multiple times).

## The Fix
Updated the **documentation example** to explicitly point to the `/data` subdirectory:
`./postgres_data:/var/lib/postgresql/data`.

This ensures that the internal database files are correctly persisted for users following this guide.