### PR TITLE
Added PUT and DELETE method to Access-Control-Allow-Methods field

### DIFF
--- a/backend/lib/express/cors.js
+++ b/backend/lib/express/cors.js
@@ -3,7 +3,7 @@ export default (req, res, next) => {
 		res.set({
 			"Access-Control-Allow-Origin": req.headers.origin,
 			"Access-Control-Allow-Credentials": true,
-			"Access-Control-Allow-Methods": "OPTIONS, GET, POST",
+			"Access-Control-Allow-Methods": "OPTIONS, GET, POST, PUT, DELETE",
 			"Access-Control-Allow-Headers":
 				"Content-Type, Cache-Control, Pragma, Expires, Authorization, X-Dataset-Total, X-Dataset-Offset, X-Dataset-Limit",
 			"Access-Control-Max-Age": 5 * 60,


### PR DESCRIPTION
I'm using the npm web api to automatically edit the advanced Nginx config of my proxy hosts from my web application.
However, I can't use the `PUT /api/nginx/proxy-hosts/123` endpoint due to CORS restrictions.

Currently, only `OPTIONS`, `GET` and `POST` are the only allowed methods for CORS. I don't know if that's intentional, but `PUT` (and `DELETE`) are missing.