### PR TITLE
Show item details in delete confirmation modals

### DIFF
--- a/frontend/src/pages/Access/TableWrapper.tsx
+++ b/frontend/src/pages/Access/TableWrapper.tsx
@@ -88,14 +88,22 @@ export default function TableWrapper() {
 					isFetching={isFetching}
 					isFiltered={!!filtered}
 					onEdit={(id: number) => showAccessListModal(id)}
-					onDelete={(id: number) =>
+					onDelete={(id: number) => {
+						const accessList = data?.find((a) => a.id === id);
 						showDeleteConfirmModal({
 							title: <T id="object.delete" tData={{ object: "access-list" }} />,
 							onConfirm: () => handleDelete(id),
 							invalidations: [["access-lists"], ["access-list", id]],
-							children: <T id="object.delete.content" tData={{ object: "access-list" }} />,
-						})
-					}
+							children: (
+								<>
+									<T id="object.delete.content" tData={{ object: "access-list" }} />
+									{accessList?.name ? (
+										<div className="mt-2 fw-bold text-break">{accessList.name}</div>
+									) : null}
+								</>
+							),
+						});
+					}}
 					onNew={() => showAccessListModal("new")}
 				/>
 			</div>

--- a/frontend/src/pages/Certificates/TableWrapper.tsx
+++ b/frontend/src/pages/Certificates/TableWrapper.tsx
@@ -146,14 +146,27 @@ export default function TableWrapper() {
 					isFetching={isFetching}
 					onRenew={showRenewCertificateModal}
 					onDownload={handleDownload}
-					onDelete={(id: number) =>
+					onDelete={(id: number) => {
+						const cert = data?.find((c) => c.id === id);
 						showDeleteConfirmModal({
 							title: <T id="object.delete" tData={{ object: "certificate" }} />,
 							onConfirm: () => handleDelete(id),
 							invalidations: [["certificates"], ["certificate", id]],
-							children: <T id="object.delete.content" tData={{ object: "certificate" }} />,
-						})
-					}
+							children: (
+								<>
+									<T id="object.delete.content" tData={{ object: "certificate" }} />
+									{cert?.niceName ? (
+										<div className="mt-2 fw-bold text-break">{cert.niceName}</div>
+									) : null}
+									{cert?.domainNames?.length ? (
+										<div className="mt-1 text-muted small text-break">
+											{cert.domainNames.join(", ")}
+										</div>
+									) : null}
+								</>
+							),
+						});
+					}}
 				/>
 			</div>
 		</div>

--- a/frontend/src/pages/Nginx/DeadHosts/TableWrapper.tsx
+++ b/frontend/src/pages/Nginx/DeadHosts/TableWrapper.tsx
@@ -93,14 +93,22 @@ export default function TableWrapper() {
 					isFiltered={!!search}
 					isFetching={isFetching}
 					onEdit={(id: number) => showDeadHostModal(id)}
-					onDelete={(id: number) =>
+					onDelete={(id: number) => {
+						const host = data?.find((h) => h.id === id);
 						showDeleteConfirmModal({
 							title: <T id="object.delete" tData={{ object: "dead-host" }} />,
 							onConfirm: () => handleDelete(id),
 							invalidations: [["dead-hosts"], ["dead-host", id]],
-							children: <T id="object.delete.content" tData={{ object: "dead-host" }} />,
-						})
-					}
+							children: (
+								<>
+									<T id="object.delete.content" tData={{ object: "dead-host" }} />
+									{host?.domainNames?.length ? (
+										<div className="mt-2 fw-bold text-break">{host.domainNames.join(", ")}</div>
+									) : null}
+								</>
+							),
+						});
+					}}
 					onDisableToggle={handleDisableToggle}
 					onNew={() => showDeadHostModal("new")}
 				/>

--- a/frontend/src/pages/Nginx/RedirectionHosts/TableWrapper.tsx
+++ b/frontend/src/pages/Nginx/RedirectionHosts/TableWrapper.tsx
@@ -99,14 +99,27 @@ export default function TableWrapper() {
 					isFiltered={!!search}
 					isFetching={isFetching}
 					onEdit={(id: number) => showRedirectionHostModal(id)}
-					onDelete={(id: number) =>
+					onDelete={(id: number) => {
+						const host = data?.find((h) => h.id === id);
 						showDeleteConfirmModal({
 							title: <T id="object.delete" tData={{ object: "redirection-host" }} />,
 							onConfirm: () => handleDelete(id),
 							invalidations: [["redirection-hosts"], ["redirection-host", id]],
-							children: <T id="object.delete.content" tData={{ object: "redirection-host" }} />,
-						})
-					}
+							children: (
+								<>
+									<T id="object.delete.content" tData={{ object: "redirection-host" }} />
+									{host?.domainNames?.length ? (
+										<div className="mt-2 fw-bold text-break">{host.domainNames.join(", ")}</div>
+									) : null}
+									{host?.forwardDomainName ? (
+										<div className="mt-1 text-muted small">
+											({host.forwardScheme}://{host.forwardDomainName})
+										</div>
+									) : null}
+								</>
+							),
+						});
+					}}
 					onDisableToggle={handleDisableToggle}
 					onNew={() => showRedirectionHostModal("new")}
 				/>

--- a/frontend/src/pages/Nginx/Streams/TableWrapper.tsx
+++ b/frontend/src/pages/Nginx/Streams/TableWrapper.tsx
@@ -97,14 +97,24 @@ export default function TableWrapper() {
 					isFetching={isFetching}
 					isFiltered={!!filtered}
 					onEdit={(id: number) => showStreamModal(id)}
-					onDelete={(id: number) =>
+					onDelete={(id: number) => {
+						const stream = data?.find((s) => s.id === id);
 						showDeleteConfirmModal({
 							title: <T id="object.delete" tData={{ object: "stream" }} />,
 							onConfirm: () => handleDelete(id),
 							invalidations: [["streams"], ["stream", id]],
-							children: <T id="object.delete.content" tData={{ object: "stream" }} />,
-						})
-					}
+							children: (
+								<>
+									<T id="object.delete.content" tData={{ object: "stream" }} />
+									{stream ? (
+										<div className="mt-2 fw-bold text-break">
+											:{stream.incomingPort} &rarr; {stream.forwardingHost}:{stream.forwardingPort}
+										</div>
+									) : null}
+								</>
+							),
+						});
+					}}
 					onDisableToggle={handleDisableToggle}
 					onNew={() => showStreamModal("new")}
 				/>

--- a/frontend/src/pages/Users/TableWrapper.tsx
+++ b/frontend/src/pages/Users/TableWrapper.tsx
@@ -105,14 +105,25 @@ export default function TableWrapper() {
 					onEditUser={(id: number) => showUserModal(id)}
 					onEditPermissions={(id: number) => showPermissionsModal(id)}
 					onSetPassword={(id: number) => showSetPasswordModal(id)}
-					onDeleteUser={(id: number) =>
+					onDeleteUser={(id: number) => {
+						const user = data?.find((u) => u.id === id);
 						showDeleteConfirmModal({
 							title: <T id="object.delete" tData={{ object: "user" }} />,
 							onConfirm: () => handleDelete(id),
 							invalidations: [["users"], ["user", id]],
-							children: <T id="object.delete.content" tData={{ object: "user" }} />,
-						})
-					}
+							children: (
+								<>
+									<T id="object.delete.content" tData={{ object: "user" }} />
+									{user?.name ? (
+										<div className="mt-2 fw-bold text-break">{user.name}</div>
+									) : null}
+									{user?.email ? (
+										<div className="mt-1 text-muted small text-break">{user.email}</div>
+									) : null}
+								</>
+							),
+						});
+					}}
 					onDisableToggle={handleDisableToggle}
 					onNewUser={() => showUserModal("new")}
 					onLoginAs={handleLoginAs}


### PR DESCRIPTION
follow-up to #5497

## Why

In the previous PR I added the proxy host name inside the delete confirmation modal. Figured I might as well do the same everywhere on every other table, so that when you hit delete on a cert, a user or anything else, you actually see what you're about to nuke instead of a plain "are you sure?"

Screenshots of the updated popups :

<img width="692" height="418" alt="image" src="https://github.com/user-attachments/assets/67b9c042-0d2f-4c7b-8e8f-de3c89b3b1e6" />

<img width="692" height="448" alt="image" src="https://github.com/user-attachments/assets/4f690901-0abe-4b4b-95cb-d4b2b4517f1c" />

<img width="693" height="448" alt="image" src="https://github.com/user-attachments/assets/0da216da-228f-440c-bb0e-7a328e50971c" />

<img width="687" height="417" alt="image" src="https://github.com/user-attachments/assets/69471230-9445-44ef-a330-ce0b0cd58975" />

<img width="703" height="422" alt="image" src="https://github.com/user-attachments/assets/90ed6ff2-6a44-473f-b1c0-3d277c328443" />

<img width="703" height="458" alt="image" src="https://github.com/user-attachments/assets/cb9cd516-3534-4417-9264-af491843708a" />

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

- [x] AI was used to write this
- [ ] AI was used to review this