### PR TITLE
Adds host info to proxy host delete confirmation modal

### DIFF
--- a/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
+++ b/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
@@ -99,14 +99,27 @@ export default function TableWrapper() {
 					isFiltered={!!search}
 					isFetching={isFetching}
 					onEdit={(id: number) => showProxyHostModal(id)}
-					onDelete={(id: number) =>
+					onDelete={(id: number) => {
+						const host = data?.find((h) => h.id === id);
 						showDeleteConfirmModal({
 							title: <T id="object.delete" tData={{ object: "proxy-host" }} />,
 							onConfirm: () => handleDelete(id),
 							invalidations: [["proxy-hosts"], ["proxy-host", id]],
-							children: <T id="object.delete.content" tData={{ object: "proxy-host" }} />,
-						})
-					}
+							children: (
+								<>
+									<T id="object.delete.content" tData={{ object: "proxy-host" }} />
+									{host?.domainNames?.length ? (
+										<div className="mt-2 fw-bold text-break">{host.domainNames.join(", ")}</div>
+									) : null}
+									{host?.forwardHost ? (
+										<div className="mt-1 text-muted small">
+											({host.forwardScheme}://{host.forwardHost}:{host.forwardPort})
+										</div>
+									) : null}
+								</>
+							),
+						});
+					}}
 					onDisableToggle={handleDisableToggle}
 					onNew={() => showProxyHostModal("new")}
 				/>


### PR DESCRIPTION
## Why

Issue #5492

Add host information to confirm which proxy host is being deleted
This prevents accidental clicks and ensures you don't select the wrong proxy host or delete the wrong one by mistake
The default issue includes this information on the proxy hosts tab, but it could be extended to all deletion confirmations to improve overall clarity

<img width="750" height="450" alt="image" src="https://github.com/user-attachments/assets/66e1c319-dbcb-4ed0-9854-af3f07c8b7b7" />


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

- [ ] AI was used to write this
- [ ] AI was used to review this
- [X] Deepl for translation (since English isn't my native language)