### PR TITLE
Allow disabling 2FA with a backup/recovery code (#5451)

### DIFF
--- a/backend/internal/2fa.js
+++ b/backend/internal/2fa.js
@@ -160,15 +160,14 @@ const internal2fa = {
 			throw new errs.ValidationError("2FA is not enabled");
 		}
 
-		const result = await verify({
-            token: code,
-            secret: auth.meta.totp_secret,
-            guardrails: createGuardrails({
-                MIN_SECRET_BYTES: 10,
-            }),
-        });
+		// Accept either a TOTP code or one of the backup/recovery codes, using the
+		// same verification path as login. Passing a backup code straight to otplib's
+		// verify() throws ("Token must contain only digits"), which previously surfaced
+		// as an "Internal error" and left users who only had their recovery codes
+		// unable to disable 2FA (see #5451).
+		const valid = await internal2fa.verifyForLogin(userId, code);
 
-		if (!result.valid) {
+		if (!valid) {
 			throw new errs.AuthError("Invalid verification code");
 		}
 


### PR DESCRIPTION
## Why

Fixes #5451.

The 2FA disable endpoint (`DELETE /api/users/:id/2fa`) passed the submitted code straight to otplib's `verify()`, which only accepts 6-digit numeric TOTP tokens. A backup/recovery code (8 hex characters, e.g. `A1B2C3D4`) makes `verify()` throw (`Token must be 6 digits` / `Token must contain only digits`), which is returned to the client as a generic 500 "Internal error". `disable()` also never fell back to matching the code against the stored backup codes.

The practical impact: a user who lost their authenticator and logged in with a recovery code cannot disable 2FA at all — the recovery code is the only credential they have, and it is rejected. Multiple users reported this on #5451.

## What

Reuse the existing `verifyForLogin()` path in `disable()`. It already accepts both a TOTP code and a backup code, guards the TOTP check by length so non-numeric codes don't throw, and relaxes the secret-length guardrails for legacy secrets. Disabling 2FA now works with either a TOTP code or a recovery code, matching login behaviour. No API shape change.

Verified with a standalone reproduction against the bundled otplib v13 + bcryptjs: the old path throws `TokenLengthError` on an 8-char recovery code (→ 500), the new path accepts a recovery code and a valid TOTP and rejects wrong codes without throwing. `biome lint` clean. (No backend unit-test harness exists — the `test/` suite is Cypress integration needing a full Docker stack; reviewer steps below.)

To verify manually: enable 2FA, log out, log back in using a recovery code, then Account → Two-Factor Auth → Disable and enter a recovery code — it should now succeed instead of "Internal error".

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## AI Usage
- [x] AI was used to write this

This PR was authored with AI assistance (Claude); every line was reviewed and the fix reproduced/verified before submission.
