### PR TITLE
Add hoster.by DNS provider

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -351,6 +351,14 @@
 		"package_name": "certbot-dns-hover",
 		"version": "~=1.2.1"
 	},
+	"hosterby": {
+  		"credentials": "dns_hosterby_access_key = YOUR_ACCESS_KEY\ndns_hosterby_secret_key = YOUR_SECRET_KEY",
+  		"dependencies": "",
+  		"full_plugin_name": "dns-hosterby",
+  		"name": "hoster.by",
+  		"package_name": "certbot-dns-hosterby",
+  		"version": "~=0.1.0"
+	},
 	"infomaniak": {
 		"credentials": "dns_infomaniak_token = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
 		"dependencies": "",


### PR DESCRIPTION
This PR adds hoster.by as a DNS challenge provider in Nginx Proxy Manager.

What is included
- Added a new provider entry to backend/certbot/dns-plugins.json
- Provider display name: hoster.by
- Certbot plugin package: certbot-dns-hosterby
- Plugin full name: dns-hosterby

Background
A third-party Certbot plugin for hoster.by DNS challenge has been published on PyPI:
- package: certbot-dns-hosterby
- current version: 0.1.0

Why this change is needed
Users with domains managed at hoster.by currently cannot select this provider from the NPM UI for Let's Encrypt DNS challenge and wildcard certificates.

Notes
- This change only registers the provider in NPM
- No backend behavior was changed outside dns-plugins.json
- The plugin has been tested against the live hoster.by DNS API for TXT create, update, delete, and Certbot dry-run