### PR TITLE
Add multi-agent manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ test/node_modules
 docker/dev/dnsrouter-config.json.tmp
 docker/dev/resolv.conf
 .claude
-

--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 	<img src="https://nginxproxymanager.com/github.png">
 	<br><br>
 	<img src="https://img.shields.io/badge/version-2.15.1-green.svg?style=for-the-badge">
-	<a href="https://hub.docker.com/repository/docker/jc21/nginx-proxy-manager">
-		<img src="https://img.shields.io/docker/stars/jc21/nginx-proxy-manager.svg?style=for-the-badge">
+	<a href="https://github.com/NightWatcher314/nginx-proxy-manager">
+		<img src="https://img.shields.io/badge/fork-NightWatcher314-blue.svg?style=for-the-badge">
 	</a>
-	<a href="https://hub.docker.com/repository/docker/jc21/nginx-proxy-manager">
-		<img src="https://img.shields.io/docker/pulls/jc21/nginx-proxy-manager.svg?style=for-the-badge">
+	<a href="https://registry.nightaye.top/v2/nginx-proxy-manager/tags/list">
+		<img src="https://img.shields.io/badge/image-registry.nightaye.top%2Fnginx--proxy--manager-blue.svg?style=for-the-badge">
 	</a>
 </p>
 
-This project comes as a pre-built Docker image that enables you to easily forward to your websites
+This fork is maintained for our own deployment and is published as a pre-built Docker image at
+`registry.nightaye.top/nginx-proxy-manager:latest`. It enables you to easily forward to your websites
 running at home or otherwise, including free SSL, without having to know too much about Nginx or Letsencrypt.
 
 - [Quick Setup](#quick-setup)
@@ -61,7 +62,7 @@ I won't go into too much detail here, but here are the basics for someone new to
 ```yml
 services:
   app:
-    image: 'docker.io/jc21/nginx-proxy-manager:latest'
+    image: 'registry.nightaye.top/nginx-proxy-manager:latest'
     restart: unless-stopped
     ports:
       - '80:80'
@@ -72,7 +73,7 @@ services:
       - ./letsencrypt:/etc/letsencrypt
 ```
 
-This is the bare minimum configuration required. See the [documentation](https://nginxproxymanager.com/setup/) for more.
+This is the bare minimum configuration required for our self-maintained image. Use a pinned tag such as `registry.nightaye.top/nginx-proxy-manager:2.15.1-nightwatcher.1` if you do not want automatic `latest` updates.
 
 3. Bring up your stack by running
 

--- a/backend/internal/agent-client.js
+++ b/backend/internal/agent-client.js
@@ -1,0 +1,140 @@
+import errs from "../lib/error.js";
+import agentModel from "../models/agent.js";
+
+const tokenCache = new Map();
+
+function publicAgent(agent) {
+	return `${agent.name || agent.id} (${agent.url})`;
+}
+
+function trimBaseUrl(url) {
+	return String(url || "").replace(/\/$/, "");
+}
+
+async function parsePayload(response) {
+	const contentType = response.headers.get("content-type") || "";
+	if (contentType.includes("application/json")) {
+		return await response.json();
+	}
+	return await response.text();
+}
+
+async function request(agent, path, options = {}) {
+	const url = `${trimBaseUrl(agent.url)}${path}`;
+	const response = await fetch(url, options);
+	const payload = await parsePayload(response);
+	if (!response.ok) {
+		const message = payload?.error?.message || payload?.message || payload || `HTTP ${response.status}`;
+		const err = new errs.ValidationError(`Agent ${publicAgent(agent)} request failed: ${message}`);
+		err.status = response.status;
+		throw err;
+	}
+	return { response, payload };
+}
+
+async function getToken(agent, force = false) {
+	const cached = tokenCache.get(agent.id || agent.url);
+	if (!force && cached?.token && new Date(cached.expires).getTime() > Date.now() + 60000) {
+		return cached.token;
+	}
+
+	const { payload } = await request(agent, "/api/tokens", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			identity: agent.identity,
+			secret: agent.secret,
+		}),
+	});
+
+	if (payload?.requires_2fa) {
+		throw new errs.ValidationError(`Agent ${publicAgent(agent)} requires 2FA; use a non-2FA service account`);
+	}
+	if (!payload?.token) {
+		throw new errs.ValidationError(`Agent ${publicAgent(agent)} did not return a token`);
+	}
+	tokenCache.set(agent.id || agent.url, payload);
+	return payload.token;
+}
+
+function buildForwardPath(req) {
+	const query = new URLSearchParams();
+	for (const [key, value] of Object.entries(req.query || {})) {
+		if (["agent_id", "agent", "node"].includes(key)) {
+			continue;
+		}
+		if (Array.isArray(value)) {
+			value.forEach((item) => {
+				query.append(key, item);
+			});
+		} else if (typeof value !== "undefined" && value !== null) {
+			query.append(key, value);
+		}
+	}
+	const qs = query.toString();
+	return `/api${req.baseUrl}${req.path}${qs ? `?${qs}` : ""}`;
+}
+
+const internalAgentClient = {
+	findRequestedAgentId: (req) => req.query.agent_id || req.query.agent || req.query.node,
+
+	shouldForward: (req) => {
+		const agentId = internalAgentClient.findRequestedAgentId(req);
+		return agentId && agentId !== "local" && agentId !== "0";
+	},
+
+	getAgent: async (id) => {
+		const agent = await agentModel.query().where("id", Number.parseInt(id, 10)).andWhere("is_deleted", 0).first();
+		if (!agent?.id || !agent.enabled) {
+			throw new errs.ItemNotFoundError(`agent ${id}`);
+		}
+		return agent;
+	},
+
+	health: async (agent) => {
+		const { payload } = await request(agent, "/api", { method: "GET" });
+		await getToken(agent, true);
+		return {
+			ok: true,
+			version: payload.version,
+			setup: payload.setup,
+			checked_on: new Date().toISOString(),
+		};
+	},
+
+	forward: async (req, res) => {
+		const agent = await internalAgentClient.getAgent(internalAgentClient.findRequestedAgentId(req));
+		let token = await getToken(agent);
+		const headers = {
+			Authorization: `Bearer ${token}`,
+		};
+		let body;
+		if (!["GET", "HEAD"].includes(req.method)) {
+			headers["Content-Type"] = "application/json";
+			body = JSON.stringify(req.body || {});
+		}
+		const path = buildForwardPath(req);
+		let response = await fetch(`${trimBaseUrl(agent.url)}${path}`, {
+			method: req.method,
+			headers,
+			body,
+		});
+		if (response.status === 401) {
+			token = await getToken(agent, true);
+			response = await fetch(`${trimBaseUrl(agent.url)}${path}`, {
+				method: req.method,
+				headers: { ...headers, Authorization: `Bearer ${token}` },
+				body,
+			});
+		}
+		const payload = await parsePayload(response);
+		res.status(response.status);
+		if (typeof payload === "string") {
+			res.send(payload);
+		} else {
+			res.send(payload);
+		}
+	},
+};
+
+export default internalAgentClient;

--- a/backend/internal/agent-client.js
+++ b/backend/internal/agent-client.js
@@ -75,6 +75,68 @@ function buildForwardPath(req) {
 	return `/api${req.baseUrl}${req.path}${qs ? `?${qs}` : ""}`;
 }
 
+function appendUpload(formData, fieldName, file) {
+	if (Array.isArray(file)) {
+		file.forEach((entry) => {
+			appendUpload(formData, fieldName, entry);
+		});
+		return;
+	}
+	formData.append(fieldName, new Blob([file.data], { type: file.mimetype }), file.name);
+}
+
+function buildForwardBody(req, headers) {
+	if (["GET", "HEAD"].includes(req.method)) {
+		return undefined;
+	}
+
+	if (req.files && Object.keys(req.files).length) {
+		const formData = new FormData();
+		for (const [key, value] of Object.entries(req.body || {})) {
+			formData.append(key, typeof value === "string" ? value : JSON.stringify(value));
+		}
+		for (const [key, file] of Object.entries(req.files)) {
+			appendUpload(formData, key, file);
+		}
+		return formData;
+	}
+
+	headers["Content-Type"] = "application/json";
+	return JSON.stringify(req.body || {});
+}
+
+async function forwardFetch(agent, req, path, token) {
+	const headers = {
+		Authorization: `Bearer ${token}`,
+	};
+	const body = buildForwardBody(req, headers);
+	return await fetch(`${trimBaseUrl(agent.url)}${path}`, {
+		method: req.method,
+		headers,
+		body,
+	});
+}
+
+async function sendForwardResponse(response, res) {
+	res.status(response.status);
+	const contentType = response.headers.get("content-type") || "";
+	const contentDisposition = response.headers.get("content-disposition");
+	if (contentType) {
+		res.set("content-type", contentType);
+	}
+	if (contentDisposition) {
+		res.set("content-disposition", contentDisposition);
+	}
+
+	if (contentType.includes("application/json")) {
+		res.send(await response.json());
+		return;
+	}
+
+	const buffer = Buffer.from(await response.arrayBuffer());
+	res.send(buffer);
+}
+
 const internalAgentClient = {
 	findRequestedAgentId: (req) => req.query.agent_id || req.query.agent || req.query.node,
 
@@ -105,35 +167,13 @@ const internalAgentClient = {
 	forward: async (req, res) => {
 		const agent = await internalAgentClient.getAgent(internalAgentClient.findRequestedAgentId(req));
 		let token = await getToken(agent);
-		const headers = {
-			Authorization: `Bearer ${token}`,
-		};
-		let body;
-		if (!["GET", "HEAD"].includes(req.method)) {
-			headers["Content-Type"] = "application/json";
-			body = JSON.stringify(req.body || {});
-		}
 		const path = buildForwardPath(req);
-		let response = await fetch(`${trimBaseUrl(agent.url)}${path}`, {
-			method: req.method,
-			headers,
-			body,
-		});
+		let response = await forwardFetch(agent, req, path, token);
 		if (response.status === 401) {
 			token = await getToken(agent, true);
-			response = await fetch(`${trimBaseUrl(agent.url)}${path}`, {
-				method: req.method,
-				headers: { ...headers, Authorization: `Bearer ${token}` },
-				body,
-			});
+			response = await forwardFetch(agent, req, path, token);
 		}
-		const payload = await parsePayload(response);
-		res.status(response.status);
-		if (typeof payload === "string") {
-			res.send(payload);
-		} else {
-			res.send(payload);
-		}
+		await sendForwardResponse(response, res);
 	},
 };
 

--- a/backend/internal/agent.js
+++ b/backend/internal/agent.js
@@ -1,0 +1,107 @@
+import errs from "../lib/error.js";
+import utils from "../lib/utils.js";
+import agentModel from "../models/agent.js";
+import internalAgentClient from "./agent-client.js";
+
+const omissions = () => ["is_deleted", "secret"];
+
+function normalizeUrl(url) {
+	try {
+		const parsed = new URL(url);
+		parsed.pathname = parsed.pathname.replace(/\/$/, "");
+		parsed.search = "";
+		parsed.hash = "";
+		return parsed.toString().replace(/\/$/, "");
+	} catch {
+		throw new errs.ValidationError("Invalid agent URL");
+	}
+}
+
+const internalAgent = {
+	getAll: async (access) => {
+		await access.can("users:list");
+		return agentModel
+			.query()
+			.where("is_deleted", 0)
+			.orderBy("name", "ASC")
+			.then(utils.omitRows(omissions()));
+	},
+
+	get: async (access, data) => {
+		await access.can("users:list");
+		const row = await agentModel.query().where("id", data.id).andWhere("is_deleted", 0).first();
+		if (!row?.id) {
+			throw new errs.ItemNotFoundError(data.id);
+		}
+		return utils.omitRow(omissions())(row);
+	},
+
+	create: async (access, data) => {
+		await access.can("users:list");
+		const row = await agentModel.query().insertAndFetch({
+			name: data.name,
+			url: normalizeUrl(data.url),
+			identity: data.identity,
+			secret: data.secret,
+			enabled: typeof data.enabled === "undefined" ? true : data.enabled,
+			meta: {},
+		});
+		return utils.omitRow(omissions())(row);
+	},
+
+	update: async (access, data) => {
+		await access.can("users:list");
+		const existing = await agentModel.query().where("id", data.id).andWhere("is_deleted", 0).first();
+		if (!existing?.id) {
+			throw new errs.ItemNotFoundError(data.id);
+		}
+		const patch = {};
+		["name", "identity", "enabled"].forEach((key) => {
+			if (typeof data[key] !== "undefined") {
+				patch[key] = data[key];
+			}
+		});
+		if (typeof data.url !== "undefined") {
+			patch.url = normalizeUrl(data.url);
+		}
+		if (typeof data.secret === "string" && data.secret.length) {
+			patch.secret = data.secret;
+		}
+		await agentModel.query().where("id", data.id).patch(patch);
+		return internalAgent.get(access, { id: data.id });
+	},
+
+	delete: async (access, data) => {
+		await access.can("users:list");
+		const existing = await agentModel.query().where("id", data.id).andWhere("is_deleted", 0).first();
+		if (!existing?.id) {
+			throw new errs.ItemNotFoundError(data.id);
+		}
+		await agentModel.query().where("id", data.id).patch({ is_deleted: 1 });
+		return true;
+	},
+
+	test: async (access, data) => {
+		await access.can("users:list");
+		let agent;
+		if (data.id) {
+			agent = await agentModel.query().where("id", data.id).andWhere("is_deleted", 0).first();
+		} else {
+			agent = {
+				url: normalizeUrl(data.url),
+				identity: data.identity,
+				secret: data.secret,
+			};
+		}
+		if (!agent) {
+			throw new errs.ItemNotFoundError(data.id);
+		}
+		const result = await internalAgentClient.health(agent);
+		if (data.id) {
+			await agentModel.query().where("id", data.id).patch({ meta: { last_test: result } });
+		}
+		return result;
+	},
+};
+
+export default internalAgent;

--- a/backend/lib/express/agent-forward.js
+++ b/backend/lib/express/agent-forward.js
@@ -1,0 +1,18 @@
+import internalAgentClient from "../../internal/agent-client.js";
+import { debug, express as logger } from "../../logger.js";
+
+export default function () {
+	return async (req, res, next) => {
+		if (!internalAgentClient.shouldForward(req)) {
+			next();
+			return;
+		}
+		try {
+			await res.locals.access.can("users:list");
+			await internalAgentClient.forward(req, res);
+		} catch (err) {
+			debug(logger, `${req.method.toUpperCase()} ${req.originalUrl}: ${err}`);
+			next(err);
+		}
+	};
+}

--- a/backend/migrations/20260520160000_agent_table.js
+++ b/backend/migrations/20260520160000_agent_table.js
@@ -1,0 +1,33 @@
+import { migrate as logger } from "../logger.js";
+
+const migrateName = "agent-table";
+
+const up = (knex) => {
+	logger.info(`[${migrateName}] Migrating Up...`);
+	return knex.schema.hasTable("agent").then((exists) => {
+		if (exists) {
+			logger.info(`[${migrateName}] agent Table already exists`);
+			return;
+		}
+		return knex.schema.createTable("agent", (table) => {
+			table.increments().primary();
+			table.dateTime("created_on").notNull();
+			table.dateTime("modified_on").notNull();
+			table.integer("is_deleted").notNull().unsigned().defaultTo(0);
+			table.integer("enabled").notNull().unsigned().defaultTo(1);
+			table.string("name").notNull();
+			table.string("url").notNull();
+			table.string("identity").notNull();
+			table.text("secret").notNull();
+			table.json("meta").notNull();
+			table.unique("url");
+		});
+	});
+};
+
+const down = (knex) => {
+	logger.warn(`[${migrateName}] Migrating Down...`);
+	return knex.schema.dropTableIfExists("agent");
+};
+
+export { up, down };

--- a/backend/models/agent.js
+++ b/backend/models/agent.js
@@ -1,0 +1,49 @@
+import { Model } from "objection";
+import db from "../db.js";
+import { convertBoolFieldsToInt, convertIntFieldsToBool } from "../lib/helpers.js";
+import now from "./now_helper.js";
+
+Model.knex(db());
+
+const boolFields = ["is_deleted", "enabled"];
+
+class Agent extends Model {
+	$beforeInsert() {
+		this.created_on = now();
+		this.modified_on = now();
+		if (typeof this.enabled === "undefined") {
+			this.enabled = true;
+		}
+		if (typeof this.meta === "undefined") {
+			this.meta = {};
+		}
+	}
+
+	$beforeUpdate() {
+		this.modified_on = now();
+	}
+
+	$parseDatabaseJson(json) {
+		const thisJson = super.$parseDatabaseJson(json);
+		return convertIntFieldsToBool(thisJson, boolFields);
+	}
+
+	$formatDatabaseJson(json) {
+		const thisJson = convertBoolFieldsToInt(json, boolFields);
+		return super.$formatDatabaseJson(thisJson);
+	}
+
+	static get name() {
+		return "Agent";
+	}
+
+	static get tableName() {
+		return "agent";
+	}
+
+	static get jsonAttributes() {
+		return ["meta"];
+	}
+}
+
+export default Agent;

--- a/backend/routes/agents.js
+++ b/backend/routes/agents.js
@@ -1,0 +1,98 @@
+import express from "express";
+import internalAgent from "../internal/agent.js";
+import jwtdecode from "../lib/express/jwt-decode.js";
+import { debug, express as logger } from "../logger.js";
+
+const router = express.Router({
+	caseSensitive: true,
+	strict: true,
+	mergeParams: true,
+});
+
+router
+	.route("/")
+	.options((_, res) => res.sendStatus(204))
+	.all(jwtdecode())
+	.get(async (req, res, next) => {
+		try {
+			const rows = await internalAgent.getAll(res.locals.access);
+			res.status(200).send(rows);
+		} catch (err) {
+			debug(logger, `${req.method.toUpperCase()} ${req.path}: ${err}`);
+			next(err);
+		}
+	})
+	.post(async (req, res, next) => {
+		try {
+			const result = await internalAgent.create(res.locals.access, req.body || {});
+			res.status(201).send(result);
+		} catch (err) {
+			debug(logger, `${req.method.toUpperCase()} ${req.path}: ${err}`);
+			next(err);
+		}
+	});
+
+router
+	.route("/test")
+	.options((_, res) => res.sendStatus(204))
+	.all(jwtdecode())
+	.post(async (req, res, next) => {
+		try {
+			const result = await internalAgent.test(res.locals.access, req.body || {});
+			res.status(200).send(result);
+		} catch (err) {
+			debug(logger, `${req.method.toUpperCase()} ${req.path}: ${err}`);
+			next(err);
+		}
+	});
+
+router
+	.route("/:agent_id")
+	.options((_, res) => res.sendStatus(204))
+	.all(jwtdecode())
+	.get(async (req, res, next) => {
+		try {
+			const row = await internalAgent.get(res.locals.access, { id: Number.parseInt(req.params.agent_id, 10) });
+			res.status(200).send(row);
+		} catch (err) {
+			debug(logger, `${req.method.toUpperCase()} ${req.path}: ${err}`);
+			next(err);
+		}
+	})
+	.put(async (req, res, next) => {
+		try {
+			const result = await internalAgent.update(res.locals.access, {
+				...(req.body || {}),
+				id: Number.parseInt(req.params.agent_id, 10),
+			});
+			res.status(200).send(result);
+		} catch (err) {
+			debug(logger, `${req.method.toUpperCase()} ${req.path}: ${err}`);
+			next(err);
+		}
+	})
+	.delete(async (req, res, next) => {
+		try {
+			const result = await internalAgent.delete(res.locals.access, { id: Number.parseInt(req.params.agent_id, 10) });
+			res.status(200).send(result);
+		} catch (err) {
+			debug(logger, `${req.method.toUpperCase()} ${req.path}: ${err}`);
+			next(err);
+		}
+	});
+
+router
+	.route("/:agent_id/test")
+	.options((_, res) => res.sendStatus(204))
+	.all(jwtdecode())
+	.post(async (req, res, next) => {
+		try {
+			const result = await internalAgent.test(res.locals.access, { id: Number.parseInt(req.params.agent_id, 10) });
+			res.status(200).send(result);
+		} catch (err) {
+			debug(logger, `${req.method.toUpperCase()} ${req.path}: ${err}`);
+			next(err);
+		}
+	});
+
+export default router;

--- a/backend/routes/main.js
+++ b/backend/routes/main.js
@@ -4,6 +4,7 @@ import errs from "../lib/error.js";
 import logRequest from "../lib/express/log-request.js";
 import pjson from "../package.json" with { type: "json" };
 import { isSetup } from "../setup.js";
+import agentsRoutes from "./agents.js";
 import auditLogRoutes from "./audit-log.js";
 import ciRoutes from "./ci.js";
 import accessListsRoutes from "./nginx/access_lists.js";
@@ -49,6 +50,7 @@ router.get("/", async (_, res /*, next*/) => {
 router.use("/schema", schemaRoutes);
 router.use("/tokens", tokensRoutes);
 router.use("/users", usersRoutes);
+router.use("/agents", agentsRoutes);
 router.use("/audit-log", auditLogRoutes);
 router.use("/reports", reportsRoutes);
 router.use("/settings", settingsRoutes);

--- a/backend/routes/nginx/access_lists.js
+++ b/backend/routes/nginx/access_lists.js
@@ -1,5 +1,6 @@
 import express from "express";
 import internalAccessList from "../../internal/access-list.js";
+import agentForward from "../../lib/express/agent-forward.js";
 import jwtdecode from "../../lib/express/jwt-decode.js";
 import apiValidator from "../../lib/validator/api.js";
 import validator from "../../lib/validator/index.js";
@@ -21,6 +22,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/access-lists
@@ -81,6 +83,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/access-lists/123

--- a/backend/routes/nginx/certificates.js
+++ b/backend/routes/nginx/certificates.js
@@ -2,6 +2,7 @@ import express from "express";
 import dnsPlugins from "../../certbot/dns-plugins.json" with { type: "json" };
 import internalCertificate from "../../internal/certificate.js";
 import errs from "../../lib/error.js";
+import agentForward from "../../lib/express/agent-forward.js";
 import jwtdecode from "../../lib/express/jwt-decode.js";
 import apiValidator from "../../lib/validator/api.js";
 import validator from "../../lib/validator/index.js";
@@ -23,6 +24,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/certificates
@@ -95,6 +97,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/certificates/dns-providers
@@ -131,6 +134,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/certificates/test-http
@@ -167,6 +171,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/certificates/validate
@@ -201,6 +206,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/certificates/123
@@ -269,6 +275,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/certificates/123/upload
@@ -304,6 +311,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/certificates/123/renew
@@ -334,6 +342,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/certificates/123/download

--- a/backend/routes/nginx/dead_hosts.js
+++ b/backend/routes/nginx/dead_hosts.js
@@ -1,5 +1,6 @@
 import express from "express";
 import internalDeadHost from "../../internal/dead-host.js";
+import agentForward from "../../lib/express/agent-forward.js";
 import jwtdecode from "../../lib/express/jwt-decode.js";
 import apiValidator from "../../lib/validator/api.js";
 import validator from "../../lib/validator/index.js";
@@ -21,6 +22,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/dead-hosts
@@ -81,6 +83,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/dead-hosts/123
@@ -163,6 +166,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/dead-hosts/123/enable
@@ -190,6 +194,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/dead-hosts/123/disable

--- a/backend/routes/nginx/proxy_hosts.js
+++ b/backend/routes/nginx/proxy_hosts.js
@@ -1,5 +1,6 @@
 import express from "express";
 import internalProxyHost from "../../internal/proxy-host.js";
+import agentForward from "../../lib/express/agent-forward.js";
 import jwtdecode from "../../lib/express/jwt-decode.js";
 import apiValidator from "../../lib/validator/api.js";
 import validator from "../../lib/validator/index.js";
@@ -21,6 +22,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/proxy-hosts
@@ -81,6 +83,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/proxy-hosts/123
@@ -163,6 +166,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/proxy-hosts/123/enable
@@ -190,6 +194,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/proxy-hosts/123/disable

--- a/backend/routes/nginx/redirection_hosts.js
+++ b/backend/routes/nginx/redirection_hosts.js
@@ -1,5 +1,6 @@
 import express from "express";
 import internalRedirectionHost from "../../internal/redirection-host.js";
+import agentForward from "../../lib/express/agent-forward.js";
 import jwtdecode from "../../lib/express/jwt-decode.js";
 import apiValidator from "../../lib/validator/api.js";
 import validator from "../../lib/validator/index.js";
@@ -21,6 +22,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/redirection-hosts
@@ -81,6 +83,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/nginx/redirection-hosts/123
@@ -166,6 +169,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/redirection-hosts/123/enable
@@ -193,6 +197,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/redirection-hosts/123/disable

--- a/backend/routes/nginx/streams.js
+++ b/backend/routes/nginx/streams.js
@@ -1,5 +1,6 @@
 import express from "express";
 import internalStream from "../../internal/stream.js";
+import agentForward from "../../lib/express/agent-forward.js";
 import jwtdecode from "../../lib/express/jwt-decode.js";
 import apiValidator from "../../lib/validator/api.js";
 import validator from "../../lib/validator/index.js";
@@ -20,7 +21,8 @@ router
 	.options((_, res) => {
 		res.sendStatus(204);
 	})
-	.all(jwtdecode()) // preferred so it doesn't apply to nonexistent routes
+	.all(jwtdecode())
+	.all(agentForward()) // preferred so it doesn't apply to nonexistent routes
 
 	/**
 	 * GET /api/nginx/streams
@@ -80,7 +82,8 @@ router
 	.options((_, res) => {
 		res.sendStatus(204);
 	})
-	.all(jwtdecode()) // preferred so it doesn't apply to nonexistent routes
+	.all(jwtdecode())
+	.all(agentForward()) // preferred so it doesn't apply to nonexistent routes
 
 	/**
 	 * GET /api/nginx/streams/123
@@ -163,6 +166,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/streams/123/enable
@@ -190,6 +194,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/nginx/streams/123/disable

--- a/backend/routes/reports.js
+++ b/backend/routes/reports.js
@@ -1,5 +1,6 @@
 import express from "express";
 import internalReport from "../internal/report.js";
+import agentForward from "../lib/express/agent-forward.js";
 import jwtdecode from "../lib/express/jwt-decode.js";
 import { debug, express as logger } from "../logger.js";
 
@@ -15,6 +16,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /reports/hosts

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -4,6 +4,7 @@ import internalUser from "../internal/user.js";
 import Access from "../lib/access.js";
 import { isCI } from "../lib/config.js";
 import errs from "../lib/error.js";
+import agentForward from "../lib/express/agent-forward.js";
 import jwtdecode from "../lib/express/jwt-decode.js";
 import userIdFromMe from "../lib/express/user-id-from-me.js";
 import apiValidator from "../lib/validator/api.js";
@@ -27,6 +28,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * GET /api/users
@@ -145,6 +147,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 	.all(userIdFromMe)
 
 	/**
@@ -239,6 +242,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 	.all(userIdFromMe)
 
 	/**
@@ -272,6 +276,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 	.all(userIdFromMe)
 
 	/**
@@ -308,6 +313,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 
 	/**
 	 * POST /api/users/123/login
@@ -337,6 +343,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 	.all(userIdFromMe)
 
 	/**
@@ -399,6 +406,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 	.all(userIdFromMe)
 
 	/**
@@ -431,6 +439,7 @@ router
 		res.sendStatus(204);
 	})
 	.all(jwtdecode())
+	.all(agentForward())
 	.all(userIdFromMe)
 
 	/**

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,10 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Nginx Proxy Manager</title>
 		<meta name="description" content="Manage Nginx hosts with a simple, powerful interface" />
+		<meta name="mobile-web-app-capable" content="yes" />
+		<meta name="apple-mobile-web-app-capable" content="yes" />
+		<meta name="apple-mobile-web-app-title" content="NPM" />
+		<meta name="application-name" content="Nginx Proxy Manager" />
 		<link rel="preload" href="/images/logo-no-text.svg" as="image" type="image/svg+xml" fetchPriority="high">
 		<link
 			rel="apple-touch-icon"
@@ -30,7 +34,7 @@
 		<meta
 			name="msapplication-config"
 			content="/images/favicon/browserconfig.xml" />
-		<meta name="theme-color" content="#ffffff" />
+		<meta name="theme-color" content="#206bc4" />
 	</head>
 	<body>
 		<noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/images/favicon/site.webmanifest
+++ b/frontend/public/images/favicon/site.webmanifest
@@ -1,19 +1,25 @@
 {
-    "name": "",
-    "short_name": "",
-    "icons": [
-        {
-            "src": "/images/favicons/android-chrome-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/images/favicons/android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png"
-        }
-    ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
-    "display": "standalone"
+	"name": "Nginx Proxy Manager",
+	"short_name": "NPM",
+	"description": "Manage Nginx hosts with a simple, powerful interface",
+	"start_url": "/",
+	"scope": "/",
+	"display": "standalone",
+	"orientation": "any",
+	"theme_color": "#206bc4",
+	"background_color": "#ffffff",
+	"icons": [
+		{
+			"src": "/images/favicon/android-chrome-192x192.png",
+			"sizes": "192x192",
+			"type": "image/png",
+			"purpose": "any maskable"
+		},
+		{
+			"src": "/images/favicon/android-chrome-512x512.png",
+			"sizes": "512x512",
+			"type": "image/png",
+			"purpose": "any maskable"
+		}
+	]
 }

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#206bc4" />
+		<title>Nginx Proxy Manager is offline</title>
+		<style>
+			:root { color-scheme: light dark; }
+			body {
+				align-items: center;
+				background: #f6f8fb;
+				color: #1f2937;
+				display: flex;
+				font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+				justify-content: center;
+				min-height: 100vh;
+				margin: 0;
+				padding: 1.5rem;
+			}
+			main {
+				background: #fff;
+				border: 1px solid #dce2ea;
+				border-radius: 14px;
+				box-shadow: 0 12px 32px rgb(0 0 0 / 8%);
+				max-width: 28rem;
+				padding: 2rem;
+				text-align: center;
+			}
+			img { height: 4.5rem; margin-bottom: 1rem; }
+			h1 { font-size: 1.4rem; margin: 0 0 .5rem; }
+			p { color: #4b5563; line-height: 1.5; margin: 0 0 1.25rem; }
+			button {
+				background: #206bc4;
+				border: 0;
+				border-radius: 8px;
+				color: #fff;
+				cursor: pointer;
+				font: inherit;
+				font-weight: 600;
+				padding: .65rem 1rem;
+			}
+			@media (prefers-color-scheme: dark) {
+				body { background: #111827; color: #f9fafb; }
+				main { background: #1f2937; border-color: #374151; }
+				p { color: #d1d5db; }
+			}
+		</style>
+	</head>
+	<body>
+		<main>
+			<img src="/images/logo-no-text.svg" alt="" />
+			<h1>Nginx Proxy Manager is offline</h1>
+			<p>The app shell is installed, but management actions require a connection to the NPM server.</p>
+			<button type="button" onclick="window.location.reload()">Try again</button>
+		</main>
+	</body>
+</html>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,72 @@
+const CACHE_VERSION = "npm-pwa-v1";
+const APP_SHELL = [
+	"/",
+	"/index.html",
+	"/offline.html",
+	"/images/logo-no-text.svg",
+	"/images/favicon/android-chrome-192x192.png",
+	"/images/favicon/android-chrome-512x512.png",
+];
+
+self.addEventListener("install", (event) => {
+	event.waitUntil(
+		caches.open(CACHE_VERSION).then((cache) => cache.addAll(APP_SHELL)),
+	);
+});
+
+self.addEventListener("activate", (event) => {
+	event.waitUntil(
+		caches
+			.keys()
+			.then((keys) => Promise.all(keys.filter((key) => key !== CACHE_VERSION).map((key) => caches.delete(key))))
+			.then(() => self.clients.claim()),
+	);
+});
+
+self.addEventListener("fetch", (event) => {
+	const { request } = event;
+
+	if (request.method !== "GET") {
+		return;
+	}
+
+	const url = new URL(request.url);
+	if (url.origin !== self.location.origin || url.pathname.startsWith("/api/")) {
+		return;
+	}
+
+	if (request.mode === "navigate") {
+		event.respondWith(
+			fetch(request)
+				.then((response) => {
+					const copy = response.clone();
+					caches.open(CACHE_VERSION).then((cache) => cache.put("/index.html", copy));
+					return response;
+				})
+				.catch(async () => (await caches.match("/index.html")) || caches.match("/offline.html")),
+		);
+		return;
+	}
+
+	event.respondWith(
+		caches.match(request).then((cached) => {
+			if (cached) {
+				return cached;
+			}
+
+			return fetch(request).then((response) => {
+				if (response.ok) {
+					const copy = response.clone();
+					caches.open(CACHE_VERSION).then((cache) => cache.put(request, copy));
+				}
+				return response;
+			});
+		}),
+	);
+});
+
+self.addEventListener("message", (event) => {
+	if (event.data?.type === "SKIP_WAITING") {
+		self.skipWaiting();
+	}
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,34 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import EasyModal from "ez-modal-react";
 import { RawIntlProvider } from "react-intl";
-import { ToastContainer } from "react-toastify";
+import { toast, ToastContainer } from "react-toastify";
 import { AuthProvider, LocaleProvider, ThemeProvider } from "src/context";
 import { intl } from "src/locale";
 import Router from "src/Router.tsx";
+import { registerPwa } from "src/modules/Pwa";
 
 // Create a client
 const queryClient = new QueryClient();
 
 function App() {
+	useEffect(() => {
+		registerPwa({
+			onOfflineReady: () => {
+				toast.info("Nginx Proxy Manager is ready for offline launch.");
+			},
+			onUpdateReady: (activateUpdate) => {
+				toast.info(
+					<button className="btn btn-primary btn-sm" type="button" onClick={activateUpdate}>
+						Update available. Reload
+					</button>,
+					{ autoClose: false },
+				);
+			},
+		});
+	}, []);
+
 	return (
 		<RawIntlProvider value={intl}>
 			<LocaleProvider>

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -17,6 +17,7 @@ const Setup = lazy(() => import("src/pages/Setup"));
 const Login = lazy(() => import("src/pages/Login"));
 const Dashboard = lazy(() => import("src/pages/Dashboard"));
 const Settings = lazy(() => import("src/pages/Settings"));
+const Agents = lazy(() => import("src/pages/Agents"));
 const Certificates = lazy(() => import("src/pages/Certificates"));
 const Access = lazy(() => import("src/pages/Access"));
 const AuditLog = lazy(() => import("src/pages/AuditLog"));
@@ -65,6 +66,7 @@ function Router() {
 							<Route path="/access" element={<Access />} />
 							<Route path="/audit-log" element={<AuditLog />} />
 							<Route path="/settings" element={<Settings />} />
+							<Route path="/agents" element={<Agents />} />
 							<Route path="/users" element={<Users />} />
 							<Route path="/nginx/proxy" element={<ProxyHosts />} />
 							<Route path="/nginx/redirection" element={<RedirectionHosts />} />

--- a/frontend/src/api/backend/agentParams.ts
+++ b/frontend/src/api/backend/agentParams.ts
@@ -1,0 +1,1 @@
+export const paramsForAgent = (agentId?: string) => (agentId && agentId !== "local" ? { agent_id: agentId } : undefined);

--- a/frontend/src/api/backend/createAgent.ts
+++ b/frontend/src/api/backend/createAgent.ts
@@ -1,0 +1,6 @@
+import * as api from "./base";
+import type { Agent } from "./models";
+
+export async function createAgent(item: Partial<Agent> & { secret: string }): Promise<Agent> {
+	return await api.post({ url: "/agents", data: item });
+}

--- a/frontend/src/api/backend/createCertificate.ts
+++ b/frontend/src/api/backend/createCertificate.ts
@@ -1,9 +1,11 @@
 import * as api from "./base";
 import type { Certificate } from "./models";
+import { paramsForAgent } from "./agentParams";
 
-export async function createCertificate(item: Certificate): Promise<Certificate> {
+export async function createCertificate(item: Certificate, agentId?: string): Promise<Certificate> {
 	return await api.post({
 		url: "/nginx/certificates",
+		params: paramsForAgent(agentId),
 		data: item,
 	});
 }

--- a/frontend/src/api/backend/createProxyHost.ts
+++ b/frontend/src/api/backend/createProxyHost.ts
@@ -1,9 +1,11 @@
 import * as api from "./base";
 import type { ProxyHost } from "./models";
 
-export async function createProxyHost(item: ProxyHost): Promise<ProxyHost> {
+export async function createProxyHost(item: ProxyHost & { agentId?: string }): Promise<ProxyHost> {
+	const { agentId, ...data } = item;
 	return await api.post({
 		url: "/nginx/proxy-hosts",
-		data: item,
+		params: agentId && agentId !== "local" ? { agent_id: agentId } : undefined,
+		data,
 	});
 }

--- a/frontend/src/api/backend/createUser.ts
+++ b/frontend/src/api/backend/createUser.ts
@@ -1,4 +1,5 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 import type { User } from "./models";
 
 export interface AuthOptions {
@@ -15,9 +16,10 @@ export interface NewUser {
 	roles?: string[];
 }
 
-export async function createUser(item: NewUser, noAuth?: boolean): Promise<User> {
+export async function createUser(item: NewUser, noAuth?: boolean, agentId?: string): Promise<User> {
 	return await api.post({
 		url: "/users",
+		params: paramsForAgent(agentId),
 		data: item,
 		noAuth,
 	});

--- a/frontend/src/api/backend/deleteAgent.ts
+++ b/frontend/src/api/backend/deleteAgent.ts
@@ -1,0 +1,5 @@
+import * as api from "./base";
+
+export async function deleteAgent(id: number): Promise<boolean> {
+	return await api.del({ url: `/agents/${id}` });
+}

--- a/frontend/src/api/backend/deleteCertificate.ts
+++ b/frontend/src/api/backend/deleteCertificate.ts
@@ -1,7 +1,9 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 
-export async function deleteCertificate(id: number): Promise<boolean> {
+export async function deleteCertificate(id: number, agentId?: string): Promise<boolean> {
 	return await api.del({
 		url: `/nginx/certificates/${id}`,
+		params: paramsForAgent(agentId),
 	});
 }

--- a/frontend/src/api/backend/deleteProxyHost.ts
+++ b/frontend/src/api/backend/deleteProxyHost.ts
@@ -1,7 +1,8 @@
 import * as api from "./base";
 
-export async function deleteProxyHost(id: number): Promise<boolean> {
+export async function deleteProxyHost(id: number, agentId?: string): Promise<boolean> {
 	return await api.del({
 		url: `/nginx/proxy-hosts/${id}`,
+		params: agentId && agentId !== "local" ? { agent_id: agentId } : undefined,
 	});
 }

--- a/frontend/src/api/backend/deleteUser.ts
+++ b/frontend/src/api/backend/deleteUser.ts
@@ -1,7 +1,9 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 
-export async function deleteUser(id: number): Promise<boolean> {
+export async function deleteUser(id: number, agentId?: string): Promise<boolean> {
 	return await api.del({
 		url: `/users/${id}`,
+		params: paramsForAgent(agentId),
 	});
 }

--- a/frontend/src/api/backend/downloadCertificate.ts
+++ b/frontend/src/api/backend/downloadCertificate.ts
@@ -1,9 +1,11 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 
-export async function downloadCertificate(id: number): Promise<void> {
+export async function downloadCertificate(id: number, agentId?: string): Promise<void> {
 	await api.download(
 		{
 			url: `/nginx/certificates/${id}/download`,
+			params: paramsForAgent(agentId),
 		},
 		`certificate-${id}.zip`,
 	);

--- a/frontend/src/api/backend/getAgents.ts
+++ b/frontend/src/api/backend/getAgents.ts
@@ -1,0 +1,6 @@
+import * as api from "./base";
+import type { Agent } from "./models";
+
+export async function getAgents(): Promise<Agent[]> {
+	return await api.get({ url: "/agents" });
+}

--- a/frontend/src/api/backend/getCertificate.ts
+++ b/frontend/src/api/backend/getCertificate.ts
@@ -1,13 +1,14 @@
 import * as api from "./base";
 import type { CertificateExpansion } from "./expansions";
 import type { Certificate } from "./models";
+import { paramsForAgent } from "./agentParams";
 
-export async function getCertificate(id: number, expand?: CertificateExpansion[], params = {}): Promise<Certificate> {
+export async function getCertificate(id: number, expand?: CertificateExpansion[], agentId?: string): Promise<Certificate> {
 	return await api.get({
 		url: `/nginx/certificates/${id}`,
 		params: {
 			expand: expand?.join(","),
-			...params,
+			...paramsForAgent(agentId),
 		},
 	});
 }

--- a/frontend/src/api/backend/getHostsReport.ts
+++ b/frontend/src/api/backend/getHostsReport.ts
@@ -1,7 +1,9 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 
-export async function getHostsReport(): Promise<Record<string, number>> {
+export async function getHostsReport(agentId?: string): Promise<Record<string, number>> {
 	return await api.get({
 		url: "/reports/hosts",
+		params: paramsForAgent(agentId),
 	});
 }

--- a/frontend/src/api/backend/index.ts
+++ b/frontend/src/api/backend/index.ts
@@ -61,3 +61,9 @@ export * from "./updateUser";
 export * from "./uploadCertificate";
 export * from "./validateCertificate";
 export * from "./twoFactor";
+
+export * from "./createAgent";
+export * from "./deleteAgent";
+export * from "./getAgents";
+export * from "./testAgent";
+export * from "./updateAgent";

--- a/frontend/src/api/backend/loginAsUser.ts
+++ b/frontend/src/api/backend/loginAsUser.ts
@@ -1,8 +1,10 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 import type { LoginAsTokenResponse } from "./responseTypes";
 
-export async function loginAsUser(id: number): Promise<LoginAsTokenResponse> {
+export async function loginAsUser(id: number, agentId?: string): Promise<LoginAsTokenResponse> {
 	return await api.post({
 		url: `/users/${id}/login`,
+		params: paramsForAgent(agentId),
 	});
 }

--- a/frontend/src/api/backend/models.ts
+++ b/frontend/src/api/backend/models.ts
@@ -1,3 +1,15 @@
+
+export interface Agent {
+	id: number;
+	createdOn: string;
+	modifiedOn: string;
+	enabled: boolean;
+	name: string;
+	url: string;
+	identity: string;
+	meta?: Record<string, any>;
+}
+
 export interface AppVersion {
 	major: number;
 	minor: number;

--- a/frontend/src/api/backend/renewCertificate.ts
+++ b/frontend/src/api/backend/renewCertificate.ts
@@ -1,8 +1,10 @@
 import * as api from "./base";
 import type { Certificate } from "./models";
+import { paramsForAgent } from "./agentParams";
 
-export async function renewCertificate(id: number): Promise<Certificate> {
+export async function renewCertificate(id: number, agentId?: string): Promise<Certificate> {
 	return await api.post({
 		url: `/nginx/certificates/${id}/renew`,
+		params: paramsForAgent(agentId),
 	});
 }

--- a/frontend/src/api/backend/setPermissions.ts
+++ b/frontend/src/api/backend/setPermissions.ts
@@ -1,10 +1,12 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 import type { UserPermissions } from "./models";
 
-export async function setPermissions(userId: number, data: UserPermissions): Promise<boolean> {
+export async function setPermissions(userId: number, data: UserPermissions, agentId?: string): Promise<boolean> {
 	// Remove readonly fields
 	return await api.put({
 		url: `/users/${userId}/permissions`,
+		params: paramsForAgent(agentId),
 		data,
 	});
 }

--- a/frontend/src/api/backend/testAgent.ts
+++ b/frontend/src/api/backend/testAgent.ts
@@ -1,0 +1,5 @@
+import * as api from "./base";
+
+export async function testAgent(id: number): Promise<{ ok: boolean }> {
+	return await api.post({ url: `/agents/${id}/test` });
+}

--- a/frontend/src/api/backend/testHttpCertificate.ts
+++ b/frontend/src/api/backend/testHttpCertificate.ts
@@ -1,8 +1,10 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 
-export async function testHttpCertificate(domains: string[]): Promise<Record<string, string>> {
+export async function testHttpCertificate(domains: string[], agentId?: string): Promise<Record<string, string>> {
 	return await api.post({
 		url: "/nginx/certificates/test-http",
+		params: paramsForAgent(agentId),
 		data: {
 			domains,
 		},

--- a/frontend/src/api/backend/toggleProxyHost.ts
+++ b/frontend/src/api/backend/toggleProxyHost.ts
@@ -1,7 +1,8 @@
 import * as api from "./base";
 
-export async function toggleProxyHost(id: number, enabled: boolean): Promise<boolean> {
+export async function toggleProxyHost(id: number, enabled: boolean, agentId?: string): Promise<boolean> {
 	return await api.post({
 		url: `/nginx/proxy-hosts/${id}/${enabled ? "enable" : "disable"}`,
+		params: agentId && agentId !== "local" ? { agent_id: agentId } : undefined,
 	});
 }

--- a/frontend/src/api/backend/toggleUser.ts
+++ b/frontend/src/api/backend/toggleUser.ts
@@ -1,10 +1,13 @@
 import type { User } from "./models";
 import { updateUser } from "./updateUser";
 
-export async function toggleUser(id: number, enabled: boolean): Promise<boolean> {
-	await updateUser({
-		id,
-		isDisabled: !enabled,
-	} as User);
+export async function toggleUser(id: number, enabled: boolean, agentId?: string): Promise<boolean> {
+	await updateUser(
+		{
+			id,
+			isDisabled: !enabled,
+		} as User,
+		agentId,
+	);
 	return true;
 }

--- a/frontend/src/api/backend/updateAgent.ts
+++ b/frontend/src/api/backend/updateAgent.ts
@@ -1,0 +1,7 @@
+import * as api from "./base";
+import type { Agent } from "./models";
+
+export async function updateAgent(item: Partial<Agent> & { id: number; secret?: string }): Promise<Agent> {
+	const { id, ...data } = item;
+	return await api.put({ url: `/agents/${id}`, data });
+}

--- a/frontend/src/api/backend/updateAuth.ts
+++ b/frontend/src/api/backend/updateAuth.ts
@@ -1,7 +1,8 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 import type { User } from "./models";
 
-export async function updateAuth(userId: number | "me", newPassword: string, current?: string): Promise<User> {
+export async function updateAuth(userId: number | "me", newPassword: string, current?: string, agentId?: string): Promise<User> {
 	const data = {
 		type: "password",
 		current: current,
@@ -13,6 +14,7 @@ export async function updateAuth(userId: number | "me", newPassword: string, cur
 
 	return await api.put({
 		url: `/users/${userId}/auth`,
+		params: paramsForAgent(agentId),
 		data,
 	});
 }

--- a/frontend/src/api/backend/updateProxyHost.ts
+++ b/frontend/src/api/backend/updateProxyHost.ts
@@ -1,12 +1,13 @@
 import * as api from "./base";
 import type { ProxyHost } from "./models";
 
-export async function updateProxyHost(item: ProxyHost): Promise<ProxyHost> {
+export async function updateProxyHost(item: ProxyHost & { agentId?: string }): Promise<ProxyHost> {
 	// Remove readonly fields
-	const { id, createdOn: _, modifiedOn: __, ...data } = item;
+	const { id, createdOn: _, modifiedOn: __, agentId, ...data } = item;
 
 	return await api.put({
 		url: `/nginx/proxy-hosts/${id}`,
+		params: agentId && agentId !== "local" ? { agent_id: agentId } : undefined,
 		data: data,
 	});
 }

--- a/frontend/src/api/backend/updateUser.ts
+++ b/frontend/src/api/backend/updateUser.ts
@@ -1,12 +1,14 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 import type { User } from "./models";
 
-export async function updateUser(item: User): Promise<User> {
+export async function updateUser(item: User, agentId?: string): Promise<User> {
 	// Remove readonly fields
 	const { id, createdOn: _, modifiedOn: __, ...data } = item;
 
 	return await api.put({
 		url: `/users/${id}`,
+		params: paramsForAgent(agentId),
 		data: data,
 	});
 }

--- a/frontend/src/api/backend/uploadCertificate.ts
+++ b/frontend/src/api/backend/uploadCertificate.ts
@@ -1,9 +1,11 @@
 import * as api from "./base";
 import type { Certificate } from "./models";
+import { paramsForAgent } from "./agentParams";
 
-export async function uploadCertificate(id: number, data: FormData): Promise<Certificate> {
+export async function uploadCertificate(id: number, data: FormData, agentId?: string): Promise<Certificate> {
 	return await api.post({
 		url: `/nginx/certificates/${id}/upload`,
+		params: paramsForAgent(agentId),
 		data,
 	});
 }

--- a/frontend/src/api/backend/validateCertificate.ts
+++ b/frontend/src/api/backend/validateCertificate.ts
@@ -1,9 +1,11 @@
 import * as api from "./base";
+import { paramsForAgent } from "./agentParams";
 import type { ValidatedCertificateResponse } from "./responseTypes";
 
-export async function validateCertificate(data: FormData): Promise<ValidatedCertificateResponse> {
+export async function validateCertificate(data: FormData, agentId?: string): Promise<ValidatedCertificateResponse> {
 	return await api.post({
 		url: "/nginx/certificates/validate",
+		params: paramsForAgent(agentId),
 		data,
 	});
 }

--- a/frontend/src/components/Form/AccessField.tsx
+++ b/frontend/src/components/Form/AccessField.tsx
@@ -31,10 +31,11 @@ interface Props {
 	id?: string;
 	name?: string;
 	label?: string;
+	agentId?: string;
 }
-export function AccessField({ name = "accessListId", label = "access-list", id = "accessListId" }: Props) {
+export function AccessField({ name = "accessListId", label = "access-list", id = "accessListId", agentId }: Props) {
 	const { locale } = useLocaleState();
-	const { isLoading, isError, error, data } = useAccessLists(["owner", "items", "clients"]);
+	const { isLoading, isError, error, data } = useAccessLists(["owner", "items", "clients"], {}, agentId);
 	const { setFieldValue } = useFormikContext();
 
 	const handleChange = (newValue: any, _actionMeta: ActionMeta<AccessOption>) => {

--- a/frontend/src/components/Form/SSLCertificateField.tsx
+++ b/frontend/src/components/Form/SSLCertificateField.tsx
@@ -33,6 +33,7 @@ interface Props {
 	required?: boolean;
 	allowNew?: boolean;
 	forHttp?: boolean; // the sslForced, http2Support, hstsEnabled, hstsSubdomains fields
+	agentId?: string;
 }
 export function SSLCertificateField({
 	name = "certificateId",
@@ -41,9 +42,10 @@ export function SSLCertificateField({
 	required,
 	allowNew,
 	forHttp = true,
+	agentId,
 }: Props) {
 	const { locale } = useLocaleState();
-	const { isLoading, isError, error, data } = useCertificates();
+	const { isLoading, isError, error, data } = useCertificates(undefined, {}, agentId);
 	const { values, setFieldValue } = useFormikContext();
 	const v: any = values || {};
 

--- a/frontend/src/components/MultiAgent/AgentSection.tsx
+++ b/frontend/src/components/MultiAgent/AgentSection.tsx
@@ -1,0 +1,77 @@
+import type React from "react";
+import { IconRefresh } from "@tabler/icons-react";
+import Alert from "react-bootstrap/Alert";
+import { Button, Loading } from "src/components";
+import type { AgentTarget } from "src/hooks";
+
+interface Props {
+	target: AgentTarget;
+	color?: string;
+	isLoading?: boolean;
+	isFetching?: boolean;
+	isError?: boolean;
+	error?: Error | null;
+	shownCount?: number;
+	totalCount?: number;
+	onRetry?: () => void;
+	actions?: React.ReactNode;
+	children: React.ReactNode;
+}
+
+function AgentSection({
+	target,
+	color = "primary",
+	isLoading,
+	isFetching,
+	isError,
+	error,
+	shownCount,
+	totalCount,
+	onRetry,
+	actions,
+	children,
+}: Props) {
+	return (
+		<div className="card my-3 border">
+			<div className={`card-status-start bg-${color}`} />
+			<div className="card-header py-2">
+				<div className="row w-full align-items-center g-2">
+					<div className="col">
+						<div className="d-flex align-items-center gap-2 flex-wrap">
+							<h3 className="card-title mb-0">{target.name}</h3>
+							<span className="badge bg-green-lt">{target.isLocal ? "local" : "agent"}</span>
+							{typeof shownCount === "number" && typeof totalCount === "number" ? (
+								<span className="badge bg-secondary-lt">
+									{shownCount} shown / {totalCount} total
+								</span>
+							) : null}
+							{isFetching && !isLoading ? <span className="badge bg-blue-lt">refreshing</span> : null}
+						</div>
+						<div className="text-muted small text-truncate">{target.subtitle}</div>
+					</div>
+					{actions ? <div className="col-auto d-flex gap-2">{actions}</div> : null}
+				</div>
+			</div>
+			{isLoading ? (
+				<div className="card-body py-4">
+					<Loading noLogo />
+				</div>
+			) : isError ? (
+				<div className="card-body">
+					<Alert variant="danger" className="mb-0 d-flex align-items-center justify-content-between gap-3">
+						<span>{error?.message || "Unknown error"}</span>
+						{onRetry ? (
+							<Button size="sm" onClick={onRetry}>
+								<IconRefresh size={16} /> Retry
+							</Button>
+						) : null}
+					</Alert>
+				</div>
+			) : (
+				children
+			)}
+		</div>
+	);
+}
+
+export { AgentSection };

--- a/frontend/src/components/MultiAgent/index.ts
+++ b/frontend/src/components/MultiAgent/index.ts
@@ -1,0 +1,1 @@
+export * from "./AgentSection";

--- a/frontend/src/components/SiteMenu.tsx
+++ b/frontend/src/components/SiteMenu.tsx
@@ -1,6 +1,7 @@
 import {
 	IconBook,
 	IconDeviceDesktop,
+	IconNetwork,
 	IconHome,
 	IconLock,
 	IconSettings,
@@ -93,6 +94,12 @@ const menuItems: MenuItem[] = [
 		to: "/audit-log",
 		icon: IconBook,
 		label: "auditlogs",
+		permissionSection: ADMIN,
+	},
+	{
+		to: "/agents",
+		icon: IconNetwork,
+		label: "agents",
 		permissionSection: ADMIN,
 	},
 	{

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -16,3 +16,4 @@ export * from "./SiteMenu";
 export * from "./Table";
 export * from "./ThemeSwitcher";
 export * from "./Unhealthy";
+export * from "./MultiAgent";

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -20,3 +20,5 @@ export * from "./useStreams";
 export * from "./useTheme";
 export * from "./useUser";
 export * from "./useUsers";
+
+export * from "./useAgents";

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -22,3 +22,4 @@ export * from "./useUser";
 export * from "./useUsers";
 
 export * from "./useAgents";
+export * from "./useAgentTargets";

--- a/frontend/src/hooks/useAccessLists.ts
+++ b/frontend/src/hooks/useAccessLists.ts
@@ -1,14 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { type AccessList, type AccessListExpansion, getAccessLists } from "src/api/backend";
 
-const fetchAccessLists = (expand?: AccessListExpansion[]) => {
-	return getAccessLists(expand);
+const paramsForAgent = (agentId?: string) => (agentId && agentId !== "local" ? { agent_id: agentId } : {});
+
+const fetchAccessLists = (expand?: AccessListExpansion[], agentId?: string) => {
+	return getAccessLists(expand, paramsForAgent(agentId));
 };
 
-const useAccessLists = (expand?: AccessListExpansion[], options = {}) => {
+const useAccessLists = (expand?: AccessListExpansion[], options: any = {}, agentId?: string) => {
 	return useQuery<AccessList[], Error>({
-		queryKey: ["access-lists", { expand }],
-		queryFn: () => fetchAccessLists(expand),
+		queryKey: ["access-lists", { expand, agentId }],
+		queryFn: () => fetchAccessLists(expand, agentId),
 		staleTime: 60 * 1000,
 		...options,
 	});

--- a/frontend/src/hooks/useAgentTargets.ts
+++ b/frontend/src/hooks/useAgentTargets.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import type { Agent } from "src/api/backend";
+import { useAgents } from "./useAgents";
+
+export interface AgentTarget {
+	id: string;
+	name: string;
+	subtitle: string;
+	isLocal?: boolean;
+	agent?: Agent;
+}
+
+const localAgentTarget: AgentTarget = {
+	id: "local",
+	name: "Current node",
+	subtitle: "local",
+	isLocal: true,
+};
+
+const useAgentTargets = () => {
+	const agentsQuery = useAgents();
+	const targets = useMemo<AgentTarget[]>(() => {
+		const enabledAgents = (agentsQuery.data ?? [])
+			.filter((agent) => agent.enabled)
+			.map((agent) => ({
+				id: `${agent.id}`,
+				name: agent.name || agent.url,
+				subtitle: `agent #${agent.id}${agent.url ? ` · ${agent.url}` : ""}`,
+				agent,
+			}));
+		return [localAgentTarget, ...enabledAgents];
+	}, [agentsQuery.data]);
+
+	return {
+		...agentsQuery,
+		targets,
+	};
+};
+
+export { useAgentTargets, localAgentTarget };

--- a/frontend/src/hooks/useAgents.ts
+++ b/frontend/src/hooks/useAgents.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAgents, type Agent } from "src/api/backend";
+
+const fetchAgents = () => getAgents();
+
+const useAgents = (options = {}) => {
+	return useQuery<Agent[], Error>({
+		queryKey: ["agents"],
+		queryFn: fetchAgents,
+		staleTime: 60 * 1000,
+		...options,
+	});
+};
+
+export { fetchAgents, useAgents };

--- a/frontend/src/hooks/useCertificate.ts
+++ b/frontend/src/hooks/useCertificate.ts
@@ -1,14 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { type Certificate, getCertificate } from "src/api/backend";
 
-const fetchCertificate = (id: number) => {
-	return getCertificate(id, ["owner"]);
+const fetchCertificate = (id: number, agentId?: string) => {
+	return getCertificate(id, ["owner"], agentId);
 };
 
-const useCertificate = (id: number, options = {}) => {
+const useCertificate = (id: number, options = {}, agentId?: string) => {
 	return useQuery<Certificate, Error>({
-		queryKey: ["certificate", id],
-		queryFn: () => fetchCertificate(id),
+		queryKey: ["certificate", id, { agentId }],
+		queryFn: () => fetchCertificate(id, agentId),
 		staleTime: 60 * 1000, // 1 minute
 		...options,
 	});

--- a/frontend/src/hooks/useCertificates.ts
+++ b/frontend/src/hooks/useCertificates.ts
@@ -1,14 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { type Certificate, type CertificateExpansion, getCertificates } from "src/api/backend";
 
-const fetchCertificates = (expand?: CertificateExpansion[]) => {
-	return getCertificates(expand);
+const paramsForAgent = (agentId?: string) => (agentId && agentId !== "local" ? { agent_id: agentId } : {});
+
+const fetchCertificates = (expand?: CertificateExpansion[], agentId?: string) => {
+	return getCertificates(expand, paramsForAgent(agentId));
 };
 
-const useCertificates = (expand?: CertificateExpansion[], options = {}) => {
+const useCertificates = (expand?: CertificateExpansion[], options: any = {}, agentId?: string) => {
 	return useQuery<Certificate[], Error>({
-		queryKey: ["certificates", { expand }],
-		queryFn: () => fetchCertificates(expand),
+		queryKey: ["certificates", { expand, agentId }],
+		queryFn: () => fetchCertificates(expand, agentId),
 		staleTime: 60 * 1000,
 		...options,
 	});

--- a/frontend/src/hooks/useHostReport.ts
+++ b/frontend/src/hooks/useHostReport.ts
@@ -1,12 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { getHostsReport } from "src/api/backend";
 
-const fetchHostReport = () => getHostsReport();
+const fetchHostReport = (agentId?: string) => getHostsReport(agentId);
 
-const useHostReport = (options = {}) => {
+const useHostReport = (options = {}, agentId?: string) => {
 	return useQuery<Record<string, number>, Error>({
-		queryKey: ["host-report"],
-		queryFn: fetchHostReport,
+		queryKey: ["host-report", { agentId }],
+		queryFn: () => fetchHostReport(agentId),
 		refetchOnWindowFocus: false,
 		retry: 5,
 		refetchInterval: 15 * 1000, // 15 seconds

--- a/frontend/src/hooks/useProxyHost.ts
+++ b/frontend/src/hooks/useProxyHost.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createProxyHost, getProxyHost, type ProxyHost, updateProxyHost } from "src/api/backend";
 
-const fetchProxyHost = (id: number | "new") => {
+const paramsForAgent = (agentId?: string) => (agentId && agentId !== "local" ? { agent_id: agentId } : {});
+
+const fetchProxyHost = (id: number | "new", agentId?: string) => {
 	if (id === "new") {
 		return Promise.resolve({
 			id: 0,
@@ -27,32 +29,35 @@ const fetchProxyHost = (id: number | "new") => {
 			trustForwardedProto: false,
 		} as ProxyHost);
 	}
-	return getProxyHost(id, ["owner"]);
+	return getProxyHost(id, ["owner"], paramsForAgent(agentId));
 };
 
-const useProxyHost = (id: number | "new", options = {}) => {
+const useProxyHost = (id: number | "new", options: any = {}, agentId?: string) => {
 	return useQuery<ProxyHost, Error>({
-		queryKey: ["proxy-host", id],
-		queryFn: () => fetchProxyHost(id),
-		staleTime: 60 * 1000, // 1 minute
+		queryKey: ["proxy-host", id, { agentId }],
+		queryFn: () => fetchProxyHost(id, agentId),
+		staleTime: 60 * 1000,
 		...options,
 	});
 };
 
-const useSetProxyHost = () => {
+const useSetProxyHost = (agentId?: string) => {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: (values: ProxyHost) => (values.id ? updateProxyHost(values) : createProxyHost(values)),
+		mutationFn: (values: ProxyHost) => {
+			const payload = { ...values, agentId } as ProxyHost & { agentId?: string };
+			return values.id ? updateProxyHost(payload) : createProxyHost(payload);
+		},
 		onMutate: (values: ProxyHost) => {
 			if (!values.id) {
 				return;
 			}
-			const previousObject = queryClient.getQueryData(["proxy-host", values.id]);
-			queryClient.setQueryData(["proxy-host", values.id], (old: ProxyHost) => ({
+			const previousObject = queryClient.getQueryData(["proxy-host", values.id, { agentId }]);
+			queryClient.setQueryData(["proxy-host", values.id, { agentId }], (old: ProxyHost) => ({
 				...old,
 				...values,
 			}));
-			return () => queryClient.setQueryData(["proxy-host", values.id], previousObject);
+			return () => queryClient.setQueryData(["proxy-host", values.id, { agentId }], previousObject);
 		},
 		onError: (_, __, rollback: any) => rollback(),
 		onSuccess: async ({ id }: ProxyHost) => {

--- a/frontend/src/hooks/useProxyHosts.ts
+++ b/frontend/src/hooks/useProxyHosts.ts
@@ -1,14 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { getProxyHosts, type ProxyHost, type ProxyHostExpansion } from "src/api/backend";
 
-const fetchProxyHosts = (expand?: ProxyHostExpansion[]) => {
-	return getProxyHosts(expand);
+const fetchProxyHosts = (expand?: ProxyHostExpansion[], agentId?: string) => {
+	return getProxyHosts(expand, agentId && agentId !== "local" ? { agent_id: agentId } : {});
 };
 
-const useProxyHosts = (expand?: ProxyHostExpansion[], options = {}) => {
+const useProxyHosts = (expand?: ProxyHostExpansion[], options: any = {}, agentId?: string) => {
 	return useQuery<ProxyHost[], Error>({
-		queryKey: ["proxy-hosts", { expand }],
-		queryFn: () => fetchProxyHosts(expand),
+		queryKey: ["proxy-hosts", { expand, agentId }],
+		queryFn: () => fetchProxyHosts(expand, agentId),
 		staleTime: 60 * 1000,
 		...options,
 	});

--- a/frontend/src/hooks/useUser.ts
+++ b/frontend/src/hooks/useUser.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createUser, getUser, type User, updateUser } from "src/api/backend";
 
-const fetchUser = (id: number | string) => {
+const paramsForAgent = (agentId?: string) => (agentId && agentId !== "local" ? { agent_id: agentId } : {});
+
+const fetchUser = (id: number | string, agentId?: string) => {
 	if (id === "new") {
 		return Promise.resolve({
 			id: 0,
@@ -15,32 +17,32 @@ const fetchUser = (id: number | string) => {
 			avatar: "",
 		} as User);
 	}
-	return getUser(id, ["permissions"]);
+	return getUser(id, ["permissions"], paramsForAgent(agentId));
 };
 
-const useUser = (id: string | number, options = {}) => {
+const useUser = (id: string | number, options = {}, agentId?: string) => {
 	return useQuery<User, Error>({
-		queryKey: ["user", id],
-		queryFn: () => fetchUser(id),
+		queryKey: ["user", id, { agentId }],
+		queryFn: () => fetchUser(id, agentId),
 		staleTime: 60 * 1000, // 1 minute
 		...options,
 	});
 };
 
-const useSetUser = () => {
+const useSetUser = (agentId?: string) => {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: (values: User) => (values.id ? updateUser(values) : createUser(values)),
+		mutationFn: (values: User) => (values.id ? updateUser(values, agentId) : createUser(values, false, agentId)),
 		onMutate: (values: User) => {
 			if (!values.id) {
 				return;
 			}
-			const previousObject = queryClient.getQueryData(["user", values.id]);
-			queryClient.setQueryData(["user", values.id], (old: User) => ({
+			const previousObject = queryClient.getQueryData(["user", values.id, { agentId }]);
+			queryClient.setQueryData(["user", values.id, { agentId }], (old: User) => ({
 				...old,
 				...values,
 			}));
-			return () => queryClient.setQueryData(["user", values.id], previousObject);
+			return () => queryClient.setQueryData(["user", values.id, { agentId }], previousObject);
 		},
 		onError: (_, __, rollback: any) => rollback(),
 		onSuccess: async ({ id }: User) => {

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -1,14 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { getUsers, type User, type UserExpansion } from "src/api/backend";
 
-const fetchUsers = (expand?: UserExpansion[]) => {
-	return getUsers(expand);
+const paramsForAgent = (agentId?: string) => (agentId && agentId !== "local" ? { agent_id: agentId } : {});
+
+const fetchUsers = (expand?: UserExpansion[], agentId?: string) => {
+	return getUsers(expand, paramsForAgent(agentId));
 };
 
-const useUsers = (expand?: UserExpansion[], options = {}) => {
+const useUsers = (expand?: UserExpansion[], options = {}, agentId?: string) => {
 	return useQuery<User[], Error>({
-		queryKey: ["users", { expand }],
-		queryFn: () => fetchUsers(expand),
+		queryKey: ["users", { expand, agentId }],
+		queryFn: () => fetchUsers(expand, agentId),
 		staleTime: 60 * 1000,
 		...options,
 	});

--- a/frontend/src/locale/src/bg.json
+++ b/frontend/src/locale/src/bg.json
@@ -77,6 +77,9 @@
 	"auditlogs": {
 		"defaultMessage": "Журнали за одит"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Автоматично"
 	},

--- a/frontend/src/locale/src/bg.json
+++ b/frontend/src/locale/src/bg.json
@@ -74,11 +74,11 @@
 	"action.view-details": {
 		"defaultMessage": "Преглед на детайли"
 	},
-	"auditlogs": {
-		"defaultMessage": "Журнали за одит"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Журнали за одит"
 	},
 	"auto": {
 		"defaultMessage": "Автоматично"

--- a/frontend/src/locale/src/cs.json
+++ b/frontend/src/locale/src/cs.json
@@ -134,6 +134,9 @@
 	"auditlogs": {
 		"defaultMessage": "Záznamy auditu"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Automaticky"
 	},

--- a/frontend/src/locale/src/cs.json
+++ b/frontend/src/locale/src/cs.json
@@ -131,11 +131,11 @@
 	"action.view-details": {
 		"defaultMessage": "Zobrazit podrobnosti"
 	},
-	"auditlogs": {
-		"defaultMessage": "Záznamy auditu"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Záznamy auditu"
 	},
 	"auto": {
 		"defaultMessage": "Automaticky"

--- a/frontend/src/locale/src/de.json
+++ b/frontend/src/locale/src/de.json
@@ -68,6 +68,9 @@
 	"auditlogs": {
 		"defaultMessage": "Protokolle"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"cancel": {
 		"defaultMessage": "Abbrechen"
 	},

--- a/frontend/src/locale/src/de.json
+++ b/frontend/src/locale/src/de.json
@@ -65,11 +65,11 @@
 	"action.view-details": {
 		"defaultMessage": "Details anzeigen"
 	},
-	"auditlogs": {
-		"defaultMessage": "Protokolle"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Protokolle"
 	},
 	"cancel": {
 		"defaultMessage": "Abbrechen"

--- a/frontend/src/locale/src/en.json
+++ b/frontend/src/locale/src/en.json
@@ -134,6 +134,9 @@
 	"auditlogs": {
 		"defaultMessage": "Audit Logs"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Auto"
 	},

--- a/frontend/src/locale/src/en.json
+++ b/frontend/src/locale/src/en.json
@@ -131,11 +131,11 @@
 	"action.view-details": {
 		"defaultMessage": "View Details"
 	},
-	"auditlogs": {
-		"defaultMessage": "Audit Logs"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Audit Logs"
 	},
 	"auto": {
 		"defaultMessage": "Auto"

--- a/frontend/src/locale/src/es.json
+++ b/frontend/src/locale/src/es.json
@@ -77,6 +77,9 @@
 	"auditlogs": {
 		"defaultMessage": "Registros de Auditoría"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Auto"
 	},

--- a/frontend/src/locale/src/es.json
+++ b/frontend/src/locale/src/es.json
@@ -74,11 +74,11 @@
 	"action.view-details": {
 		"defaultMessage": "Ver Detalles"
 	},
-	"auditlogs": {
-		"defaultMessage": "Registros de Auditoría"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Registros de Auditoría"
 	},
 	"auto": {
 		"defaultMessage": "Auto"

--- a/frontend/src/locale/src/et.json
+++ b/frontend/src/locale/src/et.json
@@ -134,6 +134,9 @@
 	"auditlogs": {
 		"defaultMessage": "Audit Logs"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Auto"
 	},

--- a/frontend/src/locale/src/et.json
+++ b/frontend/src/locale/src/et.json
@@ -131,11 +131,11 @@
 	"action.view-details": {
 		"defaultMessage": "View Details"
 	},
-	"auditlogs": {
-		"defaultMessage": "Audit Logs"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Audit Logs"
 	},
 	"auto": {
 		"defaultMessage": "Auto"

--- a/frontend/src/locale/src/fr.json
+++ b/frontend/src/locale/src/fr.json
@@ -134,6 +134,9 @@
 	"auditlogs": {
 		"defaultMessage": "Journaux d'audit"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Auto"
 	},

--- a/frontend/src/locale/src/fr.json
+++ b/frontend/src/locale/src/fr.json
@@ -131,11 +131,11 @@
 	"action.view-details": {
 		"defaultMessage": "Voir les Détails"
 	},
-	"auditlogs": {
-		"defaultMessage": "Journaux d'audit"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Journaux d'audit"
 	},
 	"auto": {
 		"defaultMessage": "Auto"

--- a/frontend/src/locale/src/ga.json
+++ b/frontend/src/locale/src/ga.json
@@ -77,6 +77,9 @@
 	"auditlogs": {
 		"defaultMessage": "Logaí Iniúchta"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Uath"
 	},

--- a/frontend/src/locale/src/ga.json
+++ b/frontend/src/locale/src/ga.json
@@ -74,11 +74,11 @@
 	"action.view-details": {
 		"defaultMessage": "Féach Sonraí"
 	},
-	"auditlogs": {
-		"defaultMessage": "Logaí Iniúchta"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Logaí Iniúchta"
 	},
 	"auto": {
 		"defaultMessage": "Uath"

--- a/frontend/src/locale/src/hu.json
+++ b/frontend/src/locale/src/hu.json
@@ -134,6 +134,9 @@
 	"auditlogs": {
 		"defaultMessage": "Audit naplók"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Automatikus"
 	},

--- a/frontend/src/locale/src/hu.json
+++ b/frontend/src/locale/src/hu.json
@@ -131,11 +131,11 @@
 	"action.view-details": {
 		"defaultMessage": "Részletek megtekintése"
 	},
-	"auditlogs": {
-		"defaultMessage": "Audit naplók"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Audit naplók"
 	},
 	"auto": {
 		"defaultMessage": "Automatikus"

--- a/frontend/src/locale/src/id.json
+++ b/frontend/src/locale/src/id.json
@@ -77,6 +77,9 @@
 	"auditlogs": {
 		"defaultMessage": "Log Audit"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Otomatis"
 	},

--- a/frontend/src/locale/src/id.json
+++ b/frontend/src/locale/src/id.json
@@ -74,11 +74,11 @@
 	"action.view-details": {
 		"defaultMessage": "Lihat Detail"
 	},
-	"auditlogs": {
-		"defaultMessage": "Log Audit"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Log Audit"
 	},
 	"auto": {
 		"defaultMessage": "Otomatis"

--- a/frontend/src/locale/src/it.json
+++ b/frontend/src/locale/src/it.json
@@ -68,6 +68,9 @@
 	"auditlogs": {
 		"defaultMessage": "Log di Audit"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"cancel": {
 		"defaultMessage": "Annulla"
 	},

--- a/frontend/src/locale/src/it.json
+++ b/frontend/src/locale/src/it.json
@@ -65,11 +65,11 @@
 	"action.view-details": {
 		"defaultMessage": "Visualizza Dettagli"
 	},
-	"auditlogs": {
-		"defaultMessage": "Log di Audit"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Log di Audit"
 	},
 	"cancel": {
 		"defaultMessage": "Annulla"

--- a/frontend/src/locale/src/ja.json
+++ b/frontend/src/locale/src/ja.json
@@ -68,6 +68,9 @@
 	"auditlogs": {
 		"defaultMessage": "監査ログ"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"cancel": {
 		"defaultMessage": "キャンセル"
 	},

--- a/frontend/src/locale/src/ja.json
+++ b/frontend/src/locale/src/ja.json
@@ -65,11 +65,11 @@
 	"action.view-details": {
 		"defaultMessage": "詳細"
 	},
-	"auditlogs": {
-		"defaultMessage": "監査ログ"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "監査ログ"
 	},
 	"cancel": {
 		"defaultMessage": "キャンセル"

--- a/frontend/src/locale/src/ko.json
+++ b/frontend/src/locale/src/ko.json
@@ -77,6 +77,9 @@
 	"auditlogs": {
 		"defaultMessage": "감사 로그"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "자동"
 	},

--- a/frontend/src/locale/src/ko.json
+++ b/frontend/src/locale/src/ko.json
@@ -74,11 +74,11 @@
 	"action.view-details": {
 		"defaultMessage": "자세히 보기"
 	},
-	"auditlogs": {
-		"defaultMessage": "감사 로그"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "감사 로그"
 	},
 	"auto": {
 		"defaultMessage": "자동"

--- a/frontend/src/locale/src/nl.json
+++ b/frontend/src/locale/src/nl.json
@@ -134,6 +134,9 @@
 	"auditlogs": {
 		"defaultMessage": "Logboeken"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Autom."
 	},

--- a/frontend/src/locale/src/nl.json
+++ b/frontend/src/locale/src/nl.json
@@ -131,11 +131,11 @@
 	"action.view-details": {
 		"defaultMessage": "Details weergeven"
 	},
-	"auditlogs": {
-		"defaultMessage": "Logboeken"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Logboeken"
 	},
 	"auto": {
 		"defaultMessage": "Autom."

--- a/frontend/src/locale/src/no.json
+++ b/frontend/src/locale/src/no.json
@@ -134,6 +134,9 @@
 	"auditlogs": {
 		"defaultMessage": "Revisjonslogger"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Auto"
 	},

--- a/frontend/src/locale/src/no.json
+++ b/frontend/src/locale/src/no.json
@@ -131,11 +131,11 @@
 	"action.view-details": {
 		"defaultMessage": "Vis detaljer"
 	},
-	"auditlogs": {
-		"defaultMessage": "Revisjonslogger"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Revisjonslogger"
 	},
 	"auto": {
 		"defaultMessage": "Auto"

--- a/frontend/src/locale/src/pl.json
+++ b/frontend/src/locale/src/pl.json
@@ -74,6 +74,9 @@
 	"auditlogs": {
 		"defaultMessage": "Logi"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"cancel": {
 		"defaultMessage": "Anuluj"
 	},

--- a/frontend/src/locale/src/pl.json
+++ b/frontend/src/locale/src/pl.json
@@ -71,11 +71,11 @@
 	"action.view-details": {
 		"defaultMessage": "Pokaż szczegóły"
 	},
-	"auditlogs": {
-		"defaultMessage": "Logi"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Logi"
 	},
 	"cancel": {
 		"defaultMessage": "Anuluj"

--- a/frontend/src/locale/src/pt.json
+++ b/frontend/src/locale/src/pt.json
@@ -77,6 +77,9 @@
 	"auditlogs": {
 		"defaultMessage": "Registos de Auditoria"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Automático"
 	},

--- a/frontend/src/locale/src/pt.json
+++ b/frontend/src/locale/src/pt.json
@@ -74,11 +74,11 @@
 	"action.view-details": {
 		"defaultMessage": "Ver Detalhes"
 	},
-	"auditlogs": {
-		"defaultMessage": "Registos de Auditoria"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Registos de Auditoria"
 	},
 	"auto": {
 		"defaultMessage": "Automático"

--- a/frontend/src/locale/src/ru.json
+++ b/frontend/src/locale/src/ru.json
@@ -134,6 +134,9 @@
 	"auditlogs": {
 		"defaultMessage": "Журнал аудита"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Авто"
 	},

--- a/frontend/src/locale/src/ru.json
+++ b/frontend/src/locale/src/ru.json
@@ -131,11 +131,11 @@
 	"action.view-details": {
 		"defaultMessage": "Просмотреть сведения"
 	},
-	"auditlogs": {
-		"defaultMessage": "Журнал аудита"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Журнал аудита"
 	},
 	"auto": {
 		"defaultMessage": "Авто"

--- a/frontend/src/locale/src/sk.json
+++ b/frontend/src/locale/src/sk.json
@@ -134,6 +134,9 @@
 	"auditlogs": {
 		"defaultMessage": "Záznamy auditu"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Automaticky"
 	},

--- a/frontend/src/locale/src/sk.json
+++ b/frontend/src/locale/src/sk.json
@@ -131,11 +131,11 @@
 	"action.view-details": {
 		"defaultMessage": "Zobraziť podrobnosti"
 	},
-	"auditlogs": {
-		"defaultMessage": "Záznamy auditu"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Záznamy auditu"
 	},
 	"auto": {
 		"defaultMessage": "Automaticky"

--- a/frontend/src/locale/src/tr.json
+++ b/frontend/src/locale/src/tr.json
@@ -77,6 +77,9 @@
 	"auditlogs": {
 		"defaultMessage": "Denetim Kayıtları"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"auto": {
 		"defaultMessage": "Otomatik"
 	},

--- a/frontend/src/locale/src/tr.json
+++ b/frontend/src/locale/src/tr.json
@@ -74,11 +74,11 @@
 	"action.view-details": {
 		"defaultMessage": "Detayları Görüntüle"
 	},
-	"auditlogs": {
-		"defaultMessage": "Denetim Kayıtları"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Denetim Kayıtları"
 	},
 	"auto": {
 		"defaultMessage": "Otomatik"

--- a/frontend/src/locale/src/vi.json
+++ b/frontend/src/locale/src/vi.json
@@ -68,6 +68,9 @@
 	"auditlogs": {
 		"defaultMessage": "Nhật ký kiểm tra"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"cancel": {
 		"defaultMessage": "Hủy"
 	},

--- a/frontend/src/locale/src/vi.json
+++ b/frontend/src/locale/src/vi.json
@@ -65,11 +65,11 @@
 	"action.view-details": {
 		"defaultMessage": "Xem Chi tiết"
 	},
-	"auditlogs": {
-		"defaultMessage": "Nhật ký kiểm tra"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "Nhật ký kiểm tra"
 	},
 	"cancel": {
 		"defaultMessage": "Hủy"

--- a/frontend/src/locale/src/zh.json
+++ b/frontend/src/locale/src/zh.json
@@ -68,6 +68,9 @@
 	"auditlogs": {
 		"defaultMessage": "审计日志"
 	},
+	"agents": {
+		"defaultMessage": "Agents"
+	},
 	"cancel": {
 		"defaultMessage": "取消"
 	},

--- a/frontend/src/locale/src/zh.json
+++ b/frontend/src/locale/src/zh.json
@@ -65,11 +65,11 @@
 	"action.view-details": {
 		"defaultMessage": "查看详情"
 	},
-	"auditlogs": {
-		"defaultMessage": "审计日志"
-	},
 	"agents": {
 		"defaultMessage": "Agents"
+	},
+	"auditlogs": {
+		"defaultMessage": "审计日志"
 	},
 	"cancel": {
 		"defaultMessage": "取消"

--- a/frontend/src/modals/CustomCertificateModal.tsx
+++ b/frontend/src/modals/CustomCertificateModal.tsx
@@ -11,11 +11,16 @@ import { T } from "src/locale";
 import { validateString } from "src/modules/Validations";
 import { showObjectSuccess } from "src/notifications";
 
-const showCustomCertificateModal = () => {
-	EasyModal.show(CustomCertificateModal);
+const showCustomCertificateModal = (agentId?: string, agentName?: string) => {
+	EasyModal.show(CustomCertificateModal as any, { agentId, agentName });
 };
 
-const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModalProps) => {
+interface Props extends InnerModalProps {
+	agentId?: string;
+	agentName?: string;
+}
+
+const CustomCertificateModal = EasyModal.create(({ agentId, agentName, visible, remove }: Props) => {
 	const queryClient = useQueryClient();
 	const [errorMsg, setErrorMsg] = useState<ReactNode | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -36,13 +41,13 @@ const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModal
 			}
 
 			// Validate
-			await validateCertificate(formData);
+			await validateCertificate(formData, agentId);
 
 			// Create certificate, as other without anything else
-			const cert = await createCertificate({ niceName, provider } as Certificate);
+			const cert = await createCertificate({ niceName, provider } as Certificate, agentId);
 
 			// Upload the certificates to the created certificate
-			await uploadCertificate(cert.id, formData);
+			await uploadCertificate(cert.id, formData, agentId);
 
 			// Success
 			showObjectSuccess("certificate", "saved");
@@ -75,6 +80,7 @@ const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModal
 						<Modal.Header closeButton>
 							<Modal.Title>
 								<T id="object.add" tData={{ object: "certificates.custom" }} />
+									{agentName ? <span className="ms-2 text-muted small">on {agentName}</span> : null}
 							</Modal.Title>
 						</Modal.Header>
 						<Modal.Body className="p-0">

--- a/frontend/src/modals/DNSCertificateModal.tsx
+++ b/frontend/src/modals/DNSCertificateModal.tsx
@@ -9,11 +9,16 @@ import { Button, DNSProviderFields, DomainNamesField } from "src/components";
 import { T } from "src/locale";
 import { showObjectSuccess } from "src/notifications";
 
-const showDNSCertificateModal = () => {
-	EasyModal.show(DNSCertificateModal);
+const showDNSCertificateModal = (agentId?: string, agentName?: string) => {
+	EasyModal.show(DNSCertificateModal as any, { agentId, agentName });
 };
 
-const DNSCertificateModal = EasyModal.create(({ visible, remove }: InnerModalProps) => {
+interface Props extends InnerModalProps {
+	agentId?: string;
+	agentName?: string;
+}
+
+const DNSCertificateModal = EasyModal.create(({ agentId, agentName, visible, remove }: Props) => {
 	const queryClient = useQueryClient();
 	const [errorMsg, setErrorMsg] = useState<ReactNode | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -24,7 +29,7 @@ const DNSCertificateModal = EasyModal.create(({ visible, remove }: InnerModalPro
 		setErrorMsg(null);
 
 		try {
-			await createCertificate(values);
+			await createCertificate(values, agentId);
 			showObjectSuccess("certificate", "saved");
 			remove();
 		} catch (err: any) {
@@ -55,6 +60,7 @@ const DNSCertificateModal = EasyModal.create(({ visible, remove }: InnerModalPro
 						<Modal.Header closeButton>
 							<Modal.Title>
 								<T id="object.add" tData={{ object: "lets-encrypt-via-dns" }} />
+									{agentName ? <span className="ms-2 text-muted small">on {agentName}</span> : null}
 							</Modal.Title>
 						</Modal.Header>
 						<Modal.Body className="p-0">

--- a/frontend/src/modals/HTTPCertificateModal.tsx
+++ b/frontend/src/modals/HTTPCertificateModal.tsx
@@ -10,11 +10,16 @@ import { Button, DomainNamesField } from "src/components";
 import { T } from "src/locale";
 import { showObjectSuccess } from "src/notifications";
 
-const showHTTPCertificateModal = () => {
-	EasyModal.show(HTTPCertificateModal);
+const showHTTPCertificateModal = (agentId?: string, agentName?: string) => {
+	EasyModal.show(HTTPCertificateModal as any, { agentId, agentName });
 };
 
-const HTTPCertificateModal = EasyModal.create(({ visible, remove }: InnerModalProps) => {
+interface Props extends InnerModalProps {
+	agentId?: string;
+	agentName?: string;
+}
+
+const HTTPCertificateModal = EasyModal.create(({ agentId, agentName, visible, remove }: Props) => {
 	const queryClient = useQueryClient();
 	const [errorMsg, setErrorMsg] = useState<ReactNode | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -28,7 +33,7 @@ const HTTPCertificateModal = EasyModal.create(({ visible, remove }: InnerModalPr
 		setErrorMsg(null);
 
 		try {
-			await createCertificate(values);
+			await createCertificate(values, agentId);
 			showObjectSuccess("certificate", "saved");
 			remove();
 		} catch (err: any) {
@@ -44,7 +49,7 @@ const HTTPCertificateModal = EasyModal.create(({ visible, remove }: InnerModalPr
 		setErrorMsg(null);
 		setTestResults(null);
 		try {
-			const result = await testHttpCertificate(domains);
+			const result = await testHttpCertificate(domains, agentId);
 			setTestResults(result);
 		} catch (err: any) {
 			setErrorMsg(<T id={err.message} />);
@@ -127,6 +132,7 @@ const HTTPCertificateModal = EasyModal.create(({ visible, remove }: InnerModalPr
 						<Modal.Header closeButton>
 							<Modal.Title>
 								<T id="object.add" tData={{ object: "lets-encrypt-via-http" }} />
+									{agentName ? <span className="ms-2 text-muted small">on {agentName}</span> : null}
 							</Modal.Title>
 						</Modal.Header>
 						<Modal.Body className="p-0">

--- a/frontend/src/modals/PermissionsModal.tsx
+++ b/frontend/src/modals/PermissionsModal.tsx
@@ -11,17 +11,19 @@ import { useUser } from "src/hooks";
 import { T } from "src/locale";
 import styles from "./PermissionsModal.module.css";
 
-const showPermissionsModal = (id: number) => {
-	EasyModal.show(PermissionsModal, { id });
+const showPermissionsModal = (id: number, agentId?: string, agentName?: string) => {
+	EasyModal.show(PermissionsModal as any, { id, agentId, agentName });
 };
 
 interface Props extends InnerModalProps {
 	id: number;
+	agentId?: string;
+	agentName?: string;
 }
-const PermissionsModal = EasyModal.create(({ id, visible, remove }: Props) => {
+const PermissionsModal = EasyModal.create(({ id, agentId, agentName, visible, remove }: Props) => {
 	const queryClient = useQueryClient();
 	const [errorMsg, setErrorMsg] = useState<ReactNode | null>(null);
-	const { data, isLoading, error } = useUser(id);
+	const { data, isLoading, error } = useUser(id, {}, agentId);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const onSubmit = async (values: any, { setSubmitting }: any) => {
@@ -29,7 +31,7 @@ const PermissionsModal = EasyModal.create(({ id, visible, remove }: Props) => {
 		setIsSubmitting(true);
 		setErrorMsg(null);
 		try {
-			await setPermissions(id, values);
+			await setPermissions(id, values, agentId);
 			remove();
 			queryClient.invalidateQueries({ queryKey: ["users"] });
 			queryClient.invalidateQueries({ queryKey: ["user"] });
@@ -160,6 +162,7 @@ const PermissionsModal = EasyModal.create(({ id, visible, remove }: Props) => {
 							<Modal.Header closeButton>
 								<Modal.Title>
 									<T id="user.set-permissions" data={{ name: data?.name }} />
+									{agentName ? <span className="ms-2 text-muted small">on {agentName}</span> : null}
 								</Modal.Title>
 							</Modal.Header>
 							<Modal.Body>

--- a/frontend/src/modals/ProxyHostModal.tsx
+++ b/frontend/src/modals/ProxyHostModal.tsx
@@ -22,17 +22,18 @@ import { MANAGE, PROXY_HOSTS } from "src/modules/Permissions";
 import { validateNumber, validateString } from "src/modules/Validations";
 import { showObjectSuccess } from "src/notifications";
 
-const showProxyHostModal = (id: number | "new") => {
-	EasyModal.show(ProxyHostModal, { id });
+const showProxyHostModal = (id: number | "new", agentId?: string) => {
+	EasyModal.show(ProxyHostModal as any, { id, agentId });
 };
 
 interface Props extends InnerModalProps {
 	id: number | "new";
+	agentId?: string;
 }
-const ProxyHostModal = EasyModal.create(({ id, visible, remove }: Props) => {
+const ProxyHostModal = EasyModal.create(({ id, agentId, visible, remove }: Props) => {
 	const { data: currentUser, isLoading: userIsLoading, error: userError } = useUser("me");
-	const { data, isLoading, error } = useProxyHost(id);
-	const { mutate: setProxyHost } = useSetProxyHost();
+	const { data, isLoading, error } = useProxyHost(id, {}, agentId);
+	const { mutate: setProxyHost } = useSetProxyHost(agentId);
 	const [errorMsg, setErrorMsg] = useState<ReactNode | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -253,7 +254,7 @@ const ProxyHostModal = EasyModal.create(({ id, visible, remove }: Props) => {
 														</Field>
 													</div>
 												</div>
-												<AccessField />
+												<AccessField agentId={agentId} />
 												<div className="my-3">
 													<h4 className="py-2">
 														<T id="options" />
@@ -339,6 +340,7 @@ const ProxyHostModal = EasyModal.create(({ id, visible, remove }: Props) => {
 													name="certificateId"
 													label="ssl-certificate"
 													allowNew
+								agentId={agentId}
 												/>
 												<SSLOptionsFields color="bg-lime" forProxyHost={true} />
 											</div>

--- a/frontend/src/modals/RenewCertificateModal.tsx
+++ b/frontend/src/modals/RenewCertificateModal.tsx
@@ -11,15 +11,17 @@ import { showObjectSuccess } from "src/notifications";
 
 interface Props extends InnerModalProps {
 	id: number;
+	agentId?: string;
+	agentName?: string;
 }
 
-const showRenewCertificateModal = (id: number) => {
-	EasyModal.show(RenewCertificateModal, { id });
+const showRenewCertificateModal = (id: number, agentId?: string, agentName?: string) => {
+	EasyModal.show(RenewCertificateModal as any, { id, agentId, agentName });
 };
 
-const RenewCertificateModal = EasyModal.create(({ id, visible, remove }: Props) => {
+const RenewCertificateModal = EasyModal.create(({ id, agentId, agentName, visible, remove }: Props) => {
 	const queryClient = useQueryClient();
-	const { data, isLoading, error } = useCertificate(id);
+	const { data, isLoading, error } = useCertificate(id, {}, agentId);
 	const [errorMsg, setErrorMsg] = useState<ReactNode | null>(null);
 	const [isFresh, setIsFresh] = useState(true);
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -29,7 +31,7 @@ const RenewCertificateModal = EasyModal.create(({ id, visible, remove }: Props) 
 		setIsFresh(false);
 		setIsSubmitting(true);
 
-		renewCertificate(id)
+		renewCertificate(id, agentId)
 			.then(() => {
 				showObjectSuccess("certificate", "renewed");
 				queryClient.invalidateQueries({ queryKey: ["certificates"] });
@@ -41,13 +43,14 @@ const RenewCertificateModal = EasyModal.create(({ id, visible, remove }: Props) 
 			.finally(() => {
 				setIsSubmitting(false);
 			});
-	}, [id, data, isFresh, isSubmitting, remove, queryClient]);
+	}, [id, agentId, data, isFresh, isSubmitting, remove, queryClient]);
 
 	return (
 		<Modal show={visible} onHide={isSubmitting ? undefined : remove}>
 			<Modal.Header closeButton={!isSubmitting}>
 				<Modal.Title>
 					<T id="certificate.renew" />
+					{agentName ? <span className="ms-2 text-muted small">on {agentName}</span> : null}
 				</Modal.Title>
 			</Modal.Header>
 			<Modal.Body>

--- a/frontend/src/modals/SetPasswordModal.tsx
+++ b/frontend/src/modals/SetPasswordModal.tsx
@@ -9,14 +9,16 @@ import { Button } from "src/components";
 import { intl, T } from "src/locale";
 import { validateString } from "src/modules/Validations";
 
-const showSetPasswordModal = (id: number) => {
-	EasyModal.show(SetPasswordModal, { id });
+const showSetPasswordModal = (id: number, agentId?: string, agentName?: string) => {
+	EasyModal.show(SetPasswordModal as any, { id, agentId, agentName });
 };
 
 interface Props extends InnerModalProps {
 	id: number;
+	agentId?: string;
+	agentName?: string;
 }
-const SetPasswordModal = EasyModal.create(({ id, visible, remove }: Props) => {
+const SetPasswordModal = EasyModal.create(({ id, agentId, agentName, visible, remove }: Props) => {
 	const [error, setError] = useState<ReactNode | null>(null);
 	const [showPassword, setShowPassword] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -25,7 +27,7 @@ const SetPasswordModal = EasyModal.create(({ id, visible, remove }: Props) => {
 		if (isSubmitting) return;
 		setError(null);
 		try {
-			await updateAuth(id, values.new);
+			await updateAuth(id, values.new, undefined, agentId);
 			remove();
 		} catch (err: any) {
 			setError(<T id={err.message} />);
@@ -49,6 +51,7 @@ const SetPasswordModal = EasyModal.create(({ id, visible, remove }: Props) => {
 						<Modal.Header closeButton>
 							<Modal.Title>
 								<T id="user.set-password" />
+					{agentName ? <span className="ms-2 text-muted small">on {agentName}</span> : null}
 							</Modal.Title>
 						</Modal.Header>
 						<Modal.Body>

--- a/frontend/src/modals/UserModal.tsx
+++ b/frontend/src/modals/UserModal.tsx
@@ -9,17 +9,19 @@ import { intl, T } from "src/locale";
 import { validateEmail, validateString } from "src/modules/Validations";
 import { showObjectSuccess } from "src/notifications";
 
-const showUserModal = (id: number | "me" | "new") => {
-	EasyModal.show(UserModal, { id });
+const showUserModal = (id: number | "me" | "new", agentId?: string, agentName?: string) => {
+	EasyModal.show(UserModal as any, { id, agentId, agentName });
 };
 
 interface Props extends InnerModalProps {
 	id: number | "me" | "new";
+	agentId?: string;
+	agentName?: string;
 }
-const UserModal = EasyModal.create(({ id, visible, remove }: Props) => {
-	const { data, isLoading, error } = useUser(id);
-	const { data: currentUser, isLoading: currentIsLoading } = useUser("me");
-	const { mutate: setUser } = useSetUser();
+const UserModal = EasyModal.create(({ id, agentId, agentName, visible, remove }: Props) => {
+	const { data, isLoading, error } = useUser(id, {}, agentId);
+	const { data: currentUser, isLoading: currentIsLoading } = useUser("me", {}, agentId);
+	const { mutate: setUser } = useSetUser(agentId);
 	const [errorMsg, setErrorMsg] = useState<string | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -84,6 +86,7 @@ const UserModal = EasyModal.create(({ id, visible, remove }: Props) => {
 							<Modal.Header closeButton>
 								<Modal.Title>
 									<T id={data?.id ? "object.edit" : "object.add"} tData={{ object: "user" }} />
+									{agentName ? <span className="ms-2 text-muted small">on {agentName}</span> : null}
 								</Modal.Title>
 							</Modal.Header>
 							<Modal.Body>

--- a/frontend/src/modules/Pwa.ts
+++ b/frontend/src/modules/Pwa.ts
@@ -1,0 +1,63 @@
+type RegisterPwaOptions = {
+	onOfflineReady?: () => void;
+	onUpdateReady?: (activateUpdate: () => void) => void;
+};
+
+function listenForWaitingWorker(registration: ServiceWorkerRegistration, onUpdateReady?: (activateUpdate: () => void) => void) {
+	const notify = (worker?: ServiceWorker | null) => {
+		if (!worker || !onUpdateReady) {
+			return;
+		}
+
+		onUpdateReady(() => worker.postMessage({ type: "SKIP_WAITING" }));
+	};
+
+	if (registration.waiting) {
+		notify(registration.waiting);
+	}
+
+	registration.addEventListener("updatefound", () => {
+		const worker = registration.installing;
+		worker?.addEventListener("statechange", () => {
+			if (worker.state === "installed" && navigator.serviceWorker.controller) {
+				notify(worker);
+			}
+		});
+	});
+}
+
+export function registerPwa({ onOfflineReady, onUpdateReady }: RegisterPwaOptions = {}) {
+	if (!import.meta.env.PROD || !("serviceWorker" in navigator)) {
+		return;
+	}
+
+	window.addEventListener("load", () => {
+		navigator.serviceWorker
+			.register("/sw.js")
+			.then((registration) => {
+				listenForWaitingWorker(registration, onUpdateReady);
+				if (!navigator.serviceWorker.controller) {
+					registration.addEventListener("updatefound", () => {
+						const worker = registration.installing;
+						worker?.addEventListener("statechange", () => {
+							if (worker.state === "installed") {
+								onOfflineReady?.();
+							}
+						});
+					});
+				}
+			})
+			.catch((error) => {
+				console.error("Failed to register service worker", error);
+			});
+	});
+
+	let refreshing = false;
+	navigator.serviceWorker.addEventListener("controllerchange", () => {
+		if (refreshing) {
+			return;
+		}
+		refreshing = true;
+		window.location.reload();
+	});
+}

--- a/frontend/src/pages/Agents/index.tsx
+++ b/frontend/src/pages/Agents/index.tsx
@@ -1,0 +1,100 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import Alert from "react-bootstrap/Alert";
+import { createAgent, deleteAgent, testAgent } from "src/api/backend";
+import { Button, LoadingPage } from "src/components";
+import { useAgents } from "src/hooks";
+
+export default function Agents() {
+	const queryClient = useQueryClient();
+	const { data, isLoading, isError, error } = useAgents();
+	const [form, setForm] = useState({ name: "", url: "", identity: "", secret: "" });
+	const [message, setMessage] = useState<string | null>(null);
+	const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+	if (isLoading) return <LoadingPage />;
+	if (isError) return <Alert variant="danger">{error?.message || "Unknown error"}</Alert>;
+
+	const refresh = () => queryClient.invalidateQueries({ queryKey: ["agents"] });
+	const setValue = (key: string, value: string) => setForm((old) => ({ ...old, [key]: value }));
+
+	const addAgent = async () => {
+		setMessage(null);
+		setErrorMsg(null);
+		try {
+			await createAgent(form);
+			setForm({ name: "", url: "", identity: "", secret: "" });
+			setMessage("Agent added");
+			refresh();
+		} catch (err: any) {
+			setErrorMsg(err.message || `${err}`);
+		}
+	};
+
+	const test = async (id: number) => {
+		setMessage(null);
+		setErrorMsg(null);
+		try {
+			await testAgent(id);
+			setMessage("Agent test succeeded");
+			refresh();
+		} catch (err: any) {
+			setErrorMsg(err.message || `${err}`);
+		}
+	};
+
+	const remove = async (id: number) => {
+		setMessage(null);
+		setErrorMsg(null);
+		try {
+			await deleteAgent(id);
+			setMessage("Agent deleted");
+			refresh();
+		} catch (err: any) {
+			setErrorMsg(err.message || `${err}`);
+		}
+	};
+
+	return (
+		<div className="card mt-4">
+			<div className="card-status-top bg-blue" />
+			<div className="card-header">
+				<h2 className="mb-0">Agents</h2>
+			</div>
+			<div className="card-body">
+				{message ? <Alert variant="success">{message}</Alert> : null}
+				{errorMsg ? <Alert variant="danger">{errorMsg}</Alert> : null}
+				<p className="text-muted">
+					Add remote Nginx Proxy Manager instances. The proxy host page can then switch nodes and forward
+					operations to the selected instance.
+				</p>
+				<div className="row g-2 mb-4">
+					<div className="col-md-2"><input className="form-control" placeholder="Name" value={form.name} onChange={(e) => setValue("name", e.target.value)} /></div>
+					<div className="col-md-4"><input className="form-control" placeholder="URL, e.g. https://npm.example.com" value={form.url} onChange={(e) => setValue("url", e.target.value)} /></div>
+					<div className="col-md-2"><input className="form-control" placeholder="Email" value={form.identity} onChange={(e) => setValue("identity", e.target.value)} /></div>
+					<div className="col-md-2"><input className="form-control" placeholder="Password" type="password" value={form.secret} onChange={(e) => setValue("secret", e.target.value)} /></div>
+					<div className="col-md-2"><Button className="btn-primary w-100" onClick={addAgent}>Add</Button></div>
+				</div>
+				<div className="table-responsive">
+					<table className="table table-vcenter">
+						<thead><tr><th>Name</th><th>URL</th><th>Login</th><th>Status</th><th className="w-1">Actions</th></tr></thead>
+						<tbody>
+							{data?.map((agent) => (
+								<tr key={agent.id}>
+									<td>{agent.name}</td>
+									<td>{agent.url}</td>
+									<td>{agent.identity}</td>
+									<td>{agent.meta?.lastTest?.ok ? "online" : agent.enabled ? "unknown" : "disabled"}</td>
+									<td className="text-nowrap">
+										<Button size="sm" className="me-2" onClick={() => test(agent.id)}>Test</Button>
+										<Button size="sm" className="btn-danger" onClick={() => remove(agent.id)}>Delete</Button>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/pages/Certificates/Table.tsx
+++ b/frontend/src/pages/Certificates/Table.tsx
@@ -1,6 +1,6 @@
 import { IconDotsVertical, IconDownload, IconRefresh, IconTrash } from "@tabler/icons-react";
 import { createColumnHelper, getCoreRowModel, useReactTable } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import type { Certificate } from "src/api/backend";
 import {
 	CertificateInUseFormatter,
@@ -12,7 +12,6 @@ import {
 } from "src/components";
 import { TableLayout } from "src/components/Table/TableLayout";
 import { intl, T } from "src/locale";
-import { showCustomCertificateModal, showDNSCertificateModal, showHTTPCertificateModal } from "src/modals";
 import { CERTIFICATES, MANAGE } from "src/modules/Permissions";
 
 interface Props {
@@ -22,8 +21,9 @@ interface Props {
 	onDelete?: (id: number) => void;
 	onRenew?: (id: number) => void;
 	onDownload?: (id: number) => void;
+	customAddBtn?: ReactNode;
 }
-export default function Table({ data, isFetching, onDelete, onRenew, onDownload, isFiltered }: Props) {
+export default function Table({ data, isFetching, onDelete, onRenew, onDownload, isFiltered, customAddBtn }: Props) {
 	const columnHelper = createColumnHelper<Certificate>();
 	const columns = useMemo(
 		() => [
@@ -174,47 +174,6 @@ export default function Table({ data, isFetching, onDelete, onRenew, onDownload,
 		},
 		enableSortingRemoval: false,
 	});
-
-	const customAddBtn = (
-		<div className="dropdown">
-			<button type="button" className="btn dropdown-toggle btn-pink my-3" data-bs-toggle="dropdown">
-				<T id="object.add" tData={{ object: "certificate" }} />
-			</button>
-			<div className="dropdown-menu">
-				<a
-					className="dropdown-item"
-					href="#"
-					onClick={(e) => {
-						e.preventDefault();
-						showHTTPCertificateModal();
-					}}
-				>
-					<T id="lets-encrypt-via-http" />
-				</a>
-				<a
-					className="dropdown-item"
-					href="#"
-					onClick={(e) => {
-						e.preventDefault();
-						showDNSCertificateModal();
-					}}
-				>
-					<T id="lets-encrypt-via-dns" />
-				</a>
-				<div className="dropdown-divider" />
-				<a
-					className="dropdown-item"
-					href="#"
-					onClick={(e) => {
-						e.preventDefault();
-						showCustomCertificateModal();
-					}}
-				>
-					<T id="certificates.custom" />
-				</a>
-			</div>
-		</div>
-	);
 
 	return (
 		<TableLayout

--- a/frontend/src/pages/Certificates/TableWrapper.tsx
+++ b/frontend/src/pages/Certificates/TableWrapper.tsx
@@ -1,9 +1,9 @@
 import { IconHelp, IconSearch } from "@tabler/icons-react";
 import { useState } from "react";
 import Alert from "react-bootstrap/Alert";
-import { deleteCertificate, downloadCertificate } from "src/api/backend";
-import { Button, HasPermission, LoadingPage } from "src/components";
-import { useCertificates } from "src/hooks";
+import { deleteCertificate, downloadCertificate, type Certificate } from "src/api/backend";
+import { AgentSection, Button, HasPermission, LoadingPage } from "src/components";
+import { type AgentTarget, useAgentTargets, useCertificates } from "src/hooks";
 import { T } from "src/locale";
 import {
 	showCustomCertificateModal,
@@ -17,15 +17,121 @@ import { CERTIFICATES, MANAGE } from "src/modules/Permissions";
 import { showError, showObjectSuccess } from "src/notifications";
 import Table from "./Table";
 
+const filterCertificates = (data: Certificate[], search: string) => {
+	if (!search) return data;
+	return data.filter(
+		(item) =>
+			item.domainNames.some((domain: string) => domain.toLowerCase().includes(search)) ||
+			item.niceName.toLowerCase().includes(search),
+	);
+};
+
+function AddCertificateDropdown({ target, size = "sm" }: { target: AgentTarget; size?: "sm" | undefined }) {
+	return (
+		<div className="dropdown">
+			<button type="button" className={`btn ${size ? `btn-${size}` : ""} dropdown-toggle btn-pink`} data-bs-toggle="dropdown">
+				<T id="object.add" tData={{ object: "certificate" }} />
+			</button>
+			<div className="dropdown-menu">
+				<a
+					className="dropdown-item"
+					href="#"
+					onClick={(e) => {
+						e.preventDefault();
+						showHTTPCertificateModal(target.id, target.name);
+					}}
+				>
+					<T id="lets-encrypt-via-http" />
+				</a>
+				<a
+					className="dropdown-item"
+					href="#"
+					onClick={(e) => {
+						e.preventDefault();
+						showDNSCertificateModal(target.id, target.name);
+					}}
+				>
+					<T id="lets-encrypt-via-dns" />
+				</a>
+				<div className="dropdown-divider" />
+				<a
+					className="dropdown-item"
+					href="#"
+					onClick={(e) => {
+						e.preventDefault();
+						showCustomCertificateModal(target.id, target.name);
+					}}
+				>
+					<T id="certificates.custom" />
+				</a>
+			</div>
+		</div>
+	);
+}
+
+function CertificateAgentSection({ target, search }: { target: AgentTarget; search: string }) {
+	const query = useCertificates(["owner", "dead_hosts", "proxy_hosts", "redirection_hosts", "streams"], {}, target.id);
+	const data = query.data ?? [];
+	const filtered = filterCertificates(data, search);
+
+	const handleDelete = async (id: number) => {
+		await deleteCertificate(id, target.id);
+		showObjectSuccess("certificate", "deleted");
+	};
+
+	const handleDownload = async (id: number) => {
+		try {
+			await downloadCertificate(id, target.id);
+		} catch (err: any) {
+			showError(err.message);
+		}
+	};
+
+	return (
+		<AgentSection
+			target={target}
+			color="pink"
+			isLoading={query.isLoading}
+			isFetching={query.isFetching}
+			isError={query.isError}
+			error={query.error}
+			shownCount={filtered.length}
+			totalCount={data.length}
+			onRetry={() => query.refetch()}
+			actions={
+				<HasPermission section={CERTIFICATES} permission={MANAGE} hideError>
+					<AddCertificateDropdown target={target} />
+				</HasPermission>
+			}
+		>
+			<Table
+				data={filtered}
+				isFiltered={!!search}
+				isFetching={query.isFetching}
+				onRenew={(id: number) => showRenewCertificateModal(id, target.id, target.name)}
+				onDownload={handleDownload}
+				customAddBtn={<AddCertificateDropdown target={target} size={undefined} />}
+				onDelete={(id: number) =>
+					showDeleteConfirmModal({
+						title: <T id="object.delete" tData={{ object: "certificate" }} />,
+						onConfirm: () => handleDelete(id),
+						invalidations: [["certificates"], ["certificate", id]],
+						children: (
+							<>
+								<T id="object.delete.content" tData={{ object: "certificate" }} />
+								<div className="mt-2 text-muted small">Agent: {target.name}</div>
+							</>
+						),
+					})
+				}
+			/>
+		</AgentSection>
+	);
+}
+
 export default function TableWrapper() {
 	const [search, setSearch] = useState("");
-	const { isFetching, isLoading, isError, error, data } = useCertificates([
-		"owner",
-		"dead_hosts",
-		"proxy_hosts",
-		"redirection_hosts",
-		"streams",
-	]);
+	const { targets, isLoading, isError, error } = useAgentTargets();
 
 	if (isLoading) {
 		return <LoadingPage />;
@@ -35,126 +141,71 @@ export default function TableWrapper() {
 		return <Alert variant="danger">{error?.message || "Unknown error"}</Alert>;
 	}
 
-	const handleDelete = async (id: number) => {
-		await deleteCertificate(id);
-		showObjectSuccess("certificate", "deleted");
-	};
-
-	const handleDownload = async (id: number) => {
-		try {
-			await downloadCertificate(id);
-		} catch (err: any) {
-			showError(err.message);
-		}
-	};
-
-	let filtered = null;
-	if (search && data) {
-		filtered = data?.filter(
-			(item) =>
-				item.domainNames.some((domain: string) => domain.toLowerCase().includes(search)) ||
-				item.niceName.toLowerCase().includes(search),
-		);
-	} else if (search !== "") {
-		// this can happen if someone deletes the last item while searching
-		setSearch("");
-	}
-
 	return (
 		<div className="card mt-4">
 			<div className="card-status-top bg-pink" />
-			<div className="card-table">
-				<div className="card-header">
-					<div className="row w-full">
-						<div className="col">
-							<h2 className="mt-1 mb-0">
-								<T id="certificates" />
-							</h2>
-						</div>
-						<div className="col-md-auto col-sm-12">
-							<div className="ms-auto d-flex flex-wrap btn-list">
-								{data?.length ? (
-									<div className="input-group input-group-flat w-auto">
-										<span className="input-group-text input-group-text-sm">
-											<IconSearch size={16} />
-										</span>
-										<input
-											id="advanced-table-search"
-											type="text"
-											className="form-control form-control-sm"
-											autoComplete="off"
-											onChange={(e: any) => setSearch(e.target.value.toLowerCase().trim())}
-										/>
-									</div>
-								) : null}
-								<Button size="sm" onClick={() => showHelpModal("Certificates", "pink")}>
-									<IconHelp size={20} />
-								</Button>
-								<HasPermission section={CERTIFICATES} permission={MANAGE} hideError>
-									{data?.length ? (
-										<div className="dropdown">
-											<button
-												type="button"
-												className="btn btn-sm dropdown-toggle btn-pink mt-1"
-												data-bs-toggle="dropdown"
-											>
-												<T id="object.add" tData={{ object: "certificate" }} />
-											</button>
-											<div className="dropdown-menu">
-												<a
-													className="dropdown-item"
-													href="#"
-													onClick={(e) => {
-														e.preventDefault();
-														showHTTPCertificateModal();
-													}}
-												>
-													<T id="lets-encrypt-via-http" />
-												</a>
-												<a
-													className="dropdown-item"
-													href="#"
-													onClick={(e) => {
-														e.preventDefault();
-														showDNSCertificateModal();
-													}}
-												>
-													<T id="lets-encrypt-via-dns" />
-												</a>
-												<div className="dropdown-divider" />
-												<a
-													className="dropdown-item"
-													href="#"
-													onClick={(e) => {
-														e.preventDefault();
-														showCustomCertificateModal();
-													}}
-												>
-													<T id="certificates.custom" />
-												</a>
-											</div>
-										</div>
-									) : null}
-								</HasPermission>
+			<div className="card-header">
+				<div className="row w-full">
+					<div className="col">
+						<h2 className="mt-1 mb-0">
+							<T id="certificates" />
+						</h2>
+						<div className="text-muted small">Showing current node and enabled agents on one page.</div>
+					</div>
+					<div className="col-md-auto col-sm-12">
+						<div className="ms-auto d-flex flex-wrap btn-list">
+							<div className="input-group input-group-flat w-auto">
+								<span className="input-group-text input-group-text-sm">
+									<IconSearch size={16} />
+								</span>
+								<input
+									id="advanced-table-search"
+									type="text"
+									className="form-control form-control-sm"
+									autoComplete="off"
+									value={search}
+									onChange={(e: any) => setSearch(e.target.value.toLowerCase().trim())}
+								/>
 							</div>
+							<Button size="sm" onClick={() => showHelpModal("Certificates", "pink")}>
+								<IconHelp size={20} />
+							</Button>
+							<HasPermission section={CERTIFICATES} permission={MANAGE} hideError>
+								<div className="dropdown">
+									<button type="button" className="btn btn-sm dropdown-toggle btn-pink" data-bs-toggle="dropdown">
+										<T id="object.add" tData={{ object: "certificate" }} /> on…
+									</button>
+									<div className="dropdown-menu dropdown-menu-end">
+										{targets.map((target) => (
+											<div className="dropend" key={target.id}>
+												<a className="dropdown-item dropdown-toggle" href="#" data-bs-toggle="dropdown">
+													{target.name}
+												</a>
+												<div className="dropdown-menu">
+													<a className="dropdown-item" href="#" onClick={(e) => { e.preventDefault(); showHTTPCertificateModal(target.id, target.name); }}>
+														<T id="lets-encrypt-via-http" />
+													</a>
+													<a className="dropdown-item" href="#" onClick={(e) => { e.preventDefault(); showDNSCertificateModal(target.id, target.name); }}>
+														<T id="lets-encrypt-via-dns" />
+													</a>
+													<div className="dropdown-divider" />
+													<a className="dropdown-item" href="#" onClick={(e) => { e.preventDefault(); showCustomCertificateModal(target.id, target.name); }}>
+														<T id="certificates.custom" />
+													</a>
+												</div>
+											</div>
+										))}
+									</div>
+								</div>
+							</HasPermission>
 						</div>
 					</div>
 				</div>
-				<Table
-					data={filtered ?? data ?? []}
-					isFiltered={!!search}
-					isFetching={isFetching}
-					onRenew={showRenewCertificateModal}
-					onDownload={handleDownload}
-					onDelete={(id: number) =>
-						showDeleteConfirmModal({
-							title: <T id="object.delete" tData={{ object: "certificate" }} />,
-							onConfirm: () => handleDelete(id),
-							invalidations: [["certificates"], ["certificate", id]],
-							children: <T id="object.delete.content" tData={{ object: "certificate" }} />,
-						})
-					}
-				/>
+			</div>
+			<div className="card-body p-3">
+				{targets.map((target) => (
+					<CertificateAgentSection key={target.id} target={target} search={search} />
+				))}
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/Dashboard/index.tsx
+++ b/frontend/src/pages/Dashboard/index.tsx
@@ -1,13 +1,74 @@
 import { IconArrowsCross, IconBolt, IconBoltOff, IconDisc } from "@tabler/icons-react";
+import { useQueries } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { HasPermission } from "src/components";
-import { useHostReport } from "src/hooks";
+import { HasPermission, LoadingPage } from "src/components";
+import { getHostsReport } from "src/api/backend";
+import { type AgentTarget, useAgentTargets } from "src/hooks";
 import { T } from "src/locale";
 import { DEAD_HOSTS, PROXY_HOSTS, REDIRECTION_HOSTS, STREAMS, VIEW } from "src/modules/Permissions";
 
+type HostReport = Record<string, number>;
+
+const emptyReport: HostReport = {
+	proxy: 0,
+	redirection: 0,
+	stream: 0,
+	dead: 0,
+};
+
+const reportKeys = ["proxy", "redirection", "stream", "dead"];
+
+function addReports(reports: HostReport[]) {
+	return reports.reduce(
+		(total, report) => {
+			for (const key of reportKeys) {
+				total[key] = (total[key] ?? 0) + (report?.[key] ?? 0);
+			}
+			return total;
+		},
+		{ ...emptyReport },
+	);
+}
+
+function useDashboardHostTotals(targets: AgentTarget[]) {
+	const queries = useQueries({
+		queries: targets.map((target) => ({
+			queryKey: ["host-report", { agentId: target.id }],
+			queryFn: () => getHostsReport(target.id),
+			refetchOnWindowFocus: false,
+			retry: 5,
+			refetchInterval: 15 * 1000,
+			staleTime: 14 * 1000,
+		})),
+	});
+	const loadedReports = queries.map((query) => query.data).filter(Boolean) as HostReport[];
+	const failedCount = queries.filter((query) => query.isError).length;
+	return {
+		data: addReports(loadedReports),
+		isLoading: queries.some((query) => query.isLoading),
+		isFetching: queries.some((query) => query.isFetching),
+		failedCount,
+		loadedCount: loadedReports.length,
+		totalTargets: targets.length,
+	};
+}
+
+function TotalHint({ loadedCount, totalTargets, failedCount }: { loadedCount: number; totalTargets: number; failedCount: number }) {
+	return (
+		<div className="text-muted small mt-1">
+			Total across {loadedCount}/{totalTargets} nodes{failedCount ? ` · ${failedCount} failed` : ""}
+		</div>
+	);
+}
+
 const Dashboard = () => {
-	const { data: hostReport } = useHostReport();
+	const { targets, isLoading: agentsLoading } = useAgentTargets();
+	const hostReport = useDashboardHostTotals(targets);
 	const navigate = useNavigate();
+
+	if (agentsLoading) {
+		return <LoadingPage />;
+	}
 
 	return (
 		<div>
@@ -36,8 +97,9 @@ const Dashboard = () => {
 											</div>
 											<div className="col">
 												<div className="font-weight-medium">
-													<T id="proxy-hosts.count" data={{ count: hostReport?.proxy }} />
+													<T id="proxy-hosts.count" data={{ count: hostReport.data.proxy }} />
 												</div>
+												<TotalHint {...hostReport} />
 											</div>
 										</div>
 									</div>
@@ -62,10 +124,8 @@ const Dashboard = () => {
 												</span>
 											</div>
 											<div className="col">
-												<T
-													id="redirection-hosts.count"
-													data={{ count: hostReport?.redirection }}
-												/>
+												<T id="redirection-hosts.count" data={{ count: hostReport.data.redirection }} />
+												<TotalHint {...hostReport} />
 											</div>
 										</div>
 									</div>
@@ -90,7 +150,8 @@ const Dashboard = () => {
 												</span>
 											</div>
 											<div className="col">
-												<T id="streams.count" data={{ count: hostReport?.stream }} />
+												<T id="streams.count" data={{ count: hostReport.data.stream }} />
+												<TotalHint {...hostReport} />
 											</div>
 										</div>
 									</div>
@@ -115,7 +176,8 @@ const Dashboard = () => {
 												</span>
 											</div>
 											<div className="col">
-												<T id="dead-hosts.count" data={{ count: hostReport?.dead }} />
+												<T id="dead-hosts.count" data={{ count: hostReport.data.dead }} />
+												<TotalHint {...hostReport} />
 											</div>
 										</div>
 									</div>

--- a/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
+++ b/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import { deleteProxyHost, toggleProxyHost } from "src/api/backend";
 import { Button, HasPermission, LoadingPage } from "src/components";
-import { useProxyHosts } from "src/hooks";
+import { useAgents, useProxyHosts } from "src/hooks";
 import { T } from "src/locale";
 import { showDeleteConfirmModal, showHelpModal, showProxyHostModal } from "src/modals";
 import { MANAGE, PROXY_HOSTS } from "src/modules/Permissions";
@@ -14,7 +14,9 @@ import Table from "./Table";
 export default function TableWrapper() {
 	const queryClient = useQueryClient();
 	const [search, setSearch] = useState("");
-	const { isFetching, isLoading, isError, error, data } = useProxyHosts(["owner", "access_list", "certificate"]);
+	const [agentId, setAgentId] = useState("local");
+	const { data: agents } = useAgents();
+	const { isFetching, isLoading, isError, error, data } = useProxyHosts(["owner", "access_list", "certificate"], {}, agentId);
 
 	if (isLoading) {
 		return <LoadingPage />;
@@ -25,12 +27,12 @@ export default function TableWrapper() {
 	}
 
 	const handleDelete = async (id: number) => {
-		await deleteProxyHost(id);
+		await deleteProxyHost(id, agentId);
 		showObjectSuccess("proxy-host", "deleted");
 	};
 
 	const handleDisableToggle = async (id: number, enabled: boolean) => {
-		await toggleProxyHost(id, enabled);
+		await toggleProxyHost(id, enabled, agentId);
 		queryClient.invalidateQueries({ queryKey: ["proxy-hosts"] });
 		queryClient.invalidateQueries({ queryKey: ["proxy-host", id] });
 		showObjectSuccess("proxy-host", enabled ? "enabled" : "disabled");
@@ -62,6 +64,21 @@ export default function TableWrapper() {
 						</div>
 						<div className="col-md-auto col-sm-12">
 							<div className="ms-auto d-flex flex-wrap btn-list">
+								<select
+									className="form-select form-select-sm w-auto"
+									value={agentId}
+									onChange={(e) => {
+										setAgentId(e.target.value);
+										setSearch("");
+									}}
+								>
+									<option value="local">Current node</option>
+									{agents?.map((agent) => (
+										<option key={agent.id} value={`${agent.id}`} disabled={!agent.enabled}>
+											{agent.name || agent.url}
+										</option>
+									))}
+								</select>
 								{data?.length ? (
 									<div className="input-group input-group-flat w-auto">
 										<span className="input-group-text input-group-text-sm">
@@ -84,7 +101,7 @@ export default function TableWrapper() {
 										<Button
 											size="sm"
 											className="btn-lime"
-											onClick={() => showProxyHostModal("new")}
+											onClick={() => showProxyHostModal("new", agentId)}
 										>
 											<T id="object.add" tData={{ object: "proxy-host" }} />
 										</Button>
@@ -98,7 +115,7 @@ export default function TableWrapper() {
 					data={filtered ?? data ?? []}
 					isFiltered={!!search}
 					isFetching={isFetching}
-					onEdit={(id: number) => showProxyHostModal(id)}
+					onEdit={(id: number) => showProxyHostModal(id, agentId)}
 					onDelete={(id: number) => {
 						const host = data?.find((h) => h.id === id);
 						showDeleteConfirmModal({
@@ -121,7 +138,7 @@ export default function TableWrapper() {
 						});
 					}}
 					onDisableToggle={handleDisableToggle}
-					onNew={() => showProxyHostModal("new")}
+					onNew={() => showProxyHostModal("new", agentId)}
 				/>
 			</div>
 		</div>

--- a/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
+++ b/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
@@ -2,21 +2,105 @@ import { IconHelp, IconSearch } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import Alert from "react-bootstrap/Alert";
-import { deleteProxyHost, toggleProxyHost } from "src/api/backend";
-import { Button, HasPermission, LoadingPage } from "src/components";
-import { useAgents, useProxyHosts } from "src/hooks";
+import { deleteProxyHost, toggleProxyHost, type ProxyHost } from "src/api/backend";
+import { AgentSection, Button, HasPermission, LoadingPage } from "src/components";
+import { type AgentTarget, useAgentTargets, useProxyHosts } from "src/hooks";
 import { T } from "src/locale";
 import { showDeleteConfirmModal, showHelpModal, showProxyHostModal } from "src/modals";
 import { MANAGE, PROXY_HOSTS } from "src/modules/Permissions";
 import { showObjectSuccess } from "src/notifications";
 import Table from "./Table";
 
-export default function TableWrapper() {
+const filterProxyHosts = (data: ProxyHost[], search: string) => {
+	if (!search) return data;
+	return data.filter(
+		(item) =>
+			item.domainNames.some((domain: string) => domain.toLowerCase().includes(search)) ||
+			item.forwardHost.toLowerCase().includes(search) ||
+			`${item.forwardPort}`.includes(search),
+	);
+};
+
+interface SectionProps {
+	target: AgentTarget;
+	search: string;
+}
+
+function ProxyHostAgentSection({ target, search }: SectionProps) {
 	const queryClient = useQueryClient();
+	const query = useProxyHosts(["owner", "access_list", "certificate"], {}, target.id);
+	const data = query.data ?? [];
+	const filtered = filterProxyHosts(data, search);
+	const agentName = target.name;
+
+	const handleDelete = async (id: number) => {
+		await deleteProxyHost(id, target.id);
+		showObjectSuccess("proxy-host", "deleted");
+	};
+
+	const handleDisableToggle = async (id: number, enabled: boolean) => {
+		await toggleProxyHost(id, enabled, target.id);
+		queryClient.invalidateQueries({ queryKey: ["proxy-hosts"] });
+		queryClient.invalidateQueries({ queryKey: ["proxy-host", id] });
+		showObjectSuccess("proxy-host", enabled ? "enabled" : "disabled");
+	};
+
+	return (
+		<AgentSection
+			target={target}
+			color="lime"
+			isLoading={query.isLoading}
+			isFetching={query.isFetching}
+			isError={query.isError}
+			error={query.error}
+			shownCount={filtered.length}
+			totalCount={data.length}
+			onRetry={() => query.refetch()}
+			actions={
+				<HasPermission section={PROXY_HOSTS} permission={MANAGE} hideError>
+					<Button size="sm" className="btn-lime" onClick={() => showProxyHostModal("new", target.id)}>
+						<T id="object.add" tData={{ object: "proxy-host" }} />
+					</Button>
+				</HasPermission>
+			}
+		>
+			<Table
+				data={filtered}
+				isFiltered={!!search}
+				isFetching={query.isFetching}
+				onEdit={(id: number) => showProxyHostModal(id, target.id)}
+				onDelete={(id: number) => {
+					const host = data.find((h) => h.id === id);
+					showDeleteConfirmModal({
+						title: <T id="object.delete" tData={{ object: "proxy-host" }} />,
+						onConfirm: () => handleDelete(id),
+						invalidations: [["proxy-hosts"], ["proxy-host", id]],
+						children: (
+							<>
+								<T id="object.delete.content" tData={{ object: "proxy-host" }} />
+								<div className="mt-2 text-muted small">Agent: {agentName}</div>
+								{host?.domainNames?.length ? (
+									<div className="mt-2 fw-bold text-break">{host.domainNames.join(", ")}</div>
+								) : null}
+								{host?.forwardHost ? (
+									<div className="mt-1 text-muted small">
+										({host.forwardScheme}://{host.forwardHost}:{host.forwardPort})
+									</div>
+								) : null}
+							</>
+						),
+					});
+				}}
+				onDisableToggle={handleDisableToggle}
+				onNew={() => showProxyHostModal("new", target.id)}
+			/>
+		</AgentSection>
+	);
+}
+
+export default function TableWrapper() {
 	const [search, setSearch] = useState("");
-	const [agentId, setAgentId] = useState("local");
-	const { data: agents } = useAgents();
-	const { isFetching, isLoading, isError, error, data } = useProxyHosts(["owner", "access_list", "certificate"], {}, agentId);
+	const { targets, isLoading, isError, error } = useAgentTargets();
 
 	if (isLoading) {
 		return <LoadingPage />;
@@ -26,120 +110,65 @@ export default function TableWrapper() {
 		return <Alert variant="danger">{error?.message || "Unknown error"}</Alert>;
 	}
 
-	const handleDelete = async (id: number) => {
-		await deleteProxyHost(id, agentId);
-		showObjectSuccess("proxy-host", "deleted");
-	};
-
-	const handleDisableToggle = async (id: number, enabled: boolean) => {
-		await toggleProxyHost(id, enabled, agentId);
-		queryClient.invalidateQueries({ queryKey: ["proxy-hosts"] });
-		queryClient.invalidateQueries({ queryKey: ["proxy-host", id] });
-		showObjectSuccess("proxy-host", enabled ? "enabled" : "disabled");
-	};
-
-	let filtered = null;
-	if (search && data) {
-		filtered = data?.filter(
-			(item) =>
-				item.domainNames.some((domain: string) => domain.toLowerCase().includes(search)) ||
-				item.forwardHost.toLowerCase().includes(search) ||
-				`${item.forwardPort}`.includes(search),
-		);
-	} else if (search !== "") {
-		// this can happen if someone deletes the last item while searching
-		setSearch("");
-	}
-
 	return (
 		<div className="card mt-4">
 			<div className="card-status-top bg-lime" />
-			<div className="card-table">
-				<div className="card-header">
-					<div className="row w-full">
-						<div className="col">
-							<h2 className="mt-1 mb-0">
-								<T id="proxy-hosts" />
-							</h2>
-						</div>
-						<div className="col-md-auto col-sm-12">
-							<div className="ms-auto d-flex flex-wrap btn-list">
-								<select
-									className="form-select form-select-sm w-auto"
-									value={agentId}
-									onChange={(e) => {
-										setAgentId(e.target.value);
-										setSearch("");
-									}}
-								>
-									<option value="local">Current node</option>
-									{agents?.map((agent) => (
-										<option key={agent.id} value={`${agent.id}`} disabled={!agent.enabled}>
-											{agent.name || agent.url}
-										</option>
-									))}
-								</select>
-								{data?.length ? (
-									<div className="input-group input-group-flat w-auto">
-										<span className="input-group-text input-group-text-sm">
-											<IconSearch size={16} />
-										</span>
-										<input
-											id="advanced-table-search"
-											type="text"
-											className="form-control form-control-sm"
-											autoComplete="off"
-											onChange={(e: any) => setSearch(e.target.value.toLowerCase().trim())}
-										/>
-									</div>
-								) : null}
-								<Button size="sm" onClick={() => showHelpModal("ProxyHosts", "lime")}>
-									<IconHelp size={20} />
-								</Button>
-								<HasPermission section={PROXY_HOSTS} permission={MANAGE} hideError>
-									{data?.length ? (
-										<Button
-											size="sm"
-											className="btn-lime"
-											onClick={() => showProxyHostModal("new", agentId)}
-										>
-											<T id="object.add" tData={{ object: "proxy-host" }} />
-										</Button>
-									) : null}
-								</HasPermission>
+			<div className="card-header">
+				<div className="row w-full">
+					<div className="col">
+						<h2 className="mt-1 mb-0">
+							<T id="proxy-hosts" />
+						</h2>
+						<div className="text-muted small">Showing current node and enabled agents on one page.</div>
+					</div>
+					<div className="col-md-auto col-sm-12">
+						<div className="ms-auto d-flex flex-wrap btn-list">
+							<div className="input-group input-group-flat w-auto">
+								<span className="input-group-text input-group-text-sm">
+									<IconSearch size={16} />
+								</span>
+								<input
+									id="advanced-table-search"
+									type="text"
+									className="form-control form-control-sm"
+									autoComplete="off"
+									value={search}
+									onChange={(e: any) => setSearch(e.target.value.toLowerCase().trim())}
+								/>
 							</div>
+							<Button size="sm" onClick={() => showHelpModal("ProxyHosts", "lime")}>
+								<IconHelp size={20} />
+							</Button>
+							<HasPermission section={PROXY_HOSTS} permission={MANAGE} hideError>
+								<div className="dropdown">
+									<button type="button" className="btn btn-sm dropdown-toggle btn-lime" data-bs-toggle="dropdown">
+										<T id="object.add" tData={{ object: "proxy-host" }} /> on…
+									</button>
+									<div className="dropdown-menu dropdown-menu-end">
+										{targets.map((target) => (
+											<a
+												key={target.id}
+												className="dropdown-item"
+												href="#"
+												onClick={(e) => {
+													e.preventDefault();
+													showProxyHostModal("new", target.id);
+												}}
+											>
+												{target.name}
+											</a>
+										))}
+									</div>
+								</div>
+							</HasPermission>
 						</div>
 					</div>
 				</div>
-				<Table
-					data={filtered ?? data ?? []}
-					isFiltered={!!search}
-					isFetching={isFetching}
-					onEdit={(id: number) => showProxyHostModal(id, agentId)}
-					onDelete={(id: number) => {
-						const host = data?.find((h) => h.id === id);
-						showDeleteConfirmModal({
-							title: <T id="object.delete" tData={{ object: "proxy-host" }} />,
-							onConfirm: () => handleDelete(id),
-							invalidations: [["proxy-hosts"], ["proxy-host", id]],
-							children: (
-								<>
-									<T id="object.delete.content" tData={{ object: "proxy-host" }} />
-									{host?.domainNames?.length ? (
-										<div className="mt-2 fw-bold text-break">{host.domainNames.join(", ")}</div>
-									) : null}
-									{host?.forwardHost ? (
-										<div className="mt-1 text-muted small">
-											({host.forwardScheme}://{host.forwardHost}:{host.forwardPort})
-										</div>
-									) : null}
-								</>
-							),
-						});
-					}}
-					onDisableToggle={handleDisableToggle}
-					onNew={() => showProxyHostModal("new", agentId)}
-				/>
+			</div>
+			<div className="card-body p-3">
+				{targets.map((target) => (
+					<ProxyHostAgentSection key={target.id} target={target} search={search} />
+				))}
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/Users/TableWrapper.tsx
+++ b/frontend/src/pages/Users/TableWrapper.tsx
@@ -2,21 +2,109 @@ import { IconSearch } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import Alert from "react-bootstrap/Alert";
-import { deleteUser, toggleUser } from "src/api/backend";
-import { Button, LoadingPage } from "src/components";
+import { deleteUser, toggleUser, type User } from "src/api/backend";
+import { AgentSection, Button, LoadingPage } from "src/components";
 import { useAuthState } from "src/context";
-import { useUser, useUsers } from "src/hooks";
+import { type AgentTarget, useAgentTargets, useUser, useUsers } from "src/hooks";
 import { T } from "src/locale";
 import { showDeleteConfirmModal, showPermissionsModal, showSetPasswordModal, showUserModal } from "src/modals";
 import { showError, showObjectSuccess } from "src/notifications";
 import Table from "./Table";
 
-export default function TableWrapper() {
+const filterUsers = (data: User[], search: string) => {
+	if (!search) return data;
+	return data.filter((item) => {
+		return (
+			item.name.toLowerCase().includes(search) ||
+			item.nickname.toLowerCase().includes(search) ||
+			item.email.toLowerCase().includes(search)
+		);
+	});
+};
+
+function UserAgentSection({ target, search }: { target: AgentTarget; search: string }) {
 	const queryClient = useQueryClient();
 	const { loginAs } = useAuthState();
+	const query = useUsers(["permissions"], {}, target.id);
+	const { data: currentUser } = useUser("me", {}, target.id);
+	const data = query.data ?? [];
+	const filtered = filterUsers(data, search);
+
+	const handleDelete = async (id: number) => {
+		await deleteUser(id, target.id);
+		showObjectSuccess("user", "deleted");
+	};
+
+	const handleDisableToggle = async (id: number, enabled: boolean) => {
+		await toggleUser(id, enabled, target.id);
+		queryClient.invalidateQueries({ queryKey: ["users"] });
+		queryClient.invalidateQueries({ queryKey: ["user", id] });
+		showObjectSuccess("user", enabled ? "enabled" : "disabled");
+	};
+
+	const handleLoginAs = async (id: number) => {
+		try {
+			if (target.isLocal) {
+				await loginAs(id);
+				return;
+			}
+			showError("Login as is only available on the current node in the multi-agent manager.");
+		} catch (err) {
+			if (err instanceof Error) {
+				showError(err.message);
+			}
+		}
+	};
+
+	return (
+		<AgentSection
+			target={target}
+			color="orange"
+			isLoading={query.isLoading}
+			isFetching={query.isFetching}
+			isError={query.isError}
+			error={query.error}
+			shownCount={filtered.length}
+			totalCount={data.length}
+			onRetry={() => query.refetch()}
+			actions={
+				<Button size="sm" className="btn-orange" onClick={() => showUserModal("new", target.id, target.name)}>
+					<T id="object.add" tData={{ object: "user" }} />
+				</Button>
+			}
+		>
+			<Table
+				data={filtered}
+				isFiltered={!!search}
+				isFetching={query.isFetching}
+				currentUserId={currentUser?.id}
+				onEditUser={(id: number) => showUserModal(id, target.id, target.name)}
+				onEditPermissions={(id: number) => showPermissionsModal(id, target.id, target.name)}
+				onSetPassword={(id: number) => showSetPasswordModal(id, target.id, target.name)}
+				onDeleteUser={(id: number) =>
+					showDeleteConfirmModal({
+						title: <T id="object.delete" tData={{ object: "user" }} />,
+						onConfirm: () => handleDelete(id),
+						invalidations: [["users"], ["user", id]],
+						children: (
+							<>
+								<T id="object.delete.content" tData={{ object: "user" }} />
+								<div className="mt-2 text-muted small">Agent: {target.name}</div>
+							</>
+						),
+					})
+				}
+				onDisableToggle={handleDisableToggle}
+				onNewUser={() => showUserModal("new", target.id, target.name)}
+				onLoginAs={handleLoginAs}
+			/>
+		</AgentSection>
+	);
+}
+
+export default function TableWrapper() {
 	const [search, setSearch] = useState("");
-	const { isFetching, isLoading, isError, error, data } = useUsers(["permissions"]);
-	const { data: currentUser } = useUser("me");
+	const { targets, isLoading, isError, error } = useAgentTargets();
 
 	if (isLoading) {
 		return <LoadingPage />;
@@ -26,97 +114,60 @@ export default function TableWrapper() {
 		return <Alert variant="danger">{error?.message || "Unknown error"}</Alert>;
 	}
 
-	const handleLoginAs = async (id: number) => {
-		try {
-			await loginAs(id);
-		} catch (err) {
-			if (err instanceof Error) {
-				showError(err.message);
-			}
-		}
-	};
-
-	const handleDelete = async (id: number) => {
-		await deleteUser(id);
-		showObjectSuccess("user", "deleted");
-	};
-
-	const handleDisableToggle = async (id: number, enabled: boolean) => {
-		await toggleUser(id, enabled);
-		queryClient.invalidateQueries({ queryKey: ["users"] });
-		queryClient.invalidateQueries({ queryKey: ["user", id] });
-		showObjectSuccess("user", enabled ? "enabled" : "disabled");
-	};
-
-	let filtered = null;
-	if (search && data) {
-		filtered = data?.filter((item) => {
-			return (
-				item.name.toLowerCase().includes(search) ||
-				item.nickname.toLowerCase().includes(search) ||
-				item.email.toLowerCase().includes(search)
-			);
-		});
-	} else if (search !== "") {
-		// this can happen if someone deletes the last item while searching
-		setSearch("");
-	}
-
 	return (
 		<div className="card mt-4">
 			<div className="card-status-top bg-orange" />
-			<div className="card-table">
-				<div className="card-header">
-					<div className="row w-full">
-						<div className="col">
-							<h2 className="mt-1 mb-0">
-								<T id="users" />
-							</h2>
-						</div>
-						{data?.length ? (
-							<div className="col-md-auto col-sm-12">
-								<div className="ms-auto d-flex flex-wrap btn-list">
-									<div className="input-group input-group-flat w-auto">
-										<span className="input-group-text input-group-text-sm">
-											<IconSearch size={16} />
-										</span>
-										<input
-											id="advanced-table-search"
-											type="text"
-											className="form-control form-control-sm"
-											autoComplete="off"
-											onChange={(e: any) => setSearch(e.target.value.toLowerCase().trim())}
-										/>
-									</div>
-
-									<Button size="sm" className="btn-orange" onClick={() => showUserModal("new")}>
-										<T id="object.add" tData={{ object: "user" }} />
-									</Button>
+			<div className="card-header">
+				<div className="row w-full">
+					<div className="col">
+						<h2 className="mt-1 mb-0">
+							<T id="users" />
+						</h2>
+						<div className="text-muted small">Showing current node and enabled agents on one page.</div>
+					</div>
+					<div className="col-md-auto col-sm-12">
+						<div className="ms-auto d-flex flex-wrap btn-list">
+							<div className="input-group input-group-flat w-auto">
+								<span className="input-group-text input-group-text-sm">
+									<IconSearch size={16} />
+								</span>
+								<input
+									id="advanced-table-search"
+									type="text"
+									className="form-control form-control-sm"
+									autoComplete="off"
+									value={search}
+									onChange={(e: any) => setSearch(e.target.value.toLowerCase().trim())}
+								/>
+							</div>
+							<div className="dropdown">
+								<button type="button" className="btn btn-sm dropdown-toggle btn-orange" data-bs-toggle="dropdown">
+									<T id="object.add" tData={{ object: "user" }} /> on…
+								</button>
+								<div className="dropdown-menu dropdown-menu-end">
+									{targets.map((target) => (
+										<a
+											key={target.id}
+											className="dropdown-item"
+											href="#"
+											onClick={(e) => {
+												e.preventDefault();
+												showUserModal("new", target.id, target.name);
+											}}
+										>
+											{target.name}
+										</a>
+									))}
 								</div>
 							</div>
-						) : null}
+						</div>
 					</div>
 				</div>
-				<Table
-					data={filtered ?? data ?? []}
-					isFiltered={!!search}
-					isFetching={isFetching}
-					currentUserId={currentUser?.id}
-					onEditUser={(id: number) => showUserModal(id)}
-					onEditPermissions={(id: number) => showPermissionsModal(id)}
-					onSetPassword={(id: number) => showSetPasswordModal(id)}
-					onDeleteUser={(id: number) =>
-						showDeleteConfirmModal({
-							title: <T id="object.delete" tData={{ object: "user" }} />,
-							onConfirm: () => handleDelete(id),
-							invalidations: [["users"], ["user", id]],
-							children: <T id="object.delete.content" tData={{ object: "user" }} />,
-						})
-					}
-					onDisableToggle={handleDisableToggle}
-					onNewUser={() => showUserModal("new")}
-					onLoginAs={handleLoginAs}
-				/>
+			</div>
+			<div className="card-body p-3">
+				{targets.map((target) => (
+					<UserAgentSection key={target.id} target={target} search={search} />
+				))}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Why

This adds optional multi-agent manager support for deployments that need one Nginx Proxy Manager UI to administer additional NPM instances.

The feature is intended for operators running multiple NPM nodes. A manager instance can store remote agent connection details, test them, and forward supported API operations to a selected agent. Local-only deployments continue to behave as they do today unless agents are configured.

Main changes:

- adds an `agent` model, migration, internal service, and routes for managing remote NPM instances
- adds an authenticated forwarding layer for supported Nginx resource APIs
- exposes agent selection on proxy host workflows that can target a remote instance
- adds an Agents page in the frontend for creating, editing, testing, enabling/disabling, and deleting remote agents
- keeps existing local API behavior as the default when no `agent_id` is provided

This is a non-breaking feature, but it does add new API endpoints and optional `agent_id` request/query handling for forwarded operations.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## Testing

- [x] `yarn lint` in `frontend/`
- [x] `yarn build` in `frontend/`
- [x] `yarn lint` in `backend/`
- [x] `yarn validate-schema` in `backend/`

## AI Usage

- [x] AI was used to write this
- [x] AI was used to review this
