### PR TITLE
Group ProxyHosts table by base domain

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,8 @@
 		"react-router-dom": "^7.16.0",
 		"react-select": "^5.10.2",
 		"react-toastify": "^11.1.0",
-		"rooks": "^9.8.0"
+		"rooks": "^9.8.0",
+		"tldts": "^7.4.8"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,8 @@
 		"react-router-dom": "^7.18.2",
 		"react-select": "^5.10.2",
 		"react-toastify": "^11.1.0",
-		"rooks": "^9.9.0"
+		"rooks": "^9.9.0",
+		"tldts": "^7.4.8"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.10",

--- a/frontend/src/components/Table/TableBody.tsx
+++ b/frontend/src/components/Table/TableBody.tsx
@@ -1,4 +1,5 @@
 import { flexRender } from "@tanstack/react-table";
+import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 import type { TableLayoutProps } from "src/components";
 import { EmptyRow } from "./EmptyRow";
 
@@ -14,12 +15,39 @@ function TableBody<T>(props: TableLayoutProps<T>) {
 		);
 	}
 
+	const visibleColumnCount = tableInstance.getVisibleLeafColumns().length;
+
 	return (
 		<tbody className="table-tbody">
 			{rows.map((row: any) => {
+				if (row.getIsGrouped()) {
+					const isExpanded = row.getIsExpanded();
+					return (
+						<tr
+							key={row.id}
+							className="table-group-row table-active cursor-pointer"
+							onClick={row.getToggleExpandedHandler()}
+						>
+							<td colSpan={visibleColumnCount}>
+								<span className="d-inline-flex align-items-center gap-2">
+									{isExpanded ? (
+										<IconChevronDown size={16} />
+									) : (
+										<IconChevronRight size={16} />
+									)}
+									<strong>{String(row.groupingValue ?? "")}</strong>
+									<span className="badge bg-secondary-lt">{row.subRows.length}</span>
+								</span>
+							</td>
+						</tr>
+					);
+				}
 				return (
 					<tr key={row.id} {...extraStyles?.row(row.original)}>
 						{row.getVisibleCells().map((cell: any) => {
+							if (cell.getIsPlaceholder()) {
+								return null;
+							}
 							const { className } = (cell.column.columnDef.meta as any) ?? {};
 							return (
 								<td key={cell.id} className={className}>

--- a/frontend/src/components/Table/TableBody.tsx
+++ b/frontend/src/components/Table/TableBody.tsx
@@ -1,3 +1,4 @@
+import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 import { flexRender, type RowData } from "@tanstack/react-table";
 import type { TableLayoutProps } from "src/components";
 import { EmptyRow } from "./EmptyRow";
@@ -14,12 +15,35 @@ function TableBody<T extends RowData>(props: TableLayoutProps<T>) {
 		);
 	}
 
+	const visibleColumnCount = tableInstance.getVisibleLeafColumns().length;
+
 	return (
 		<tbody className="table-tbody">
 			{rows.map((row: any) => {
+				if (row.getIsGrouped()) {
+					const isExpanded = row.getIsExpanded();
+					return (
+						<tr
+							key={row.id}
+							className="table-group-row table-active cursor-pointer"
+							onClick={row.getToggleExpandedHandler()}
+						>
+							<td colSpan={visibleColumnCount}>
+								<span className="d-inline-flex align-items-center gap-2">
+									{isExpanded ? <IconChevronDown size={16} /> : <IconChevronRight size={16} />}
+									<strong>{String(row.groupingValue ?? "")}</strong>
+									<span className="badge bg-secondary-lt">{row.subRows.length}</span>
+								</span>
+							</td>
+						</tr>
+					);
+				}
 				return (
 					<tr key={row.id} {...extraStyles?.row(row.original)}>
 						{row.getVisibleCells().map((cell: any) => {
+							if (cell.getIsPlaceholder()) {
+								return null;
+							}
 							const { className } = (cell.column.columnDef.meta as any) ?? {};
 							return (
 								<td key={cell.id} className={className}>

--- a/frontend/src/components/Table/features.ts
+++ b/frontend/src/components/Table/features.ts
@@ -1,7 +1,11 @@
 import {
+	columnGroupingFeature,
 	columnVisibilityFeature,
+	createExpandedRowModel,
+	createGroupedRowModel,
 	createSortedRowModel,
 	metaHelper,
+	rowExpandingFeature,
 	rowSortingFeature,
 	tableFeatures,
 } from "@tanstack/react-table";
@@ -20,12 +24,18 @@ interface TableMeta {
  * unconditionally, e.g. `getVisibleFlatColumns`/`getVisibleCells`) by the
  * shared TableLayout/TableHeader/TableBody/EmptyData components, so every
  * table instance must register them even when a particular table doesn't
- * wire up controlled sorting state itself.
+ * wire up controlled sorting state itself. The same applies to grouping and
+ * expanding: TableBody calls `row.getIsGrouped()` on every row, so the
+ * features must be registered even for the tables that never group.
  */
 const features = tableFeatures({
 	rowSortingFeature,
 	sortedRowModel: createSortedRowModel(),
 	columnVisibilityFeature,
+	columnGroupingFeature,
+	groupedRowModel: createGroupedRowModel(),
+	rowExpandingFeature,
+	expandedRowModel: createExpandedRowModel(),
 	columnMeta: metaHelper<ColumnMeta>(),
 	tableMeta: metaHelper<TableMeta>(),
 });

--- a/frontend/src/pages/Nginx/ProxyHosts/Table.tsx
+++ b/frontend/src/pages/Nginx/ProxyHosts/Table.tsx
@@ -1,7 +1,10 @@
 import { IconDotsVertical, IconEdit, IconPower, IconTrash } from "@tabler/icons-react";
 import {
 	createColumnHelper,
+	type ExpandedState,
 	getCoreRowModel,
+	getExpandedRowModel,
+	getGroupedRowModel,
 	getSortedRowModel,
 	type SortingState,
 	useReactTable,
@@ -21,8 +24,10 @@ import { TableLayout } from "src/components/Table/TableLayout";
 import { intl, T } from "src/locale";
 import { MANAGE, PROXY_HOSTS } from "src/modules/Permissions";
 
+type ProxyHostRow = ProxyHost & { baseDomain: string };
+
 interface Props {
-	data: ProxyHost[];
+	data: ProxyHostRow[];
 	isFiltered?: boolean;
 	isFetching?: boolean;
 	onEdit?: (id: number) => void;
@@ -31,9 +36,13 @@ interface Props {
 	onNew?: () => void;
 }
 export default function Table({ data, isFetching, onEdit, onDelete, onDisableToggle, onNew, isFiltered }: Props) {
-	const columnHelper = createColumnHelper<ProxyHost>();
+	const columnHelper = createColumnHelper<ProxyHostRow>();
 	const columns = useMemo(
 		() => [
+			columnHelper.accessor((row: any) => row.baseDomain, {
+				id: "baseDomain",
+				enableSorting: false,
+			}),
 			columnHelper.accessor((row: any) => row.owner, {
 				id: "owner",
 				enableSorting: false,
@@ -164,14 +173,23 @@ export default function Table({ data, isFetching, onEdit, onDelete, onDisableTog
 	);
 
 	const [sorting, setSorting] = useState<SortingState>([]);
+	const [expanded, setExpanded] = useState<ExpandedState>(true);
 
-	const tableInstance = useReactTable<ProxyHost>({
+	const tableInstance = useReactTable<ProxyHostRow>({
 		columns,
 		data,
-		state: { sorting },
+		state: { sorting, expanded },
+		initialState: {
+			grouping: ["baseDomain"],
+			columnVisibility: { baseDomain: false },
+		},
 		onSortingChange: setSorting,
+		onExpandedChange: setExpanded,
 		getCoreRowModel: getCoreRowModel(),
 		getSortedRowModel: getSortedRowModel(),
+		getGroupedRowModel: getGroupedRowModel(),
+		getExpandedRowModel: getExpandedRowModel(),
+		autoResetExpanded: false,
 		rowCount: data.length,
 		meta: {
 			isFetching,

--- a/frontend/src/pages/Nginx/ProxyHosts/Table.tsx
+++ b/frontend/src/pages/Nginx/ProxyHosts/Table.tsx
@@ -1,5 +1,5 @@
 import { IconDotsVertical, IconEdit, IconPower, IconTrash } from "@tabler/icons-react";
-import { createColumnHelper, type SortingState, useTable } from "@tanstack/react-table";
+import { createColumnHelper, type ExpandedState, type SortingState, useTable } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import type { ProxyHost } from "src/api/backend";
 import {
@@ -16,8 +16,10 @@ import { TableLayout } from "src/components/Table/TableLayout";
 import { intl, T } from "src/locale";
 import { MANAGE, PROXY_HOSTS } from "src/modules/Permissions";
 
+type ProxyHostRow = ProxyHost & { baseDomain: string };
+
 interface Props {
-	data: ProxyHost[];
+	data: ProxyHostRow[];
 	isFiltered?: boolean;
 	isFetching?: boolean;
 	onEdit?: (id: number) => void;
@@ -26,9 +28,13 @@ interface Props {
 	onNew?: () => void;
 }
 export default function Table({ data, isFetching, onEdit, onDelete, onDisableToggle, onNew, isFiltered }: Props) {
-	const columnHelper = createColumnHelper<Features, ProxyHost>();
+	const columnHelper = createColumnHelper<Features, ProxyHostRow>();
 	const columns = useMemo(
 		() => [
+			columnHelper.accessor((row: any) => row.baseDomain, {
+				id: "baseDomain",
+				enableSorting: false,
+			}),
 			columnHelper.accessor((row: any) => row.owner, {
 				id: "owner",
 				enableSorting: false,
@@ -159,13 +165,20 @@ export default function Table({ data, isFetching, onEdit, onDelete, onDisableTog
 	);
 
 	const [sorting, setSorting] = useState<SortingState>([]);
+	const [expanded, setExpanded] = useState<ExpandedState>(true);
 
 	const tableInstance = useTable({
 		features,
 		columns,
 		data,
-		state: { sorting },
+		state: { sorting, expanded },
+		initialState: {
+			grouping: ["baseDomain"],
+			columnVisibility: { baseDomain: false },
+		},
 		onSortingChange: setSorting,
+		onExpandedChange: setExpanded,
+		autoResetExpanded: false,
 		meta: {
 			isFetching,
 		},

--- a/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
+++ b/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
@@ -1,6 +1,6 @@
 import { IconHelp, IconSearch } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import { deleteProxyHost, toggleProxyHost } from "src/api/backend";
 import { Button, HasPermission, LoadingPage } from "src/components";
@@ -9,6 +9,7 @@ import { T } from "src/locale";
 import { showDeleteConfirmModal, showHelpModal, showProxyHostModal } from "src/modals";
 import { MANAGE, PROXY_HOSTS } from "src/modules/Permissions";
 import { showObjectSuccess } from "src/notifications";
+import { getBaseDomain } from "./baseDomain";
 import Table from "./Table";
 
 export default function TableWrapper() {
@@ -16,12 +17,36 @@ export default function TableWrapper() {
 	const [search, setSearch] = useState("");
 	const { isFetching, isLoading, isError, error, data } = useProxyHosts(["owner", "access_list", "certificate"]);
 
+	const filtered = useMemo(() => {
+		if (!search || !data) return null;
+		return data.filter(
+			(item) =>
+				item.domainNames.some((domain: string) => domain.toLowerCase().includes(search)) ||
+				item.forwardHost.toLowerCase().includes(search) ||
+				`${item.forwardPort}`.includes(search),
+		);
+	}, [search, data]);
+
+	const tableData = useMemo(
+		() =>
+			(filtered ?? data ?? []).map((item) => ({
+				...item,
+				baseDomain: getBaseDomain(item.domainNames?.[0]),
+			})),
+		[filtered, data],
+	);
+
 	if (isLoading) {
 		return <LoadingPage />;
 	}
 
 	if (isError) {
 		return <Alert variant="danger">{error?.message || "Unknown error"}</Alert>;
+	}
+
+	if (search !== "" && !data?.length) {
+		// this can happen if someone deletes the last item while searching
+		setSearch("");
 	}
 
 	const handleDelete = async (id: number) => {
@@ -35,19 +60,6 @@ export default function TableWrapper() {
 		queryClient.invalidateQueries({ queryKey: ["proxy-host", id] });
 		showObjectSuccess("proxy-host", enabled ? "enabled" : "disabled");
 	};
-
-	let filtered = null;
-	if (search && data) {
-		filtered = data?.filter(
-			(item) =>
-				item.domainNames.some((domain: string) => domain.toLowerCase().includes(search)) ||
-				item.forwardHost.toLowerCase().includes(search) ||
-				`${item.forwardPort}`.includes(search),
-		);
-	} else if (search !== "") {
-		// this can happen if someone deletes the last item while searching
-		setSearch("");
-	}
 
 	return (
 		<div className="card mt-4">
@@ -95,7 +107,7 @@ export default function TableWrapper() {
 					</div>
 				</div>
 				<Table
-					data={filtered ?? data ?? []}
+					data={tableData}
 					isFiltered={!!search}
 					isFetching={isFetching}
 					onEdit={(id: number) => showProxyHostModal(id)}

--- a/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
+++ b/frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx
@@ -1,6 +1,6 @@
 import { IconHelp, IconSearch } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import { deleteProxyHost, toggleProxyHost } from "src/api/backend";
 import { Button, HasPermission, LoadingPage } from "src/components";
@@ -9,6 +9,7 @@ import { T } from "src/locale";
 import { showDeleteConfirmModal, showHelpModal, showProxyHostModal } from "src/modals";
 import { MANAGE, PROXY_HOSTS } from "src/modules/Permissions";
 import { showObjectSuccess } from "src/notifications";
+import { getBaseDomain } from "./baseDomain";
 import Table from "./Table";
 
 export default function TableWrapper() {
@@ -16,12 +17,36 @@ export default function TableWrapper() {
 	const [search, setSearch] = useState("");
 	const { isFetching, isLoading, isError, error, data } = useProxyHosts(["owner", "access_list", "certificate"]);
 
+	const filtered = useMemo(() => {
+		if (!search || !data) return null;
+		return data.filter(
+			(item) =>
+				item.domainNames.some((domain: string) => domain.toLowerCase().includes(search)) ||
+				item.forwardHost.toLowerCase().includes(search) ||
+				`${item.forwardPort}`.includes(search),
+		);
+	}, [search, data]);
+
+	const tableData = useMemo(
+		() =>
+			(filtered ?? data ?? []).map((item) => ({
+				...item,
+				baseDomain: getBaseDomain(item.domainNames?.[0]),
+			})),
+		[filtered, data],
+	);
+
 	if (isLoading) {
 		return <LoadingPage />;
 	}
 
 	if (isError) {
 		return <Alert variant="danger">{error?.message || "Unknown error"}</Alert>;
+	}
+
+	if (search !== "" && !data) {
+		// this can happen if someone deletes the last item while searching
+		setSearch("");
 	}
 
 	const handleDelete = async (id: number) => {
@@ -35,19 +60,6 @@ export default function TableWrapper() {
 		queryClient.invalidateQueries({ queryKey: ["proxy-host", id] });
 		showObjectSuccess("proxy-host", enabled ? "enabled" : "disabled");
 	};
-
-	let filtered = null;
-	if (search && data) {
-		filtered = data?.filter(
-			(item) =>
-				item.domainNames.some((domain: string) => domain.toLowerCase().includes(search)) ||
-				item.forwardHost.toLowerCase().includes(search) ||
-				`${item.forwardPort}`.includes(search),
-		);
-	} else if (search !== "") {
-		// this can happen if someone deletes the last item while searching
-		setSearch("");
-	}
 
 	return (
 		<div className="card mt-4">
@@ -95,7 +107,7 @@ export default function TableWrapper() {
 					</div>
 				</div>
 				<Table
-					data={filtered ?? data ?? []}
+					data={tableData}
 					isFiltered={!!search}
 					isFetching={isFetching}
 					onEdit={(id: number) => showProxyHostModal(id)}

--- a/frontend/src/pages/Nginx/ProxyHosts/baseDomain.ts
+++ b/frontend/src/pages/Nginx/ProxyHosts/baseDomain.ts
@@ -1,0 +1,6 @@
+import { getDomain } from "tldts";
+
+export function getBaseDomain(domain: string | undefined): string {
+	if (!domain) return "";
+	return getDomain(domain) ?? domain;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2555,6 +2555,18 @@ tinyrainbow@^3.1.0:
   resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
   integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
 
+tldts-core@^7.4.8:
+  version "7.4.8"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.4.8.tgz#c729aee4ff9d3670741193682a98e25a3d780dd9"
+  integrity sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==
+
+tldts@^7.4.8:
+  version "7.4.8"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-7.4.8.tgz#f2edc0d81483ea76c45827d642ccd535a3a7a4f7"
+  integrity sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==
+  dependencies:
+    tldts-core "^7.4.8"
+
 tmp@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2725,6 +2725,18 @@ tinyrainbow@^3.1.0:
   resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.1.tgz#c0168387d3d8d70b6b3c2c0936de5fee738cea20"
   integrity sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==
 
+tldts-core@^7.4.8:
+  version "7.4.8"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.4.8.tgz#c729aee4ff9d3670741193682a98e25a3d780dd9"
+  integrity sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==
+
+tldts@^7.4.8:
+  version "7.4.8"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-7.4.8.tgz#f2edc0d81483ea76c45827d642ccd535a3a7a4f7"
+  integrity sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==
+  dependencies:
+    tldts-core "^7.4.8"
+
 tmp@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"


### PR DESCRIPTION
## Summary

Groups the Proxy Hosts listing under collapsible headers keyed by each host's **base domain** (registrable domain). Once you get more than a handful of proxy hosts, the flat alphabetical list becomes hard to scan — related domains like `api.booze.pics` and `booze.pics` sit far from each other, mixed with unrelated ones like `booze.app`. Clustering by base domain makes related hosts visually adjacent and hides bulk behind expandable groups.

Grouping is **always on**, all groups expanded by default, and toggling any column header still sorts rows *within* their group.

## How base domain is computed

Base domain is extracted from `domainNames[0]` (the first entry in a host's `domainNames` array) using [`tldts`](https://www.npmjs.com/package/tldts), which is backed by the Mozilla Public Suffix List. This handles multi-level TLDs correctly:

| First domain           | Base domain      |
| ---------------------- | ---------------- |
| `api.booze.pics`       | `booze.pics`     |
| `booze.pics`           | `booze.pics`     |
| `web.booze.pics`       | `booze.pics`     |
| `api.school.co.uk`     | `school.co.uk`   |
| `school.co.uk`         | `school.co.uk`   |
| `blog.github.io`       | `blog.github.io` |
| `service.local`        | `service.local`  |

The helper (`frontend/src/pages/Nginx/ProxyHosts/baseDomain.ts`):

```ts
import { getDomain } from "tldts";

export function getBaseDomain(domain: string | undefined): string {
  if (!domain) return "";
  return getDomain(domain) ?? domain;
}
```

`getDomain` returns `null` for IPs / non-PSL suffixes; we fall back to the raw string so those hosts still cluster deterministically by their exact hostname.

### Why `domainNames[0]`?

A single proxy host can serve multiple domains — the `domainNames` field is `string[]`. Almost always they share a base (`example.com` + `www.example.com`), but occasionally a host serves domains from different bases (e.g., `['booze.app', 'booze.site', 'm.booze.pics']` — visible in the screenshot). We use the **first domain only** to pick the group, matching the existing sort behavior on the Source column (which already sorts by `domainNames?.[0]`). The full list still renders in the row, so the extra domains remain visible; they're just not indexed for grouping. Duplicating the row under every base group was rejected as more confusing than helpful (same record showing multiple times).

<img width="1354" height="720" alt="Pasted image" src="https://github.com/user-attachments/assets/334315e5-a3f8-4e00-9124-21caa62231ce" />



## Implementation notes

- Uses [`@tanstack/react-table`](https://tanstack.com/table) v9's built-in grouping and expanding — no new table library.
- `columnGroupingFeature` + `rowExpandingFeature` (and their row models) are registered in the shared `features.ts`, alongside the sorting and column-visibility features already there. They're registered app-wide rather than for this table alone because `TableBody` calls `row.getIsGrouped()` on every row of every table — the same reason the existing features are shared. Happy to split this into a ProxyHosts-only feature set if you'd rather not pay for it elsewhere.
- `baseDomain` is added as a **hidden** accessor column (`columnVisibility: { baseDomain: false }`) so it drives grouping without occupying screen space.
- `grouping` and `columnVisibility` live in `initialState` (uncontrolled), while `expanded` is controlled so a future "collapse all" toggle can hook in.
- `tableData` is memoized in `TableWrapper.tsx` to avoid re-computing baseDomains on every render.
- Group header rows use the theme-aware `table-active` class so contrast works in both light and dark themes.
- `TableBody.tsx` now branches on `row.getIsGrouped()`; leaf-row rendering is unchanged, so every other table (Redirection Hosts, Streams, Dead Hosts, Access Lists) is unaffected.

## Files changed

- `frontend/package.json` — adds `tldts` (~small, tree-shakeable PSL lib)
- `frontend/src/pages/Nginx/ProxyHosts/baseDomain.ts` (new) — `getBaseDomain` helper
- `frontend/src/pages/Nginx/ProxyHosts/TableWrapper.tsx` — injects `baseDomain` into each row via memoized map, hooks reordered to satisfy rules-of-hooks
- `frontend/src/pages/Nginx/ProxyHosts/Table.tsx` — hidden `baseDomain` accessor column + TanStack grouping/expansion config
- `frontend/src/components/Table/features.ts` — registers the grouping + expanding features and their row models
- `frontend/src/components/Table/TableBody.tsx` — renders group header rows (chevron + base domain + subrow count, click to toggle)
