### PR TITLE
Bump certbot-dns-netcup version

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -477,7 +477,7 @@
 		"full_plugin_name": "dns-netcup",
 		"name": "netcup",
 		"package_name": "certbot-dns-netcup",
-		"version": "~=1.0.0"
+		"version": "~=2.0.0"
 	},
 	"nicru": {
 		"credentials": "dns_nicru_client_id = application-id\ndns_nicru_client_secret = application-token\ndns_nicru_username = 0001110/NIC-D\ndns_nicru_password = password\ndns_nicru_scope = .+:.+/zones/example.com(/.+)?\ndns_nicru_service = DNS_SERVICE_NAME\ndns_nicru_zone = example.com",


### PR DESCRIPTION
Using netcup DNS, certificate renewal will currently fail:

```
The 'certbot_dns_netcup' plugin errored while loading: Error while trying finding requirements.. You may need to remove or update this plugin. The Certbot log will contain the full error details and this should be reported to the plugin developer.
```

An updated version of this plugin fixes the issue. As a workaround, one can update the file placed at `/opt/certbot/dns-netcup/lib/python3.12/site-packages/certbot_dns_netcup.py` with the plugin's upstream: https://github.com/coldfix/certbot-dns-netcup/raw/refs/heads/master/certbot_dns_netcup.py