### PR TITLE
feat: Add DNS challenge provider support for Aliyun ESA.

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -360,12 +360,12 @@
 		"version": "~=1.2.1"
 	},
 	"hosterby": {
-  		"credentials": "dns_hosterby_access_key = YOUR_ACCESS_KEY\ndns_hosterby_secret_key = YOUR_SECRET_KEY",
-  		"dependencies": "",
-  		"full_plugin_name": "dns-hosterby",
-  		"name": "hoster.by",
-  		"package_name": "certbot-dns-hosterby",
-  		"version": "~=0.1.0"
+		"credentials": "dns_hosterby_access_key = YOUR_ACCESS_KEY\ndns_hosterby_secret_key = YOUR_SECRET_KEY",
+		"dependencies": "",
+		"full_plugin_name": "dns-hosterby",
+		"name": "hoster.by",
+		"package_name": "certbot-dns-hosterby",
+		"version": "~=0.1.0"
 	},
 	"infomaniak": {
 		"credentials": "dns_infomaniak_token = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
@@ -679,12 +679,20 @@
 		"package_name": "certbot-dns-zoneedit",
 		"version": "~=0.3.2"
 	},
-		"rcode0": {
+	"rcode0": {
 		"credentials": "dns_rcode0_api_key = acme_0123456789abcdef0123456789abcdef01234567",
 		"dependencies": "",
 		"full_plugin_name": "dns-rcode0",
 		"name": "RcodeZero",
 		"package_name": "certbot-dns-rcode0",
 		"version": "~=0.0.0.2"
+	},
+	"aliyun_esa": {
+		"credentials": "dns_aliyun_esa_access_key_id = 12345678\ndns_aliyun_esa_access_key_secret = 1234567890abcdef1234567890abcdef",
+		"dependencies": "",
+		"full_plugin_name": "dns-aliyun-esa",
+		"name": "AliyunESA",
+		"package_name": "certbot-dns-aliyun-esa",
+		"version": "~=0.1.1"
 	}
 }


### PR DESCRIPTION
## Why

Add DNS challenge provider support for Aliyun ESA.

Aliyun ESA uses a different Certbot DNS plugin from the existing Aliyun DNS provider. This PR adds a new provider entry for:

- PyPI: https://pypi.org/project/certbot-dns-aliyun-esa/
- Source: https://github.com/lampofaladdin/certbot-dns-aliyun-esa
- Certbot plugin: `dns-aliyun-esa`

Credentials template:

```ini
dns_aliyun_esa_access_key_id = 12345678
dns_aliyun_esa_access_key_secret = 1234567890abcdef1234567890abcdef
```

This is a non-breaking addition and does not change the existing Aliyun provider.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

- [x] AI was used to write this
- [x] AI was used to review this

## Snapshot
- Certbot  Successfully received certificate.
<img width="1220" height="771" alt="37c07441bf837e51ecc328b3dc0f6ec8" src="https://github.com/user-attachments/assets/67174bbb-404e-44e1-8417-07aba0d7ee60" />

- NPM select UI
<img width="3828" height="1911" alt="84b3e88691bb008dec573b29aaf24af9" src="https://github.com/user-attachments/assets/d8e76e67-f1e5-477e-8853-f1733274cba6" />

- Aliyun ESA
<img width="3828" height="1911" alt="a3835bd3-d0c6-4eb5-b7ba-4984f54a365a" src="https://github.com/user-attachments/assets/9513ccbc-f3da-46ff-9f42-2917189597b2" />

- NPM Success
<img width="3828" height="1911" alt="fcec355aea3cd299edf5de06680e1f40" src="https://github.com/user-attachments/assets/43b68a69-ecd2-442d-befc-291eb5359004" />


