### PR TITLE
Performance: AJV schema compiled on every validation call (api.js)

### DIFF
--- a/backend/lib/validator/api.js
+++ b/backend/lib/validator/api.js
@@ -9,6 +9,8 @@ const ajv = new Ajv({
 	coerceTypes: true,
 });
 
+const compiledSchemas = new WeakMap();
+
 /**
  * @param {Object} schema
  * @param {Object} payload
@@ -25,7 +27,11 @@ const apiValidator = async (schema, payload /*, description*/) => {
 	}
 
 
-	const validate = ajv.compile(schema);
+	let validate = compiledSchemas.get(schema);
+	if (!validate) {
+		validate = ajv.compile(schema);
+		compiledSchemas.set(schema, validate);
+	}
 
 	const valid = validate(payload);
 

--- a/backend/lib/validator/index.js
+++ b/backend/lib/validator/index.js
@@ -14,6 +14,8 @@ const ajv = new Ajv({
 	schemas: [commonDefinitions],
 });
 
+const compiledSchemas = new WeakMap();
+
 /**
  *
  * @param   {Object} schema
@@ -26,7 +28,11 @@ const validator = (schema, payload) => {
 			reject(new errs.InternalValidationError("Payload is falsy"));
 		} else {
 			try {
-				const validate = ajv.compile(schema);
+				let validate = compiledSchemas.get(schema);
+				if (!validate) {
+					validate = ajv.compile(schema);
+					compiledSchemas.set(schema, validate);
+				}
 				const valid = validate(payload);
 
 				if (valid && !validate.errors) {


### PR DESCRIPTION
## Problem

In `backend/lib/validator/api.js`, `ajv.compile(schema)` is called inside `apiValidator` on every single request. AJV schema compilation is computationally expensive and should be done once per schema, then the compiled validate function should be reused. Under load, this causes significant CPU overhead on every API request that involves validation.

**Severity**: `high`
**File**: `backend/lib/validator/api.js`

## Solution

Cache compiled validators using a Map keyed by schema (or schema $id). For example: `const cache = new Map(); function getValidator(schema) { let v = cache.get(schema); if (!v) { v = ajv.compile(schema); cache.set(schema, v); } return v; }` Then call `getValidator(schema)` instead of `ajv.compile(schema)` on each invocation.

## Changes

- `backend/lib/validator/api.js` (modified)
- `backend/lib/validator/index.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
