### PR TITLE
fix: omit "Access rules" directives if no rules configured

### DIFF
--- a/backend/templates/_access.conf
+++ b/backend/templates/_access.conf
@@ -10,11 +10,13 @@
 
     {% endif %}
 
+    {% if access_list.clients.length > 0 %}
     # Access Rules: {{ access_list.clients | size }} total
     {% for client in access_list.clients %}
     {{client | nginxAccessRule}}
     {% endfor %}
     deny all;
+    {% endif %}
 
     # Access checks must...
     {% if access_list.satisfy_any == 1 or access_list.satisfy_any == true %}


### PR DESCRIPTION
## Why
When an access list was associated with a template which had users (items) but no rules (clients), a `deny all` directive was inserted to the config. This resulted in all requests, including those with valid credentials, being rejected due to the lack of any `allow` directive.

This PR wraps the access rule configuration inside of an if block, so the `deny all;` directive is only present when at least one rule is configured.

The Nginx documentation confirms that the `deny` directive is relevent for client address blocking, and not authentication:
>  Denies access for the specified network or address. If the special value unix: is specified (1.5.1), denies access for all UNIX-domain sockets. 
https://nginx.org/en/docs/http/ngx_http_access_module.html

Closes #5287

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage
- [x] AI was used to write this
- [ ] AI was used to review this

