### PR TITLE
Add option to disable Gravatar via environment variable (Privacy improvement)

### DIFF
--- a/backend/internal/user.js
+++ b/backend/internal/user.js
@@ -8,11 +8,20 @@ import userPermissionModel from "../models/user_permission.js";
 import internalAuditLog from "./audit-log.js";
 import internalToken from "./token.js";
 
+const disableGravatar = String(process.env.DISABLE_GRAVATAR).toLowerCase() === "true";
+
+function getAvatar(email) {
+        if (disableGravatar) {
+                return "";
+        }
+        return gravatar.url(email, { default: "mm" });
+}
+
 const omissions = () => {
 	return ["is_deleted", "permissions.id", "permissions.user_id", "permissions.created_on", "permissions.modified_on"];
 };
 
-const DEFAULT_AVATAR = gravatar.url("admin@example.com", { default: "mm" });
+const DEFAULT_AVATAR = disableGravatar ? "" : gravatar.url("admin@example.com", { default: "mm" });
 
 const internalUser = {
 	/**
@@ -35,7 +44,7 @@ const internalUser = {
 		}
 
 		await access.can("users:create", data);
-		data.avatar = gravatar.url(data.email, { default: "mm" });
+		data.avatar = getAvatar(data.email);
 
 		let user = await userModel.query().insertAndFetch(data).then(utils.omitRow(omissions()));
 		if (auth) {
@@ -118,7 +127,7 @@ const internalUser = {
 					);
 				}
 
-				data.avatar = gravatar.url(data.email || user.email, { default: "mm" });
+				data.avatar = getAvatar(data.email || user.email);
 				return userModel.query().patchAndFetchById(user.id, data).then(utils.omitRow(omissions()));
 			})
 			.then(() => {
@@ -179,10 +188,12 @@ const internalUser = {
 					return _.omit(row, thisData.omit);
 				}
 
-				if (row.avatar === "") {
+				if (disableGravatar) {
+					row.avatar = "";
+				} else if (row.avatar === "") {
 					row.avatar = DEFAULT_AVATAR;
 				}
-
+				
 				return row;
 			});
 	},
@@ -318,7 +329,16 @@ const internalUser = {
 		}
 
 		const res = await query;
-		return utils.omitRows(omissions())(res);
+		const rows = utils.omitRows(omissions())(res);
+		
+		return rows.map((row) => {
+			if (disableGravatar) {
+				row.avatar = "";
+			} else if (row.avatar === "") {
+				row.avatar = DEFAULT_AVATAR;
+			}
+			return row;
+		});
 	},
 
 	/**

--- a/docs/src/faq/index.md
+++ b/docs/src/faq/index.md
@@ -30,3 +30,11 @@ as this is the standardized header meant for this kind of information. However h
 is not allowed in the [internet standard](https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2) and almost all apps
 do not support multiple values in the `Authorization` header. Hence one of the two logins will be broken. This can
 only be fixed by either removing one of the logins or by changing the app to use other non-standard headers for authorization.
+
+## How do I disable Gravatar for privacy?
+
+Gravatar can be disabled by setting the `DISABLE_GRAVATAR` environment variable to `true`.
+
+```yaml
+environment:
+  DISABLE_GRAVATAR: 'true'


### PR DESCRIPTION
Related to #1843

This adds an optional environment variable, `DISABLE_GRAVATAR`, to disable Gravatar usage.
It is useful for users who want to improve privacy and avoid external requests to Gravatar.

Add to docker-compose.yml
```
environment:
  DISABLE_GRAVATAR: 'true'
```

When set to `true`:
- Gravatar is no longer queried when disabled.
- Gravatar URLs are not generated
- the avatar field returns an empty string
- the frontend falls back to the default local avatar

When set to `false` or left unset:
- existing behavior remains unchanged / Gravatar is requested (again)

Tested with:
- new users
- existing users