### PR TITLE
Add bulk delete functionality for unused and expired certificates

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -463,6 +463,46 @@ const internalCertificate = {
 	},
 
 	/**
+	 * Delete all certificates that are both unused and expired.
+	 *
+	 * @param   {Access}  access
+	 * @returns {Promise}
+	 */
+	deleteUnusedExpired: async (access) => {
+		const certificates = await internalCertificate.getAll(access, [
+			"proxy_hosts",
+			"redirection_hosts",
+			"dead_hosts",
+			"streams",
+		]);
+		const now = moment();
+
+		const candidates = certificates.filter((certificate) => {
+			const isExpired =
+				certificate.expires_on &&
+				moment(certificate.expires_on, "YYYY-MM-DD HH:mm:ss", true).isValid() &&
+				moment(certificate.expires_on, "YYYY-MM-DD HH:mm:ss", true).isSameOrBefore(now);
+			const isInUse =
+				(certificate.proxy_hosts && certificate.proxy_hosts.length > 0) ||
+				(certificate.redirection_hosts && certificate.redirection_hosts.length > 0) ||
+				(certificate.dead_hosts && certificate.dead_hosts.length > 0) ||
+				(certificate.streams && certificate.streams.length > 0);
+
+			return isExpired && !isInUse;
+		});
+
+		for (const certificate of candidates) {
+			await internalCertificate.delete(access, { id: certificate.id });
+		}
+
+		return {
+			candidates_count: candidates.length,
+			deleted_count: candidates.length,
+			deleted_ids: candidates.map((certificate) => certificate.id),
+		};
+	},
+
+	/**
 	 * Report use
 	 *
 	 * @param   {Number}  userId

--- a/backend/routes/nginx/certificates.js
+++ b/backend/routes/nginx/certificates.js
@@ -191,6 +191,33 @@ router
 	});
 
 /**
+ * Bulk delete unused and expired certificates
+ *
+ * /api/nginx/certificates/unused-expired
+ */
+router
+	.route("/unused-expired")
+	.options((_, res) => {
+		res.sendStatus(204);
+	})
+	.all(jwtdecode())
+
+	/**
+	 * DELETE /api/nginx/certificates/unused-expired
+	 *
+	 * Delete all unused and expired certificates
+	 */
+	.delete(async (req, res, next) => {
+		try {
+			const result = await internalCertificate.deleteUnusedExpired(res.locals.access);
+			res.status(200).send(result);
+		} catch (err) {
+			debug(logger, `${req.method.toUpperCase()} ${req.path}: ${err}`);
+			next(err);
+		}
+	});
+
+/**
  * Specific certificate
  *
  * /api/nginx/certificates/123

--- a/backend/schema/paths/nginx/certificates/unused-expired/delete.json
+++ b/backend/schema/paths/nginx/certificates/unused-expired/delete.json
@@ -1,0 +1,45 @@
+{
+	"operationId": "deleteUnusedExpiredCertificates",
+	"summary": "Delete all unused and expired Certificates",
+	"tags": ["certificates"],
+	"security": [
+		{
+			"bearerAuth": ["certificates.manage"]
+		}
+	],
+	"responses": {
+		"200": {
+			"description": "200 response",
+			"content": {
+				"application/json": {
+					"examples": {
+						"default": {
+							"value": {
+								"candidates_count": 2,
+								"deleted_count": 2,
+								"deleted_ids": [1, 7]
+							}
+						}
+					},
+					"schema": {
+						"type": "object",
+						"properties": {
+							"candidates_count": {
+								"type": "integer"
+							},
+							"deleted_count": {
+								"type": "integer"
+							},
+							"deleted_ids": {
+								"type": "array",
+								"items": {
+									"type": "integer"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/backend/schema/swagger.json
+++ b/backend/schema/swagger.json
@@ -131,6 +131,11 @@
 				"$ref": "./paths/nginx/certificates/certID/delete.json"
 			}
 		},
+		"/nginx/certificates/unused-expired": {
+			"delete": {
+				"$ref": "./paths/nginx/certificates/unused-expired/delete.json"
+			}
+		},
 		"/nginx/certificates/{certID}/download": {
 			"get": {
 				"$ref": "./paths/nginx/certificates/certID/download/get.json"

--- a/frontend/src/api/backend/deleteUnusedExpiredCertificates.ts
+++ b/frontend/src/api/backend/deleteUnusedExpiredCertificates.ts
@@ -1,0 +1,8 @@
+import * as api from "./base";
+import type { DeleteUnusedExpiredCertificatesResponse } from "./responseTypes";
+
+export async function deleteUnusedExpiredCertificates(): Promise<DeleteUnusedExpiredCertificatesResponse> {
+	return await api.del({
+		url: "/nginx/certificates/unused-expired",
+	});
+}

--- a/frontend/src/api/backend/index.ts
+++ b/frontend/src/api/backend/index.ts
@@ -8,6 +8,7 @@ export * from "./createStream";
 export * from "./createUser";
 export * from "./deleteAccessList";
 export * from "./deleteCertificate";
+export * from "./deleteUnusedExpiredCertificates";
 export * from "./deleteDeadHost";
 export * from "./deleteProxyHost";
 export * from "./deleteRedirectionHost";

--- a/frontend/src/api/backend/models.ts
+++ b/frontend/src/api/backend/models.ts
@@ -95,6 +95,7 @@ export interface Certificate {
 	proxyHosts?: ProxyHost[];
 	deadHosts?: DeadHost[];
 	redirectionHosts?: RedirectionHost[];
+	streams?: Stream[];
 }
 
 export interface ProxyLocation {

--- a/frontend/src/api/backend/responseTypes.ts
+++ b/frontend/src/api/backend/responseTypes.ts
@@ -44,3 +44,9 @@ export interface TwoFactorSetupResponse {
 export interface TwoFactorEnableResponse {
 	backupCodes: string[];
 }
+
+export interface DeleteUnusedExpiredCertificatesResponse {
+	candidatesCount: number;
+	deletedCount: number;
+	deletedIds: number[];
+}

--- a/frontend/src/locale/src/bg.json
+++ b/frontend/src/locale/src/bg.json
@@ -116,6 +116,24 @@
 	"certificates": {
 		"defaultMessage": "Сертификати"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Изтрий неизползвани, изтекли ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Ще бъдат изтрити следните неизползвани и изтекли сертификати:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Не са намерени неизползвани и изтекли сертификати."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Изтрити {count} неизползвани и изтекли {count, plural, one {сертификат} other {сертификати}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Изтриване на неизползвани и изтекли сертификати"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Внимание: това не може да бъде отменено."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Потребителски сертификат"
 	},

--- a/frontend/src/locale/src/cs.json
+++ b/frontend/src/locale/src/cs.json
@@ -173,6 +173,24 @@
 	"certificates": {
 		"defaultMessage": "Certifikáty"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Smazat nepoužívané a vypršené ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Následující nepoužívané a vypršené certifikáty budou smazány:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Nebyl nalezen žádný nepoužívaný a vypršený certifikát."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Smazáno {count} nepoužívaných a vypršených {count, plural, one {certifikát} other {certifikátů}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Smazat nepoužívané a vypršené certifikáty"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Varování: toto nelze vrátit zpět."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Vlastní certifikát"
 	},

--- a/frontend/src/locale/src/de.json
+++ b/frontend/src/locale/src/de.json
@@ -104,6 +104,24 @@
 	"certificates": {
 		"defaultMessage": "Zertifikate"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Ungenutzte, abgelaufene löschen ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Die folgenden ungenutzten und abgelaufenen Zertifikate werden gelöscht:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Keine ungenutzten und abgelaufenen Zertifikate gefunden."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Gelöscht {count} ungenutzte und abgelaufene {count, plural, one {Zertifikat} other {Zertifikate}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Ungenutzte und abgelaufene Zertifikate löschen"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Warnung: dies kann nicht rückgängig gemacht werden."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Benutzerdefiniertes Zertifikat"
 	},

--- a/frontend/src/locale/src/en.json
+++ b/frontend/src/locale/src/en.json
@@ -173,6 +173,24 @@
 	"certificates": {
 		"defaultMessage": "Certificates"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Delete unused expired ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "The following unused and expired certificates will be deleted:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "No unused and expired certificates were found."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Deleted {count} unused and expired {count, plural, one {certificate} other {certificates}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Delete Unused and Expired Certificates"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Warning: this cannot be undone."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Custom Certificate"
 	},

--- a/frontend/src/locale/src/es.json
+++ b/frontend/src/locale/src/es.json
@@ -116,6 +116,24 @@
 	"certificates": {
 		"defaultMessage": "Certificados"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Eliminar expirados no usados ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Se eliminarán los siguientes certificados no usados y expirados:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "No se encontraron certificados no usados y expirados."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Eliminados {count} certificados no usados y expirados."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Eliminar certificados no usados y expirados"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Advertencia: esto no se puede deshacer."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Certificado Personalizado"
 	},

--- a/frontend/src/locale/src/et.json
+++ b/frontend/src/locale/src/et.json
@@ -173,6 +173,24 @@
 	"certificates": {
 		"defaultMessage": "Certificates"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Kustuta kasutamata ja aegunud ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Järgnevad kasutamata ja aegunud sertifikaadid kustutatakse:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Kasutamata ja aegunud sertifikaate ei leitud."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Kustutatud {count} kasutamata ja aegunud {count, plural, one {sertifikaat} other {sertifikaati}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Kustuta kasutamata ja aegunud sertifikaadid"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Hoiatus: seda ei saa tagasi võtta."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Custom Certificate"
 	},

--- a/frontend/src/locale/src/fr.json
+++ b/frontend/src/locale/src/fr.json
@@ -104,6 +104,24 @@
 	"certificates": {
 		"defaultMessage": "Certificats"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Supprimer les certificats expirés non utilisés ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Les certificats expirés et non utilisés suivants seront supprimés :"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Aucun certificat expiré et non utilisé trouvé."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Supprimé {count} certificat expiré et non utilisé {count, plural, one { } other {s}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Supprimer les certificats non utilisés et expirés"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Attention : cette action est irréversible."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Certificat personnalisé"
 	},

--- a/frontend/src/locale/src/ga.json
+++ b/frontend/src/locale/src/ga.json
@@ -116,6 +116,24 @@
 	"certificates": {
 		"defaultMessage": "Teastais"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Scrios neamhúsáidte agus imithe in éag ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Scriosfar na deimhnithe neamhúsáidte agus imithe in éag seo a leanas:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Níor aimsíodh deimhnithe neamhúsáidte agus imithe in éag."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Scriosta {count} deimhnithe neamhúsáidte agus imithe in éag."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Scrios Deimhnithe Neamhúsáidte agus Imithe in Éag"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Rabhadh: ní féidir an gníomh seo a chur ar ais."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Teastas Saincheaptha"
 	},

--- a/frontend/src/locale/src/hu.json
+++ b/frontend/src/locale/src/hu.json
@@ -173,6 +173,24 @@
 	"certificates": {
 		"defaultMessage": "Tanúsítványok"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Nem használt, lejárt törlése ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "A következő nem használt és lejárt tanúsítványok törlésre kerülnek:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Nem találhatók nem használt és lejárt tanúsítványok."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Törölve lett {count} nem használt és lejárt {count, plural, one {tanúsítvány} other {tanúsítványok}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Nem használt és lejárt tanúsítványok törlése"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Figyelem: ez nem vonható vissza."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Egyéni tanúsítvány"
 	},

--- a/frontend/src/locale/src/id.json
+++ b/frontend/src/locale/src/id.json
@@ -116,6 +116,24 @@
 	"certificates": {
 		"defaultMessage": "Sertifikat"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Hapus kadaluarsa yang tidak digunakan ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Sertifikat tidak digunakan dan kedaluwarsa berikut akan dihapus:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Tidak ditemukan sertifikat yang tidak digunakan dan kedaluwarsa."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Menghapus {count} sertifikat yang tidak digunakan dan kedaluwarsa."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Hapus Sertifikat yang Tidak Digunakan dan Kadaluarsa"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Peringatan: tindakan ini tidak dapat dibatalkan."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Sertifikat Kustom"
 	},

--- a/frontend/src/locale/src/it.json
+++ b/frontend/src/locale/src/it.json
@@ -104,6 +104,24 @@
 	"certificates": {
 		"defaultMessage": "Certificati"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Elimina scaduti non utilizzati ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "I seguenti certificati non utilizzati e scaduti verranno eliminati:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Nessun certificato non utilizzato e scaduto trovato."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Eliminati {count} certificati non utilizzati e scaduti."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Elimina certificati non utilizzati e scaduti"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Attenzione: questa operazione non può essere annullata."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Certificato Personalizzato"
 	},

--- a/frontend/src/locale/src/ja.json
+++ b/frontend/src/locale/src/ja.json
@@ -104,6 +104,24 @@
 	"certificates": {
 		"defaultMessage": "証明書"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "未使用かつ期限切れを削除 ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "次の未使用かつ期限切れの証明書が削除されます："
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "未使用かつ期限切れの証明書は見つかりませんでした。"
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "{count} 件の未使用かつ期限切れの証明書を削除しました。"
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "未使用かつ期限切れの証明書を削除"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "警告: この操作は取り消せません。"
+	},
 	"certificates.custom": {
 		"defaultMessage": "カスタム証明書"
 	},

--- a/frontend/src/locale/src/ko.json
+++ b/frontend/src/locale/src/ko.json
@@ -116,6 +116,24 @@
 	"certificates": {
 		"defaultMessage": "인증서"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "사용되지 않은 만료 항목 삭제 ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "다음의 사용되지 않았고 만료된 인증서가 삭제됩니다:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "사용되지 않았고 만료된 인증서를 찾지 못했습니다."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "{count}개의 사용되지 않고 만료된 인증서를 삭제했습니다."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "사용되지 않고 만료된 인증서 삭제"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "경고: 이 작업은 취소할 수 없습니다."
+	},
 	"certificates.custom": {
 		"defaultMessage": "사용자 지정 인증서"
 	},

--- a/frontend/src/locale/src/nl.json
+++ b/frontend/src/locale/src/nl.json
@@ -104,6 +104,24 @@
 	"certificates": {
 		"defaultMessage": "Certificaten"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Verwijder ongebruikte verlopen ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "De volgende ongebruikte en verlopen certificaten worden verwijderd:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Geen ongebruikte en verlopen certificaten gevonden."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Verwijderd {count} ongebruikte en verlopen {count, plural, one {certificaat} other {certificaten}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Verwijder ongebruikte en verlopen certificaten"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Waarschuwing: dit kan niet ongedaan worden gemaakt."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Aangepast Certificaat"
 	},

--- a/frontend/src/locale/src/no.json
+++ b/frontend/src/locale/src/no.json
@@ -173,6 +173,24 @@
 	"certificates": {
 		"defaultMessage": "Sertifikater"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Slett ubrukte og utgåtte ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Følgende ubrukte og utgåtte sertifikater vil bli slettet:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Ingen ubrukte og utgåtte sertifikater funnet."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Slettet {count} ubrukte og utgåtte {count, plural, one {sertifikat} other {sertifikater}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Slett ubrukte og utgåtte sertifikater"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Advarsel: dette kan ikke angres."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Egendefinert Sertifikat"
 	},

--- a/frontend/src/locale/src/pl.json
+++ b/frontend/src/locale/src/pl.json
@@ -110,6 +110,24 @@
 	"certificates": {
 		"defaultMessage": "Certyfikaty"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Usuń nieużywane i wygasłe ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Następujące nieużywane i wygasłe certyfikaty zostaną usunięte:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Nie znaleziono nieużywanych i wygasłych certyfikatów."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Usunięto {count} nieużywane i wygasłe {count, plural, one {certyfikat} other {certyfikaty}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Usuń nieużywane i wygasłe certyfikaty"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Ostrzeżenie: tej operacji nie można cofnąć."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Własny certyfikat"
 	},

--- a/frontend/src/locale/src/pt.json
+++ b/frontend/src/locale/src/pt.json
@@ -116,6 +116,24 @@
 	"certificates": {
 		"defaultMessage": "Certificados"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Excluir expirados não usados ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Os seguintes certificados não usados e expirados serão excluídos:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Nenhum certificado não usado e expirado encontrado."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Excluídos {count} certificados não usados e expirados."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Excluir certificados não usados e expirados"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Aviso: isto não pode ser desfeito."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Certificado Personalizado"
 	},

--- a/frontend/src/locale/src/ru.json
+++ b/frontend/src/locale/src/ru.json
@@ -104,6 +104,24 @@
 	"certificates": {
 		"defaultMessage": "Сертификаты"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Удалить неиспользуемые, просроченные ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Будут удалены следующие неиспользуемые и просроченные сертификаты:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Не найдено неиспользуемых и просроченных сертификатов."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Удалено {count} неиспользуемых и просроченных {count, plural, one {сертификат} other {сертификатов}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Удалить неиспользуемые и просроченные сертификаты"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Внимание: это нельзя отменить."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Свой сертификат"
 	},

--- a/frontend/src/locale/src/sk.json
+++ b/frontend/src/locale/src/sk.json
@@ -173,6 +173,24 @@
 	"certificates": {
 		"defaultMessage": "Certifikáty"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Vymazať nepoužívané a expirované ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Nasledujúce nepoužívané a expirované certifikáty budú odstránené:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Neboli nájdené žiadne nepoužívané a expirované certifikáty."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Odstránené {count} nepoužívané a expirované {count, plural, one {certifikát} other {certifikáty}}."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Vymazať nepoužívané a expirované certifikáty"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Upozornenie: túto akciu nie je možné vrátiť späť."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Vlastný certifikát"
 	},

--- a/frontend/src/locale/src/tr.json
+++ b/frontend/src/locale/src/tr.json
@@ -116,6 +116,24 @@
 	"certificates": {
 		"defaultMessage": "Sertifikalar"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Kullanılmayan ve süresi dolmuşları sil ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Aşağıdaki kullanılmayan ve süresi dolmuş sertifikalar silinecek:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Kullanılmayan ve süresi dolmuş sertifika bulunamadı."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "{count} adet kullanılmayan ve süresi dolmuş sertifika silindi."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Kullanılmayan ve süresi dolmuş sertifikaları sil"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Uyarı: bu işlem geri alınamaz."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Özel Sertifika"
 	},

--- a/frontend/src/locale/src/vi.json
+++ b/frontend/src/locale/src/vi.json
@@ -104,6 +104,24 @@
 	"certificates": {
 		"defaultMessage": "Danh sách chứng chỉ"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "Xóa chứng chỉ hết hạn không sử dụng ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "Các chứng chỉ không sử dụng và đã hết hạn sau sẽ bị xóa:"
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "Không tìm thấy chứng chỉ không sử dụng và đã hết hạn."
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "Đã xóa {count} chứng chỉ không sử dụng và đã hết hạn."
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "Xóa chứng chỉ không sử dụng và đã hết hạn"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "Cảnh báo: thao tác này không thể hoàn tác."
+	},
 	"certificates.custom": {
 		"defaultMessage": "Chứng chỉ tùy chỉnh"
 	},

--- a/frontend/src/locale/src/zh.json
+++ b/frontend/src/locale/src/zh.json
@@ -104,6 +104,24 @@
 	"certificates": {
 		"defaultMessage": "证书列表"
 	},
+	"certificates.bulk-delete.button": {
+		"defaultMessage": "删除未使用且已过期 ({count})"
+	},
+	"certificates.bulk-delete.list-title": {
+		"defaultMessage": "将删除以下未使用且已过期的证书："
+	},
+	"certificates.bulk-delete.none": {
+		"defaultMessage": "未找到未使用且已过期的证书。"
+	},
+	"certificates.bulk-delete.success": {
+		"defaultMessage": "已删除 {count} 个未使用且已过期的证书。"
+	},
+	"certificates.bulk-delete.title": {
+		"defaultMessage": "删除未使用且已过期的证书"
+	},
+	"certificates.bulk-delete.warning": {
+		"defaultMessage": "警告：此操作无法撤销。"
+	},
 	"certificates.custom": {
 		"defaultMessage": "自定义证书"
 	},

--- a/frontend/src/pages/Certificates/TableWrapper.tsx
+++ b/frontend/src/pages/Certificates/TableWrapper.tsx
@@ -1,10 +1,11 @@
-import { IconHelp, IconSearch } from "@tabler/icons-react";
+import { IconAlertTriangle, IconHelp, IconSearch } from "@tabler/icons-react";
 import { useState } from "react";
 import Alert from "react-bootstrap/Alert";
-import { deleteCertificate, downloadCertificate } from "src/api/backend";
+import { deleteCertificate, deleteUnusedExpiredCertificates, downloadCertificate } from "src/api/backend";
+import type { Certificate } from "src/api/backend";
 import { Button, HasPermission, LoadingPage } from "src/components";
 import { useCertificates } from "src/hooks";
-import { T } from "src/locale";
+import { intl, T } from "src/locale";
 import {
 	showCustomCertificateModal,
 	showDeleteConfirmModal,
@@ -14,7 +15,7 @@ import {
 	showRenewCertificateModal,
 } from "src/modals";
 import { CERTIFICATES, MANAGE } from "src/modules/Permissions";
-import { showError, showObjectSuccess } from "src/notifications";
+import { showError, showObjectSuccess, showSuccess } from "src/notifications";
 import Table from "./Table";
 
 export default function TableWrapper() {
@@ -48,10 +49,38 @@ export default function TableWrapper() {
 		}
 	};
 
+	const isUnusedExpired = (certificate: Certificate) => {
+		const expiresAt = Date.parse(certificate.expiresOn);
+		const isExpired = !Number.isNaN(expiresAt) && expiresAt <= Date.now();
+		const isInUse =
+			(certificate.proxyHosts?.length ?? 0) > 0 ||
+			(certificate.redirectionHosts?.length ?? 0) > 0 ||
+			(certificate.deadHosts?.length ?? 0) > 0 ||
+			(certificate.streams?.length ?? 0) > 0;
+
+		return isExpired && !isInUse;
+	};
+
+	const unusedExpiredCertificates = (data ?? []).filter(isUnusedExpired);
+
+	const handleDeleteUnusedExpired = async () => {
+		const result = await deleteUnusedExpiredCertificates();
+		if (result.deletedCount > 0) {
+			showSuccess(
+				intl.formatMessage(
+					{ id: "certificates.bulk-delete.success" },
+					{ count: result.deletedCount },
+				),
+			);
+		} else {
+			showSuccess(intl.formatMessage({ id: "certificates.bulk-delete.none" }));
+		}
+	};
+
 	let filtered = null;
 	if (search && data) {
 		filtered = data?.filter(
-			(item) =>
+			(item: Certificate) =>
 				item.domainNames.some((domain: string) => domain.toLowerCase().includes(search)) ||
 				item.niceName.toLowerCase().includes(search),
 		);
@@ -91,6 +120,45 @@ export default function TableWrapper() {
 									<IconHelp size={20} />
 								</Button>
 								<HasPermission section={CERTIFICATES} permission={MANAGE} hideError>
+									{unusedExpiredCertificates.length ? (
+										<Button
+											size="sm"
+											variant="outline"
+											className="mt-1"
+											onClick={() =>
+												showDeleteConfirmModal({
+													title: <T id="certificates.bulk-delete.title" />,
+													onConfirm: handleDeleteUnusedExpired,
+													invalidations: [["certificates"]],
+													children: (
+														<div className="text-start">
+															<div className="d-flex align-items-center text-danger fw-bold mb-2">
+																<IconAlertTriangle size={18} className="me-2" />
+																<span>
+																	<T id="certificates.bulk-delete.warning" />
+																</span>
+															</div>
+															<div className="mb-2">
+																<T id="certificates.bulk-delete.list-title" />
+															</div>
+															<ul className="mb-0 ps-3" style={{ maxHeight: "180px", overflowY: "auto" }}>
+																{unusedExpiredCertificates.map((certificate) => (
+																	<li key={certificate.id}>
+																		{certificate.niceName || certificate.domainNames.join(", ")}
+																	</li>
+																))}
+															</ul>
+														</div>
+													),
+												})
+											}
+										>
+											<T
+												id="certificates.bulk-delete.button"
+												data={{ count: unusedExpiredCertificates.length }}
+											/>
+										</Button>
+									) : null}
 									{data?.length ? (
 										<div className="dropdown">
 											<button


### PR DESCRIPTION
Hello, this pull request closes the issue / feature request #5360 

## Short summary
Adds a bulk action in the Certificate tab to delete all unused and expired certificates at once.

## Changes
**UI:** added new bulk delete button to the certificates page.

**Backend:** secure endpoint/logic to delete certificates in bulk, restricted to certificates classified as unused or expired.

**Validation:**
- Requires explicit user confirmation.  
- Displays a modal with a list of affected certificates before deletion.  
- Includes server-side validation to prevent deletion of certificates that are still in use.

## Backward compatibility & security
Only certificates flagged as unused or expired are deletable by this action.
Endpoint enforces admin authorization and double-confirmation before deletion.

## Here are some Screenshots showcasing the UI:
<img width="1312" height="333" alt="Screenshot 2026-04-01 at 00 41 15" src="https://github.com/user-attachments/assets/7c541942-79d7-497d-874d-a33aeedd4d97" />
<img width="817" height="468" alt="Screenshot 2026-04-01 at 00 41 36" src="https://github.com/user-attachments/assets/484d9bfb-1130-4a03-9800-89761d7d281f" />
<img width="1324" height="348" alt="Screenshot 2026-04-01 at 00 41 53" src="https://github.com/user-attachments/assets/83b874b4-827a-4f8f-af0c-f9522627dbca" />

## Note
I attempted to translate the UI into all available languages. Since I am only fluent in English and German, some translations may need improvement.