### PR TITLE
Bump Cloudflare version

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -77,7 +77,7 @@
 		"full_plugin_name": "dns-cloudflare",
 		"name": "Cloudflare",
 		"package_name": "certbot-dns-cloudflare",
-		"version": "=={{certbot-version}}"
+		"version": "~=5.6.0"
 	},
 	"cloudns": {
 		"credentials": "# Target user ID (see https://www.cloudns.net/api-settings/)\n\tdns_cloudns_auth_id=1234\n\t# Alternatively, one of the following two options can be set:\n\t# dns_cloudns_sub_auth_id=1234\n\t# dns_cloudns_sub_auth_user=foobar\n\n\t# API password\n\tdns_cloudns_auth_password=password1",


### PR DESCRIPTION
Bumps the version of the Certbot plugin for Cloudflare

## Why

Version 2.15.1 fails to load; testing this as a fix.

## Type of Change

<!-- Mark the relevant options with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

<!-- Mark the relevant options with an "x" -->

- [ ] AI was used to write this
- [ ] AI was used to review this

