### PR TITLE
Update dns plugin for deSec to 1.3.2

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -133,7 +133,7 @@
 		"full_plugin_name": "dns-desec",
 		"name": "deSEC",
 		"package_name": "certbot-dns-desec",
-		"version": "~=1.2.1"
+		"version": "~=1.3.2"
 	},
 	"digitalocean": {
 		"credentials": "dns_digitalocean_token = 0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",


### PR DESCRIPTION
There a a couple of bug fixes (e.g. for DNS challenge with CNAME) for deSec.