### PR TITLE
feat: add use_http_host option to preserve port in Host header

### DIFF
--- a/backend/migrations/20260518120000_use_http_host.js
+++ b/backend/migrations/20260518120000_use_http_host.js
@@ -1,0 +1,27 @@
+import { migrate as logger } from "../logger.js";
+
+const migrateName = "use_http_host";
+
+const up = (knex) => {
+    logger.info(`[${migrateName}] Migrating Up...`);
+    return knex.schema
+        .alterTable("proxy_host", (table) => {
+            table.tinyint("use_http_host").notNullable().defaultTo(0);
+        })
+        .then(() => {
+            logger.info(`[${migrateName}] proxy_host Table altered`);
+        });
+};
+
+const down = (knex) => {
+    logger.info(`[${migrateName}] Migrating Down...`);
+    return knex.schema
+        .alterTable("proxy_host", (table) => {
+            table.dropColumn("use_http_host");
+        })
+        .then(() => {
+            logger.info(`[${migrateName}] proxy_host Table altered`);
+        });
+};
+
+export { up, down };

--- a/backend/models/proxy_host.js
+++ b/backend/models/proxy_host.js
@@ -22,6 +22,7 @@ const boolFields = [
 	"hsts_enabled",
 	"hsts_subdomains",
 	"trust_forwarded_proto",
+	"use_http_host",
 ];
 
 class ProxyHost extends Model {

--- a/backend/schema/components/proxy-host-object.json
+++ b/backend/schema/components/proxy-host-object.json
@@ -23,7 +23,8 @@
 		"locations",
 		"hsts_enabled",
 		"hsts_subdomains",
-		"trust_forwarded_proto"
+		"trust_forwarded_proto",
+		"use_http_host"
 	],
 	"properties": {
 		"id": {
@@ -145,6 +146,11 @@
 		"trust_forwarded_proto":{
 			"type": "boolean",
 			"description": "Trust the forwarded headers",
+			"example": false
+		},
+		"use_http_host": {
+			"type": "boolean",
+			"description": "Use $http_host (preserves port) instead of $host for the Host and X-Forwarded-Host headers",
 			"example": false
 		},
 		"certificate": {

--- a/backend/schema/paths/nginx/proxy-hosts/get.json
+++ b/backend/schema/paths/nginx/proxy-hosts/get.json
@@ -59,7 +59,8 @@
 									"locations": [],
 									"hsts_enabled": false,
 									"hsts_subdomains": false,
-									"trust_forwarded_proto": false
+									"trust_forwarded_proto": false,
+									"use_http_host": false
 								}
 							]
 						}

--- a/backend/schema/paths/nginx/proxy-hosts/hostID/get.json
+++ b/backend/schema/paths/nginx/proxy-hosts/hostID/get.json
@@ -57,6 +57,7 @@
 								"hsts_enabled": false,
 								"hsts_subdomains": false,
 								"trust_forwarded_proto": false,
+								"use_http_host": false,
 								"owner": {
 									"id": 1,
 									"created_on": "2025-10-28T00:50:24.000Z",

--- a/backend/schema/paths/nginx/proxy-hosts/hostID/put.json
+++ b/backend/schema/paths/nginx/proxy-hosts/hostID/put.json
@@ -59,6 +59,9 @@
 						"trust_forwarded_proto": {
     						"$ref": "../../../../components/proxy-host-object.json#/properties/trust_forwarded_proto"
 						},
+						"use_http_host": {
+							"$ref": "../../../../components/proxy-host-object.json#/properties/use_http_host"
+						},
 						"http2_support": {
 							"$ref": "../../../../components/proxy-host-object.json#/properties/http2_support"
 						},
@@ -126,6 +129,7 @@
 								"hsts_enabled": false,
 								"hsts_subdomains": false,
 								"trust_forwarded_proto": false,
+								"use_http_host": false,
 								"owner": {
 									"id": 1,
 									"created_on": "2025-10-28T00:50:24.000Z",

--- a/backend/schema/paths/nginx/proxy-hosts/post.json
+++ b/backend/schema/paths/nginx/proxy-hosts/post.json
@@ -51,6 +51,9 @@
 						"trust_forwarded_proto": {
     						"$ref": "../../../components/proxy-host-object.json#/properties/trust_forwarded_proto"
 						},
+						"use_http_host": {
+							"$ref": "../../../components/proxy-host-object.json#/properties/use_http_host"
+						},
 						"http2_support": {
 							"$ref": "../../../components/proxy-host-object.json#/properties/http2_support"
 						},
@@ -123,6 +126,7 @@
 								"hsts_enabled": false,
 								"hsts_subdomains": false,
 								"trust_forwarded_proto": false,
+								"use_http_host": false,
 								"certificate": null,
 								"owner": {
 									"id": 1,

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,7 +1,12 @@
   location {{ path }} {
     {{ advanced_config }}
 
-    proxy_set_header Host $host;
+    {% if use_http_host == 1 or use_http_host == true %}
+    proxy_set_header Host             $http_host;
+    proxy_set_header X-Forwarded-Host $http_host;
+    {% else %}
+    proxy_set_header Host             $host;
+    {% endif %}
     proxy_set_header X-Forwarded-Scheme $scheme;
     proxy_set_header X-Forwarded-Proto  $scheme;
     proxy_set_header X-Forwarded-For    $remote_addr;

--- a/frontend/src/api/backend/models.ts
+++ b/frontend/src/api/backend/models.ts
@@ -128,6 +128,7 @@ export interface ProxyHost {
 	hstsEnabled: boolean;
 	hstsSubdomains: boolean;
 	trustForwardedProto: boolean;
+	useHttpHost: boolean;
 	// Expansions:
 	owner?: User;
 	accessList?: AccessList;

--- a/frontend/src/hooks/useProxyHost.ts
+++ b/frontend/src/hooks/useProxyHost.ts
@@ -25,6 +25,7 @@ const fetchProxyHost = (id: number | "new") => {
 			hstsEnabled: false,
 			hstsSubdomains: false,
 			trustForwardedProto: false,
+			useHttpHost: false,
 		} as ProxyHost);
 	}
 	return getProxyHost(id, ["owner"]);

--- a/frontend/src/locale/src/bg.json
+++ b/frontend/src/locale/src/bg.json
@@ -373,6 +373,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Поддръжка на WebSockets"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Използвай $http_host (запази порта)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Порт"

--- a/frontend/src/locale/src/cs.json
+++ b/frontend/src/locale/src/cs.json
@@ -430,6 +430,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Podpora WebSockets"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Použít $http_host (zachovat port)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Port přesměrování"

--- a/frontend/src/locale/src/de.json
+++ b/frontend/src/locale/src/de.json
@@ -358,6 +358,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Websockets Support"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Verwende $http_host (Port beibehalten)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Forward Port"

--- a/frontend/src/locale/src/en.json
+++ b/frontend/src/locale/src/en.json
@@ -437,6 +437,9 @@
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Websockets Support"
 	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Use $http_host (Preserve Port)"
+	},
 	"host.forward-port": {
 		"defaultMessage": "Forward Port"
 	},

--- a/frontend/src/locale/src/es.json
+++ b/frontend/src/locale/src/es.json
@@ -373,6 +373,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Soporte de Websockets"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Usar $http_host (preservar puerto)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Puerto"

--- a/frontend/src/locale/src/et.json
+++ b/frontend/src/locale/src/et.json
@@ -436,6 +436,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Websockets Support"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Kasuta $http_host (säilita port)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Forward Port"

--- a/frontend/src/locale/src/fr.json
+++ b/frontend/src/locale/src/fr.json
@@ -436,6 +436,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Prise en charge de Websockets"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Utiliser $http_host (conserver le port)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Port de redirection"

--- a/frontend/src/locale/src/ga.json
+++ b/frontend/src/locale/src/ga.json
@@ -362,6 +362,9 @@
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Tacaíocht Websockets"
 	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Úsáid $http_host (Caomhnaigh an Port)"
+	},
 	"host.forward-port": {
 		"defaultMessage": "Port Ar Aghaidh"
 	},

--- a/frontend/src/locale/src/hu.json
+++ b/frontend/src/locale/src/hu.json
@@ -430,6 +430,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Websockets támogatás"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Használja a $http_host-ot (port megőrzése)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Továbbító port"

--- a/frontend/src/locale/src/id.json
+++ b/frontend/src/locale/src/id.json
@@ -361,6 +361,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Dukungan Websocket"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Gunakan $http_host (pertahankan port)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Port Terusan"

--- a/frontend/src/locale/src/it.json
+++ b/frontend/src/locale/src/it.json
@@ -358,6 +358,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Supporto WebSockets"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Usa $http_host (preserva porta)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Porta di Destinazione"

--- a/frontend/src/locale/src/ja.json
+++ b/frontend/src/locale/src/ja.json
@@ -358,6 +358,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Websocketsサポート"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "$http_hostを使用する（ポートを保持）"
 	},
 	"host.forward-port": {
 		"defaultMessage": "転送ポート"

--- a/frontend/src/locale/src/ko.json
+++ b/frontend/src/locale/src/ko.json
@@ -373,6 +373,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "웹소켓 지원"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "$http_host 사용 (포트 유지)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "전달할 포트"

--- a/frontend/src/locale/src/nl.json
+++ b/frontend/src/locale/src/nl.json
@@ -436,6 +436,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Websockets-ondersteuning"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Gebruik $http_host (poort behouden)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Poort doorsturen"

--- a/frontend/src/locale/src/no.json
+++ b/frontend/src/locale/src/no.json
@@ -436,6 +436,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Websockets-støtte"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Bruk $http_host (bevar port)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Viderekoble Port"

--- a/frontend/src/locale/src/pl.json
+++ b/frontend/src/locale/src/pl.json
@@ -364,6 +364,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Obsługa WebSockets"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Użyj $http_host (zachowaj port)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Port docelowy"

--- a/frontend/src/locale/src/pt.json
+++ b/frontend/src/locale/src/pt.json
@@ -361,6 +361,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Suporte para WebSockets"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Usar $http_host (preservar porta)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Porta de Encaminhamento"

--- a/frontend/src/locale/src/ru.json
+++ b/frontend/src/locale/src/ru.json
@@ -436,6 +436,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Поддержка WebSocket"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Использовать $http_host (сохранить порт)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Целевой порт"

--- a/frontend/src/locale/src/sk.json
+++ b/frontend/src/locale/src/sk.json
@@ -430,6 +430,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Podpora WebSockets"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Použiť $http_host (zachovať port)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Port presmerovania"

--- a/frontend/src/locale/src/tr.json
+++ b/frontend/src/locale/src/tr.json
@@ -361,6 +361,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Websockets Desteği"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "$http_host kullan (portu koru)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "İletme Portu"

--- a/frontend/src/locale/src/vi.json
+++ b/frontend/src/locale/src/vi.json
@@ -358,6 +358,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Hỗ trợ Websockets"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "Sử dụng $http_host (giữ nguyên cổng)"
 	},
 	"host.forward-port": {
 		"defaultMessage": "Chuyển tiếp cổng"

--- a/frontend/src/locale/src/zh.json
+++ b/frontend/src/locale/src/zh.json
@@ -364,6 +364,9 @@
 	},
 	"host.flags.websockets-upgrade": {
 		"defaultMessage": "Websockets 支持"
+	},
+	"host.flags.use-http-host": {
+		"defaultMessage": "使用 $http_host（保留端口）"
 	},
 	"host.forward-port": {
 		"defaultMessage": "转发端口"

--- a/frontend/src/modals/ProxyHostModal.tsx
+++ b/frontend/src/modals/ProxyHostModal.tsx
@@ -89,6 +89,7 @@ const ProxyHostModal = EasyModal.create(({ id, visible, remove }: Props) => {
 							hstsEnabled: data?.hstsEnabled || false,
 							hstsSubdomains: data?.hstsSubdomains || false,
 							trustForwardedProto: data?.trustForwardedProto || false,
+							useHttpHost: data?.useHttpHost || false,
 							// Advanced tab
 							advancedConfig: data?.advancedConfig || "",
 							meta: data?.meta || {},
@@ -328,9 +329,32 @@ const ProxyHostModal = EasyModal.create(({ id, visible, remove }: Props) => {
 																</span>
 															</label>
 														</div>
-													</div>
+														<div>
+															<label className="row" htmlFor="useHttpHost">
+																<span className="col">
+																	<T id="host.flags.use-http-host" />
+																</span>
+																<span className="col-auto">
+																	<Field name="useHttpHost" type="checkbox">
+																		{({ field }: any) => (
+																			<label className="form-check form-check-single form-switch">
+																				<input
+																					{...field}
+																					id="useHttpHost"
+																					className={cn("form-check-input", {
+																						"bg-lime": field.checked,
+																					})}
+																					type="checkbox"
+																				/>
+																			</label>
+																		)}
+																	</Field>
+																</span>
+															</label>
+														</div>
 												</div>
 											</div>
+										</div>
 											<div className="tab-pane" id="tab-locations" role="tabpanel">
 												<LocationsFields initialValues={data?.locations || []} />
 											</div>

--- a/test/cypress/e2e/api/ProxyHosts.cy.js
+++ b/test/cypress/e2e/api/ProxyHosts.cy.js
@@ -32,7 +32,8 @@ describe('Proxy Hosts endpoints', () => {
 				http2_support:           false,
 				hsts_enabled:            false,
 				hsts_subdomains:         false,
-				ssl_forced:              false
+				ssl_forced:              false,
+				use_http_host:           false
 			}
 		}).then((data) => {
 			cy.validateSwaggerSchema('post', 201, '/nginx/proxy-hosts', data);
@@ -42,6 +43,40 @@ describe('Proxy Hosts endpoints', () => {
 			expect(data).to.have.property("enabled", true);
 			expect(data).to.have.property('meta');
 			expect(typeof data.meta.nginx_online).to.be.equal('undefined');
+			expect(data).to.have.property('use_http_host', false);
+		});
+	});
+
+	it('Should be able to create a http host with use_http_host enabled', () => {
+		cy.task('backendApiPost', {
+			token: token,
+			path:  '/api/nginx/proxy-hosts',
+			data:  {
+				domain_names:   ['test2.example.com'],
+				forward_scheme: 'http',
+				forward_host:   '1.1.1.1',
+				forward_port:   80,
+				access_list_id: '0',
+				certificate_id: 0,
+				meta:           {
+					dns_challenge: false
+				},
+				advanced_config:         '',
+				locations:               [],
+				block_exploits:          false,
+				caching_enabled:         false,
+				allow_websocket_upgrade: false,
+				http2_support:           false,
+				hsts_enabled:            false,
+				hsts_subdomains:         false,
+				ssl_forced:              false,
+				use_http_host:           true
+			}
+		}).then((data) => {
+			cy.validateSwaggerSchema('post', 201, '/nginx/proxy-hosts', data);
+			expect(data).to.have.property('id');
+			expect(data.id).to.be.greaterThan(0);
+			expect(data).to.have.property('use_http_host', true);
 		});
 	});
 


### PR DESCRIPTION
Closes #3981                                                                                                                                                                                                                                       
                                                                          
Adds a per-proxy-host boolean toggle **"Use $http_host (Preserve Port)"** in the Details tab              
of the proxy host modal. When enabled, nginx sends `proxy_set_header Host $http_host` and
`proxy_set_header X-Forwarded-Host $http_host` instead of the default `proxy_set_header Host $host`.
When disabled (default), behaviour is identical to today — zero impact on existing setups.

## Why

The nginx variable `$host` does not preserve the original client port, which breaks applications
that validate the full `Host` header including port (e.g. ESPHome behind NAT port forwarding,
see also esphome/issues#4327).

Previously, users could not work around this via the Advanced Config field because the default
headers are written after the advanced config block, making override impossible.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

- [x] AI was used to write this
- [x] AI was used to review this
