### PR TITLE
Security: Undefined Variable `next` Referenced in Route Error Handler

### DIFF
--- a/backend/routes/schema.js
+++ b/backend/routes/schema.js
@@ -18,7 +18,7 @@ router
 	/**
 	 * GET /schema
 	 */
-	.get(async (req, res) => {
+	.get(async (req, res, next) => {
 		try {
 			const swaggerJSON = await getCompiledSchema();
 


### PR DESCRIPTION
## Problem

The GET /schema route handler's function signature is `(req, res)` (only two parameters), but the catch block calls `next(err)`. Since `next` is not defined in this scope, this will throw a `ReferenceError` at runtime when an error occurs, potentially crashing the process or causing an unhandled rejection instead of properly returning an error response.

**Severity**: `high`
**File**: `backend/routes/schema.js`

## Solution

Add `next` as the third parameter to the route handler: `.get(async (req, res, next) => {`, or handle the error directly with `res.status(500).send(...)` in the catch block.

## Changes

- `backend/routes/schema.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
