### PR TITLE
Add dependency for DNSPod plugin

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -177,7 +177,7 @@
 	},
 	"dnspod": {
 		"credentials": "dns_dnspod_email = \"email@example.com\"\ndns_dnspod_api_token = \"id,key\"",
-		"dependencies": "",
+		"dependencies": "zope.interface==8.3",
 		"full_plugin_name": "dns-dnspod",
 		"name": "DNSPod",
 		"package_name": "certbot-dns-dnspod",


### PR DESCRIPTION
Because DNSPod plugin on pypi is very old, it still needs zope-interface to work. Fixes #2440