### PR TITLE
Guard against null user in Users table avatar cell

### DIFF
--- a/frontend/src/pages/Users/Table.tsx
+++ b/frontend/src/pages/Users/Table.tsx
@@ -54,7 +54,7 @@ export default function Table({
 				id: "avatar",
 				cell: (info: any) => {
 					const value = info.getValue();
-					return <GravatarFormatter url={value.avatar} name={value.name} />;
+					return <GravatarFormatter url={value ? value.avatar : ""} name={value ? value.name : ""} />;
 				},
 				meta: {
 					className: "w-1",


### PR DESCRIPTION
## Why

(original issue #4838)
0ceb7d0 added the null guard to every table that renders a user avatar except the Users one. If the row owner is null, the cell still throws "Cannot read properties of null (reading 'avatar')" and breaks the page
Same one-line pattern as the other 7 tables

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

- [ ] AI was used to write this
- [ ] AI was used to review this