### PR TITLE
fix(nginx): custom locations take precedence over Cache Assets regex (location ^~)

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,4 +1,4 @@
-  location {{ path }} {
+  location ^~ {{ path }} {
     {{ advanced_config }}
 
     proxy_set_header Host $host;


### PR DESCRIPTION
## Problem
A proxy host with a **Custom Location** pointing at a *different* upstream (e.g. `/paperless` -> a Paperless container) **and** `Cache Assets` enabled returns **404** for static files under that path (`/paperless/static/app.js`, `.css`, ...). The Custom Location's HTML/API paths work; only asset extensions break.

## Root cause
`Cache Assets` includes a server-level regex location `location ~* \.(css|js|png|...)$ { proxy_pass <main upstream>; }`. In nginx, **regex locations take precedence over prefix locations**, so this regex beats the Custom Location `location {{ path }}` (plain prefix) generated by `_location.conf`. Asset requests under custom paths are routed to the **main** upstream (which doesn't know them) -> 404. The UI offers no way to raise the custom location's priority.

Related: #2557, #1981, #4423.

## Change
Emit custom locations as `location ^~ {{ path }}`. `^~` gives the prefix location precedence over regex locations, so the cached-asset regex no longer hijacks custom-location paths.

## Caveat
`^~` disables regex matching *within* that path. Users who intend a Custom Location path as a regex would be affected. If custom paths may be regex, a guarded variant (only `^~` for plain prefixes) would be safer — happy to adjust based on maintainer preference.

## Test
1. Proxy host `example` -> upstream A; Custom Location `/sub` -> upstream B serving `/sub/x.js`.
2. Enable `Cache Assets` -> `/sub/x.js` = 404 (bug).
3. With this change -> `/sub/x.js` = 200 from B; main-upstream assets still cached.
