### PR TITLE
fix: replace Oracle Cloud Infrastructure DNS plugin 

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -520,12 +520,12 @@
 		"version": "=={{certbot-version}}"
 	},
 	"oci": {
-		"credentials": "[DEFAULT]\nuser = ocid1.user.oc1...\nfingerprint = xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx\ntenancy = ocid1.tenancy.oc1...\nregion = us-ashburn-1\nkey_file = ~/.oci/oci_api_key.pem",
+		"credentials": "[DEFAULT]\nuser = ocid1.user.oc1...\nfingerprint = xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx\ntenancy = ocid1.tenancy.oc1...\nregion = us-ashburn-1\nkey_file = /root/.oci/oci_api_key.pem",
 		"dependencies": "oci",
-		"full_plugin_name": "dns-oci",
+		"full_plugin_name": "dns-oraclecloud",
 		"name": "Oracle Cloud Infrastructure DNS",
-		"package_name": "certbot-dns-oci",
-		"version": "~=0.3.6"
+		"package_name": "certbot-dns-oraclecloud",
+		"version": "~=1.0.1"
 	},
 	"ovh": {
 		"credentials": "dns_ovh_endpoint = ovh-eu\ndns_ovh_application_key = MDAwMDAwMDAwMDAw\ndns_ovh_application_secret = MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw\ndns_ovh_consumer_key = MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw",


### PR DESCRIPTION
<!-- WARNING: Any PR without a description will be closed. The title is not enough! -->

<!-- ANOTHER WARNING: Don't go creating a duplicate PR! Check that someone hasn't already created something that tackles your fix and if so, help them first -->

## Why

The existing Oracle Cloud Infrastructure DNS plugin locks certbot at 1.15.0. Which is bad. This one does not.

<!-- Consider if you are changing the API, then go in to detail why and/or if
you change will break API for existing users -->

## Type of Change

<!-- Mark the relevant options with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

<!-- Mark the relevant options with an "x" -->

- [ ] AI was used to write this
- [ ] AI was used to review this

