### PR TITLE
Estonia language translate

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
 	"license": "MIT",
 	"scripts": {
 		"dev": "vite",
+		"prebuild": "yarn locale-compile",
 		"build": "tsc && vite build",
 		"lint": "biome lint",
 		"preview": "vite preview",

--- a/frontend/src/components/LocalePicker.tsx
+++ b/frontend/src/components/LocalePicker.tsx
@@ -39,7 +39,7 @@ function LocalePicker({ menuAlign = "start" }: Props) {
 						key={`locale-${item[0]}`}
 						onClick={(e) => {
 							e.preventDefault();
-							changeTo(item[0]);
+							changeTo(item[1]);
 						}}
 					>
 						<Flag countryCode={getFlagCodeForLocale(item[0])} /> <T id={`locale-${item[1]}`} />

--- a/frontend/src/locale/IntlProvider.tsx
+++ b/frontend/src/locale/IntlProvider.tsx
@@ -73,6 +73,7 @@ const getFlagCodeForLocale = (locale?: string) => {
     ko: "kr", // Korea
     cs: "cz", // Czechia
     ga: "ie", // Ireland (Irish)
+    et: "ee", // Estonia (Estonian)
   };
 
   if (specialCases[thisLocale]) {
@@ -101,11 +102,18 @@ const cache = createIntlCache();
 const initialMessages = loadMessages(getLocale());
 let intl = createIntl({ locale: getLocale(), messages: initialMessages }, cache);
 
+const resolveLocale = (locale: string): string => {
+  const short = locale.slice(0, 2);
+  const match = localeOptions.find(([code]) => code === short);
+  return match ? match[1] : locale;
+};
+
 const changeLocale = (locale: string): void => {
-  const messages = loadMessages(locale);
-  intl = createIntl({ locale, messages }, cache);
-  window.localStorage.setItem("locale", locale);
-  document.documentElement.lang = locale;
+  const resolvedLocale = resolveLocale(locale);
+  const messages = loadMessages(resolvedLocale);
+  intl = createIntl({ locale: resolvedLocale, messages }, cache);
+  window.localStorage.setItem("locale", resolvedLocale);
+  document.documentElement.lang = resolvedLocale;
 };
 
 // This is a translation component that wraps the translation in a span with a data

--- a/frontend/src/locale/IntlProvider.tsx
+++ b/frontend/src/locale/IntlProvider.tsx
@@ -105,7 +105,7 @@ let intl = createIntl({ locale: getLocale(), messages: initialMessages }, cache)
 const resolveLocale = (locale: string): string => {
   const short = locale.slice(0, 2);
   const match = localeOptions.find(([code]) => code === short);
-  return match ? match[1] : locale;
+  return match ? (match[1] as string) : locale;
 };
 
 const changeLocale = (locale: string): void => {

--- a/frontend/src/locale/IntlProvider.tsx
+++ b/frontend/src/locale/IntlProvider.tsx
@@ -49,7 +49,9 @@ const localeOptions = [
   ["tr", "tr-TR", langTr],
   ["hu", "hu-HU", langHu],
   ["no", "no-NO", langNo],
-];
+] as [string, string, Record<string, string>][];
+
+const localeCodeByShort = Object.fromEntries(localeOptions.map(([code, fullLocale]) => [code, fullLocale]));
 
 const loadMessages = (locale?: string): typeof langList & typeof langEn => {
   const thisLocale = (locale || "en").slice(0, 2);
@@ -103,9 +105,7 @@ const initialMessages = loadMessages(getLocale());
 let intl = createIntl({ locale: getLocale(), messages: initialMessages }, cache);
 
 const resolveLocale = (locale: string): string => {
-  const short = locale.slice(0, 2);
-  const match = localeOptions.find(([code]) => code === short);
-  return match ? (match[1] as string) : locale;
+  return localeCodeByShort[locale.slice(0, 2)] ?? locale;
 };
 
 const changeLocale = (locale: string): void => {

--- a/frontend/src/locale/Utils.test.tsx
+++ b/frontend/src/locale/Utils.test.tsx
@@ -92,6 +92,11 @@ describe("getFlagCodeForLocale", () => {
 		expect(getFlagCodeForLocale("ga-IE")).toBe("IE");
 	});
 
+	it("returns EE (Estonia) for Estonian locale, not ET (Ethiopia)", () => {
+		expect(getFlagCodeForLocale("et-EE")).toBe("EE");
+		expect(getFlagCodeForLocale("et")).toBe("EE");
+	});
+
 	it("falls back to EN when no locale is provided", () => {
 		expect(getFlagCodeForLocale()).toBe("EN");
 		expect(getFlagCodeForLocale(undefined)).toBe("EN");

--- a/frontend/src/locale/src/HelpDoc/et/AccessLists.md
+++ b/frontend/src/locale/src/HelpDoc/et/AccessLists.md
@@ -1,7 +1,7 @@
 ## Mis on juurdepääsuloend?
 
-Ligipääsuloendid pakuvad konkreetsete klientide IP-aadresside musta või valget nimekirja koos puhverserverite autentimisega põhilise HTTP-autentimise kaudu.
+Juurdepääsuloendid pakuvad konkreetsete klientide IP-aadresside musta või valget nimekirja koos _puhverserveri hostide_ autentimisega põhilise HTTP-autentimise kaudu.
 
-Saate ühe juurdepääsuloendi jaoks konfigureerida mitu kliendireeglit, kasutajanime ja parooli ning seejärel rakendada neid ühele või mitmele _puhverserverile_.
+Saate ühe juurdepääsuloendi jaoks konfigureerida mitu kliendireeglit, kasutajanime ja parooli ning seejärel rakendada seda ühele või mitmele _puhverserveri hostile_.
 
 See on kõige kasulikum edastatud veebiteenuste puhul, millel pole sisseehitatud autentimismehhanisme või kui soovite kaitsta tundmatute klientide eest.

--- a/frontend/src/locale/src/HelpDoc/et/Certificates.md
+++ b/frontend/src/locale/src/HelpDoc/et/Certificates.md
@@ -2,25 +2,20 @@
 
 ### HTTP-sertifikaat
 
-HTTP-valideeritud sertifikaat tähendab, et Let's Encrypti serverid
+HTTP-valideeritud sertifikaat tähendab, et Let's Encrypti serverid proovivad teie domeenidega ühendust luua HTTP (mitte HTTPS!) kaudu ja kui see õnnestub, väljastavad nad teile sertifikaadi.
 
-proovivad teie domeenidega ühendust luua HTTP (mitte HTTPS!) kaudu ja kui see õnnestub,
-väljastavad nad teile sertifikaadi.
+Selle meetodi jaoks peate oma domeeni(de) jaoks looma _puhverserveri hosti_, millele pääseb ligi HTTP kaudu ja mis osutab sellele Nginx Proxy Manageri installatsioonile. Pärast sertifikaadi väljastamist saate muuta _puhverserveri hosti_, et seda sertifikaati ka HTTPS-ühenduste jaoks kasutada. Sertifikaadi uuendamiseks tuleb aga _puhverserveri host_ ikkagi HTTP-juurdepääsu jaoks konfigureerida.
 
-Selle meetodi jaoks peate oma domeeni(de) jaoks looma _Proxy Host_, millele pääseb ligi HTTP kaudu ja mis osutab sellele Nginxi installile. Pärast sertifikaadi väljastamist saate muuta _Proxy Host_'i, et seda sertifikaati ka HTTPS
-ühenduste jaoks kasutada. Sertifikaadi uuendamiseks tuleb aga _Proxy Host_ ikkagi HTTP-juurdepääsu jaoks konfigureerida.
-
-See protsess _ei_ toeta metamärke kasutavaid domeene.
+See protsess _ei_ toeta metamärke (wildcard) kasutavaid domeene.
 
 ### DNS-sertifikaat
 
-DNS-i poolt valideeritud sertifikaadi saamiseks peate kasutama DNS-pakkuja pistikprogrammi. Seda DNS-teenuse pakkujat kasutatakse teie domeenis ajutiste kirjete loomiseks ja seejärel pärib Let's
-Encrypt nende kirjete kohta päringu, et veenduda, et olete omanik, ja kui see õnnestub, väljastavad nad teile sertifikaadi.
+DNS-i poolt valideeritud sertifikaadi saamiseks peate kasutama DNS-teenusepakkuja pistikprogrammi. Seda DNS-teenusepakkujat kasutatakse teie domeenis ajutiste kirjete loomiseks ja seejärel pärib Let's Encrypt nende kirjete kohta, et veenduda, et olete omanik, ning kui see õnnestub, väljastavad nad teile sertifikaadi.
 
-Selle tüüpi sertifikaadi taotlemiseks ei ole vaja luua _Proxy Host_'i. Samuti ei pea teie _Proxy Host_ olema HTTP-juurdepääsu jaoks konfigureeritud.
+Selle tüüpi sertifikaadi taotlemiseks ei ole vaja _puhverserveri hosti_ eelnevalt luua. Samuti ei pea teie _puhverserveri host_ olema HTTP-juurdepääsu jaoks konfigureeritud.
 
-See protsess _toetab_ metamärke kasutavaid domeene.
+See protsess _toetab_ metamärke (wildcard) kasutavaid domeene.
 
 ### Kohandatud sertifikaat
 
-Kasutage seda valikut oma SSL-sertifikaadi üleslaadimiseks, mille on esitanud teie enda sertifitseerimisasutus.
+Kasutage seda valikut oma SSL-sertifikaadi üleslaadimiseks, mille on väljastanud teie enda sertifitseerimisasutus.

--- a/frontend/src/locale/src/HelpDoc/et/DeadHosts.md
+++ b/frontend/src/locale/src/HelpDoc/et/DeadHosts.md
@@ -3,7 +3,8 @@
 404 host on lihtsalt hosti seadistus, mis kuvab 404 lehte.
 
 See võib olla kasulik, kui teie domeen on otsingumootorites loetletud ja soovite
-esitada kenama vealehe või konkreetselt otsingu indekseerijatele öelda, et
+kuvada kenamat vealehte või öelda otsinguindekseerijatele, et
 domeenilehed enam ei eksisteeri.
 
-Selle hosti teine eelis on selle külastatavuste logide jälgimine ja suunajate vaatamine.
+Selle hosti teine eelis on selle külastuste logide jälgimine ja
+viitajate (referrer) vaatamine.

--- a/frontend/src/locale/src/HelpDoc/et/ProxyHosts.md
+++ b/frontend/src/locale/src/HelpDoc/et/ProxyHosts.md
@@ -1,7 +1,7 @@
-## Mis on puhverserver?
+## Mis on puhverserveri host?
 
-Puhverserver on veebiteenuse sissetuleva andmevoo lõpp-punkt, mida soovite edastada.
+Puhverserveri host on veebiteenuse sissetulev lõpp-punkt, mida soovite edastada.
 
 See pakub valikulist SSL-i lõpetamist teie teenusele, millel ei pruugi olla sisseehitatud SSL-tuge.
 
-Puhverserverid on Nginxi puhverserveri halduri kõige levinum kasutusala.
+Puhverserveri hostid on Nginx Proxy Manageri kõige levinum kasutusviis.

--- a/frontend/src/locale/src/HelpDoc/et/RedirectionHosts.md
+++ b/frontend/src/locale/src/HelpDoc/et/RedirectionHosts.md
@@ -1,5 +1,5 @@
-## Mis on ümbersuunamishost?
+## Mis on ümbersuunamise host?
 
-Ümbersuunamishost suunab sissetuleva domeeni päringud ümber ja suunab vaataja teisele domeenile.
+Ümbersuunamise host suunab sissetuleva domeeni päringud ümber ja suunab vaataja teisele domeenile.
 
-Kõige levinum põhjus seda tüüpi hosti kasutamiseks on see, kui teie veebisaidi domeenid muutuvad, kuid otsingumootori või suunaja lingid osutavad endiselt vanale domeenile.
+Kõige levinum põhjus seda tüüpi hosti kasutamiseks on see, kui teie veebisaidi domeen muutub, kuid otsingumootori või viitaja (referrer) lingid osutavad endiselt vanale domeenile.

--- a/frontend/src/locale/src/HelpDoc/et/Streams.md
+++ b/frontend/src/locale/src/HelpDoc/et/Streams.md
@@ -1,5 +1,5 @@
 ## Mis on voog?
 
-Nginxi suhteliselt uus funktsioon, voog, edastab TCP/UDP liiklust otse võrgus olevale teisele arvutile.
+Nginxi suhteliselt uus funktsioon – voog edastab TCP/UDP liiklust otse võrgus olevasse teise arvutisse.
 
-Kui sul on mänguserverid, FTP- või SSH-serverid, võib see kasuks tulla.
+Kui teil on mänguservereid, FTP- või SSH-servereid, võib see kasuks tulla.

--- a/frontend/src/locale/src/et.json
+++ b/frontend/src/locale/src/et.json
@@ -1,237 +1,237 @@
 {
 	"2fa.backup-codes-remaining": {
-		"defaultMessage": "Backup codes remaining: {count}"
+		"defaultMessage": "Varukoodid alles: {count}"
 	},
 	"2fa.backup-warning": {
-		"defaultMessage": "Save these backup codes in a secure place. Each code can only be used once."
+		"defaultMessage": "Salvestage need varukoodid turvalisse kohta. Iga koodi saab kasutada ainult üks kord."
 	},
 	"2fa.disable": {
-		"defaultMessage": "Disable Two-Factor Authentication"
+		"defaultMessage": "Keela kaheastmeline autentimine"
 	},
 	"2fa.disable-confirm": {
-		"defaultMessage": "Disable 2FA"
+		"defaultMessage": "Keela 2FA"
 	},
 	"2fa.disable-warning": {
-		"defaultMessage": "Disabling two-factor authentication will make your account less secure."
+		"defaultMessage": "Kaheastmelise autentimise keelamine muudab teie konto vähem turvaliseks."
 	},
 	"2fa.disabled": {
-		"defaultMessage": "Disabled"
+		"defaultMessage": "Keelatud"
 	},
 	"2fa.done": {
-		"defaultMessage": "I have saved my backup codes"
+		"defaultMessage": "Olen varukoodid salvestanud"
 	},
 	"2fa.enable": {
-		"defaultMessage": "Enable Two-Factor Authentication"
+		"defaultMessage": "Luba kaheastmeline autentimine"
 	},
 	"2fa.enabled": {
-		"defaultMessage": "Enabled"
+		"defaultMessage": "Lubatud"
 	},
 	"2fa.enter-code": {
-		"defaultMessage": "Enter verification code"
+		"defaultMessage": "Sisestage kinnituskood"
 	},
 	"2fa.enter-code-disable": {
-		"defaultMessage": "Enter verification code to disable"
+		"defaultMessage": "Keelamiseks sisestage kinnituskood"
 	},
 	"2fa.regenerate": {
-		"defaultMessage": "Regenerate"
+		"defaultMessage": "Genereeri uuesti"
 	},
 	"2fa.regenerate-backup": {
-		"defaultMessage": "Regenerate Backup Codes"
+		"defaultMessage": "Genereeri varukoodid uuesti"
 	},
 	"2fa.regenerate-instructions": {
-		"defaultMessage": "Enter a verification code to generate new backup codes. Your old codes will be invalidated."
+		"defaultMessage": "Uute varukoodide genereerimiseks sisestage kinnituskood. Teie vanad koodid muutuvad kehtetuks."
 	},
 	"2fa.secret-key": {
-		"defaultMessage": "Secret Key"
+		"defaultMessage": "Salavõti"
 	},
 	"2fa.setup-instructions": {
-		"defaultMessage": "Scan this QR code with your authenticator app, or enter the secret manually."
+		"defaultMessage": "Skannige see QR-kood autentimisrakendusega või sisestage salavõti käsitsi."
 	},
 	"2fa.status": {
-		"defaultMessage": "Status"
+		"defaultMessage": "Olek"
 	},
 	"2fa.title": {
-		"defaultMessage": "Two-Factor Authentication"
+		"defaultMessage": "Kaheastmeline autentimine"
 	},
 	"2fa.verify-enable": {
-		"defaultMessage": "Verify and Enable"
+		"defaultMessage": "Kinnita ja luba"
 	},
 	"access-list": {
-		"defaultMessage": "Access List"
+		"defaultMessage": "Juurdepääsuloend"
 	},
 	"access-list.access-count": {
-		"defaultMessage": "{count} {count, plural, one {Rule} other {Rules}}"
+		"defaultMessage": "{count} {count, plural, one {reegel} other {reeglit}}"
 	},
 	"access-list.auth-count": {
-		"defaultMessage": "{count} {count, plural, one {User} other {Users}}"
+		"defaultMessage": "{count} {count, plural, one {kasutaja} other {kasutajat}}"
 	},
 	"access-list.help-rules-last": {
-		"defaultMessage": "When at least 1 rule exists, this deny all rule will be added last"
+		"defaultMessage": "Kui vähemalt üks reegel on olemas, lisatakse see kõikide keelamise reegel viimaseks"
 	},
 	"access-list.help.rules-order": {
-		"defaultMessage": "Note that the allow and deny directives will be applied in the order they are defined."
+		"defaultMessage": "Pange tähele, et lubamise ja keelamise direktiive rakendatakse nende määratlemise järjekorras."
 	},
 	"access-list.pass-auth": {
-		"defaultMessage": "Pass Auth to Upstream"
+		"defaultMessage": "Edasta autentimine ülesvoolu"
 	},
 	"access-list.public": {
-		"defaultMessage": "Publicly Accessible"
+		"defaultMessage": "Avalikult juurdepääsetav"
 	},
 	"access-list.public.subtitle": {
-		"defaultMessage": "No basic auth required"
+		"defaultMessage": "Põhiautentimist pole vaja"
 	},
 	"access-list.rule-source.placeholder": {
-		"defaultMessage": "192.168.1.100 or 192.168.1.0/24 or 2001:0db8::/32"
+		"defaultMessage": "192.168.1.100 või 192.168.1.0/24 või 2001:0db8::/32"
 	},
 	"access-list.satisfy-any": {
 		"defaultMessage": "Satisfy Any"
 	},
 	"access-list.subtitle": {
-		"defaultMessage": "{users} {users, plural, one {User} other {Users}}, {rules} {rules, plural, one {Rule} other {Rules}} - Created: {date}"
+		"defaultMessage": "{users} {users, plural, one {kasutaja} other {kasutajat}}, {rules} {rules, plural, one {reegel} other {reeglit}} – Loodud: {date}"
 	},
 	"access-lists": {
-		"defaultMessage": "Access Lists"
+		"defaultMessage": "Juurdepääsuloendid"
 	},
 	"action.add": {
-		"defaultMessage": "Add"
+		"defaultMessage": "Lisa"
 	},
 	"action.add-location": {
-		"defaultMessage": "Add Location"
+		"defaultMessage": "Lisa asukoht"
 	},
 	"action.allow": {
-		"defaultMessage": "Allow"
+		"defaultMessage": "Luba"
 	},
 	"action.close": {
-		"defaultMessage": "Close"
+		"defaultMessage": "Sulge"
 	},
 	"action.delete": {
-		"defaultMessage": "Delete"
+		"defaultMessage": "Kustuta"
 	},
 	"action.deny": {
-		"defaultMessage": "Deny"
+		"defaultMessage": "Keela"
 	},
 	"action.disable": {
-		"defaultMessage": "Disable"
+		"defaultMessage": "Keela"
 	},
 	"action.download": {
-		"defaultMessage": "Download"
+		"defaultMessage": "Laadi alla"
 	},
 	"action.edit": {
-		"defaultMessage": "Edit"
+		"defaultMessage": "Muuda"
 	},
 	"action.enable": {
-		"defaultMessage": "Enable"
+		"defaultMessage": "Luba"
 	},
 	"action.permissions": {
-		"defaultMessage": "Permissions"
+		"defaultMessage": "Õigused"
 	},
 	"action.renew": {
-		"defaultMessage": "Renew"
+		"defaultMessage": "Uuenda"
 	},
 	"action.view-details": {
-		"defaultMessage": "View Details"
+		"defaultMessage": "Vaata üksikasju"
 	},
 	"auditlogs": {
-		"defaultMessage": "Audit Logs"
+		"defaultMessage": "Auditi logid"
 	},
 	"auto": {
-		"defaultMessage": "Auto"
+		"defaultMessage": "Automaatne"
 	},
 	"cancel": {
-		"defaultMessage": "Cancel"
+		"defaultMessage": "Tühista"
 	},
 	"certificate": {
-		"defaultMessage": "Certificate"
+		"defaultMessage": "Sertifikaat"
 	},
 	"certificate.custom-certificate": {
-		"defaultMessage": "Certificate"
+		"defaultMessage": "Sertifikaat"
 	},
 	"certificate.custom-certificate-key": {
-		"defaultMessage": "Certificate Key"
+		"defaultMessage": "Sertifikaadi võti"
 	},
 	"certificate.custom-intermediate": {
-		"defaultMessage": "Intermediate Certificate"
+		"defaultMessage": "Vahesertifikaat"
 	},
 	"certificate.in-use": {
-		"defaultMessage": "In Use"
+		"defaultMessage": "Kasutusel"
 	},
 	"certificate.none.subtitle": {
-		"defaultMessage": "No certificate assigned"
+		"defaultMessage": "Sertifikaati pole määratud"
 	},
 	"certificate.none.subtitle.for-http": {
-		"defaultMessage": "This host will not use HTTPS"
+		"defaultMessage": "See host ei kasuta HTTPS-i"
 	},
 	"certificate.none.title": {
-		"defaultMessage": "None"
+		"defaultMessage": "Puudub"
 	},
 	"certificate.not-in-use": {
-		"defaultMessage": "Not Used"
+		"defaultMessage": "Pole kasutusel"
 	},
 	"certificate.renew": {
-		"defaultMessage": "Renew Certificate"
+		"defaultMessage": "Uuenda sertifikaati"
 	},
 	"certificates": {
-		"defaultMessage": "Certificates"
+		"defaultMessage": "Sertifikaadid"
 	},
 	"certificates.custom": {
-		"defaultMessage": "Custom Certificate"
+		"defaultMessage": "Kohandatud sertifikaat"
 	},
 	"certificates.custom.warning": {
-		"defaultMessage": "Key files protected with a passphrase are not supported."
+		"defaultMessage": "Parooliga kaitstud võtmefaile ei toetata."
 	},
 	"certificates.dns.credentials": {
-		"defaultMessage": "Credentials File Content"
+		"defaultMessage": "Mandaatide faili sisu"
 	},
 	"certificates.dns.credentials-note": {
-		"defaultMessage": "This plugin requires a configuration file containing an API token or other credentials for your provider"
+		"defaultMessage": "See pistikprogramm nõuab konfiguratsioonifaili, mis sisaldab API tokenit või muid mandaate teie teenusepakkuja jaoks"
 	},
 	"certificates.dns.credentials-warning": {
-		"defaultMessage": "This data will be stored as plaintext in the database and in a file!"
+		"defaultMessage": "Need andmed salvestatakse andmebaasi ja faili lihttekstina!"
 	},
 	"certificates.dns.propagation-seconds": {
-		"defaultMessage": "Propagation Seconds"
+		"defaultMessage": "Leviku sekundid"
 	},
 	"certificates.dns.propagation-seconds-note": {
-		"defaultMessage": "Leave empty to use the plugins default value. Number of seconds to wait for DNS propagation."
+		"defaultMessage": "Jätke tühjaks, et kasutada pistikprogrammi vaikimisi väärtust. Sekundite arv DNS-i leviku ootamiseks."
 	},
 	"certificates.dns.provider": {
-		"defaultMessage": "DNS Provider"
+		"defaultMessage": "DNS-i teenusepakkuja"
 	},
 	"certificates.dns.provider.placeholder": {
-		"defaultMessage": "Select a Provider..."
+		"defaultMessage": "Valige teenusepakkuja..."
 	},
 	"certificates.dns.warning": {
-		"defaultMessage": "This section requires some knowledge about Certbot and its DNS plugins. Please consult the respective plugins documentation."
+		"defaultMessage": "See jaotis nõuab teadmisi Certbotist ja selle DNS-i pistikprogrammidest. Palun tutvuge vastavate pistikprogrammide dokumentatsiooniga."
 	},
 	"certificates.http.reachability-404": {
-		"defaultMessage": "There is a server found at this domain but it does not seem to be Nginx Proxy Manager. Please make sure your domain points to the IP where your NPM instance is running."
+		"defaultMessage": "Sellel domeenil on server olemas, kuid see ei tundu olevat Nginx Proxy Manager. Veenduge, et teie domeen osutab IP-aadressile, kus teie NPM-i eksemplar töötab."
 	},
 	"certificates.http.reachability-failed-to-check": {
-		"defaultMessage": "Failed to check the reachability due to a communication error with site24x7.com."
+		"defaultMessage": "Kättesaadavuse kontrollimine ebaõnnestus site24x7.com-iga suhtlemise vea tõttu."
 	},
 	"certificates.http.reachability-not-resolved": {
-		"defaultMessage": "There is no server available at this domain. Please make sure your domain exists and points to the IP where your NPM instance is running and if necessary port 80 is forwarded in your router."
+		"defaultMessage": "Sellel domeenil pole serverit saadaval. Veenduge, et teie domeen eksisteerib ja osutab IP-aadressile, kus teie NPM-i eksemplar töötab, ning vajadusel on ruuteris port 80 suunatud."
 	},
 	"certificates.http.reachability-ok": {
-		"defaultMessage": "Your server is reachable and creating certificates should be possible."
+		"defaultMessage": "Teie server on kättesaadav ja sertifikaatide loomine peaks olema võimalik."
 	},
 	"certificates.http.reachability-other": {
-		"defaultMessage": "There is a server found at this domain but it returned an unexpected status code {code}. Is it the NPM server? Please make sure your domain points to the IP where your NPM instance is running."
+		"defaultMessage": "Sellel domeenil on server olemas, kuid see tagastas ootamatu olekukoodi {code}. Kas see on NPM-i server? Veenduge, et teie domeen osutab IP-aadressile, kus teie NPM-i eksemplar töötab."
 	},
 	"certificates.http.reachability-wrong-data": {
-		"defaultMessage": "There is a server found at this domain but it returned an unexpected data. Is it the NPM server? Please make sure your domain points to the IP where your NPM instance is running."
+		"defaultMessage": "Sellel domeenil on server olemas, kuid see tagastas ootamatud andmed. Kas see on NPM-i server? Veenduge, et teie domeen osutab IP-aadressile, kus teie NPM-i eksemplar töötab."
 	},
 	"certificates.http.test-results": {
-		"defaultMessage": "Test Results"
+		"defaultMessage": "Testi tulemused"
 	},
 	"certificates.http.warning": {
-		"defaultMessage": "These domains must be already configured to point to this installation."
+		"defaultMessage": "Need domeenid peavad juba olema seadistatud osutama sellele installatsioonile."
 	},
 	"certificates.key-type": {
-		"defaultMessage": "Key Type"
+		"defaultMessage": "Võtme tüüp"
 	},
 	"certificates.key-type-description": {
-		"defaultMessage": "RSA is widely compatible, ECDSA is faster and more secure but may not be supported by older systems"
+		"defaultMessage": "RSA on laialdaselt ühilduv, ECDSA on kiirem ja turvalisem, kuid vanemad süsteemid ei pruugi seda toetada"
 	},
 	"certificates.key-type-ecdsa": {
 		"defaultMessage": "ECDSA 256"
@@ -240,388 +240,388 @@
 		"defaultMessage": "RSA 2048"
 	},
 	"certificates.request.subtitle": {
-		"defaultMessage": "with Let's Encrypt"
+		"defaultMessage": "Let's Encryptiga"
 	},
 	"certificates.request.title": {
-		"defaultMessage": "Request a new Certificate"
+		"defaultMessage": "Taotle uut sertifikaati"
 	},
 	"column.access": {
-		"defaultMessage": "Access"
+		"defaultMessage": "Juurdepääs"
 	},
 	"column.authorization": {
-		"defaultMessage": "Authorization"
+		"defaultMessage": "Autoriseerimine"
 	},
 	"column.authorizations": {
-		"defaultMessage": "Authorizations"
+		"defaultMessage": "Autoriseerimised"
 	},
 	"column.custom-locations": {
-		"defaultMessage": "Custom Locations"
+		"defaultMessage": "Kohandatud asukohad"
 	},
 	"column.destination": {
-		"defaultMessage": "Destination"
+		"defaultMessage": "Sihtkoht"
 	},
 	"column.details": {
-		"defaultMessage": "Details"
+		"defaultMessage": "Üksikasjad"
 	},
 	"column.email": {
-		"defaultMessage": "Email"
+		"defaultMessage": "E-post"
 	},
 	"column.event": {
-		"defaultMessage": "Event"
+		"defaultMessage": "Sündmus"
 	},
 	"column.expires": {
-		"defaultMessage": "Expires"
+		"defaultMessage": "Aegub"
 	},
 	"column.http-code": {
-		"defaultMessage": "HTTP Code"
+		"defaultMessage": "HTTP-kood"
 	},
 	"column.incoming-port": {
-		"defaultMessage": "Incoming Port"
+		"defaultMessage": "Sissetulev port"
 	},
 	"column.name": {
-		"defaultMessage": "Name"
+		"defaultMessage": "Nimi"
 	},
 	"column.protocol": {
-		"defaultMessage": "Protocol"
+		"defaultMessage": "Protokoll"
 	},
 	"column.provider": {
-		"defaultMessage": "Provider"
+		"defaultMessage": "Teenusepakkuja"
 	},
 	"column.roles": {
-		"defaultMessage": "Roles"
+		"defaultMessage": "Rollid"
 	},
 	"column.rules": {
-		"defaultMessage": "Rules"
+		"defaultMessage": "Reeglid"
 	},
 	"column.satisfy": {
 		"defaultMessage": "Satisfy"
 	},
 	"column.satisfy-all": {
-		"defaultMessage": "All"
+		"defaultMessage": "Kõik"
 	},
 	"column.satisfy-any": {
-		"defaultMessage": "Any"
+		"defaultMessage": "Ükskõik milline"
 	},
 	"column.scheme": {
-		"defaultMessage": "Scheme"
+		"defaultMessage": "Skeem"
 	},
 	"column.source": {
-		"defaultMessage": "Source"
+		"defaultMessage": "Allikas"
 	},
 	"column.ssl": {
 		"defaultMessage": "SSL"
 	},
 	"column.status": {
-		"defaultMessage": "Status"
+		"defaultMessage": "Olek"
 	},
 	"created-on": {
-		"defaultMessage": "Created: {date}"
+		"defaultMessage": "Loodud: {date}"
 	},
 	"dashboard": {
-		"defaultMessage": "Dashboard"
+		"defaultMessage": "Töölaud"
 	},
 	"dead-host": {
-		"defaultMessage": "404 Host"
+		"defaultMessage": "404 host"
 	},
 	"dead-hosts": {
-		"defaultMessage": "404 Hosts"
+		"defaultMessage": "404 hostid"
 	},
 	"dead-hosts.count": {
-		"defaultMessage": "{count} {count, plural, one {404 Host} other {404 Hosts}}"
+		"defaultMessage": "{count} {count, plural, one {404 host} other {404 hosti}}"
 	},
 	"disabled": {
-		"defaultMessage": "Disabled"
+		"defaultMessage": "Keelatud"
 	},
 	"domain-names": {
-		"defaultMessage": "Domain Names"
+		"defaultMessage": "Domeeninimed"
 	},
 	"domain-names.max": {
-		"defaultMessage": "{count} domain names maximum"
+		"defaultMessage": "Maksimaalselt {count} domeeninime"
 	},
 	"domain-names.placeholder": {
-		"defaultMessage": "Start typing to add domain..."
+		"defaultMessage": "Alustage domeeni lisamiseks kirjutamist..."
 	},
 	"domain-names.wildcards-not-permitted": {
-		"defaultMessage": "Wildcards not permitted for this type"
+		"defaultMessage": "Metamärgid pole selle tüübi jaoks lubatud"
 	},
 	"domain-names.wildcards-not-supported": {
-		"defaultMessage": "Wildcards not supported for this CA"
+		"defaultMessage": "Metamärgid pole selle CA jaoks toetatud"
 	},
 	"domains.advanced": {
-		"defaultMessage": "Advanced"
+		"defaultMessage": "Täpsemalt"
 	},
 	"domains.force-ssl": {
-		"defaultMessage": "Force SSL"
+		"defaultMessage": "Sunnitud SSL"
 	},
 	"domains.hsts-enabled": {
-		"defaultMessage": "HSTS Enabled"
+		"defaultMessage": "HSTS lubatud"
 	},
 	"domains.hsts-subdomains": {
-		"defaultMessage": "HSTS Sub-domains"
+		"defaultMessage": "HSTS alamdomeenid"
 	},
 	"domains.http2-support": {
-		"defaultMessage": "HTTP/2 Support"
+		"defaultMessage": "HTTP/2 tugi"
 	},
 	"domains.trust-forwarded-proto": {
-		"defaultMessage": "Trust Upstream Forwarded Proto Headers"
+		"defaultMessage": "Usalda ülesvoolu edastatud proto päiseid"
 	},
 	"domains.use-dns": {
-		"defaultMessage": "Use DNS Challenge"
+		"defaultMessage": "Kasuta DNS-i väljakutset"
 	},
 	"email-address": {
-		"defaultMessage": "Email address"
+		"defaultMessage": "E-posti aadress"
 	},
 	"empty-search": {
-		"defaultMessage": "No results found"
+		"defaultMessage": "Tulemusi ei leitud"
 	},
 	"empty-subtitle": {
-		"defaultMessage": "Why don't you create one?"
+		"defaultMessage": "Miks mitte üks luua?"
 	},
 	"enabled": {
-		"defaultMessage": "Enabled"
+		"defaultMessage": "Lubatud"
 	},
 	"error.access.at-least-one": {
-		"defaultMessage": "Either one Authorization or one Access Rule is required"
+		"defaultMessage": "Vajalik on kas üks autoriseerimine või üks juurdepääsureegel"
 	},
 	"error.access.duplicate-usernames": {
-		"defaultMessage": "Authorization Usernames must be unique"
+		"defaultMessage": "Autoriseerimise kasutajanimed peavad olema unikaalsed"
 	},
 	"error.invalid-auth": {
-		"defaultMessage": "Invalid email or password"
+		"defaultMessage": "Vigane e-post või parool"
 	},
 	"error.invalid-domain": {
-		"defaultMessage": "Invalid domain: {domain}"
+		"defaultMessage": "Vigane domeen: {domain}"
 	},
 	"error.invalid-email": {
-		"defaultMessage": "Invalid email address"
+		"defaultMessage": "Vigane e-posti aadress"
 	},
 	"error.max-character-length": {
-		"defaultMessage": "Maximum length is {max} character{max, plural, one {} other {s}}"
+		"defaultMessage": "Maksimaalne pikkus on {max} märk{max, plural, one {} other {i}}"
 	},
 	"error.max-domains": {
-		"defaultMessage": "Too many domains, max is {max}"
+		"defaultMessage": "Liiga palju domeene, maksimum on {max}"
 	},
 	"error.maximum": {
-		"defaultMessage": "Maximum is {max}"
+		"defaultMessage": "Maksimum on {max}"
 	},
 	"error.min-character-length": {
-		"defaultMessage": "Minimum length is {min} character{min, plural, one {} other {s}}"
+		"defaultMessage": "Minimaalne pikkus on {min} märk{min, plural, one {} other {i}}"
 	},
 	"error.minimum": {
-		"defaultMessage": "Minimum is {min}"
+		"defaultMessage": "Miinimum on {min}"
 	},
 	"error.passwords-must-match": {
-		"defaultMessage": "Passwords must match"
+		"defaultMessage": "Paroolid peavad ühtima"
 	},
 	"error.required": {
-		"defaultMessage": "This is required"
+		"defaultMessage": "See väli on kohustuslik"
 	},
 	"expires.on": {
-		"defaultMessage": "Expires: {date}"
+		"defaultMessage": "Aegub: {date}"
 	},
 	"footer.github-fork": {
-		"defaultMessage": "Fork me on Github"
+		"defaultMessage": "Forki mind Githubis"
 	},
 	"host.flags.block-exploits": {
-		"defaultMessage": "Block Common Exploits"
+		"defaultMessage": "Blokeeri levinud ründed"
 	},
 	"host.flags.cache-assets": {
-		"defaultMessage": "Cache Assets"
+		"defaultMessage": "Vahemälu varad"
 	},
 	"host.flags.preserve-path": {
-		"defaultMessage": "Preserve Path"
+		"defaultMessage": "Säilita tee"
 	},
 	"host.flags.protocols": {
-		"defaultMessage": "Protocols"
+		"defaultMessage": "Protokollid"
 	},
 	"host.flags.websockets-upgrade": {
-		"defaultMessage": "Websockets Support"
+		"defaultMessage": "WebSocketi tugi"
 	},
 	"host.forward-port": {
-		"defaultMessage": "Forward Port"
+		"defaultMessage": "Suunamise port"
 	},
 	"host.forward-scheme": {
-		"defaultMessage": "Scheme"
+		"defaultMessage": "Skeem"
 	},
 	"hosts": {
-		"defaultMessage": "Hosts"
+		"defaultMessage": "Hostid"
 	},
 	"http-only": {
-		"defaultMessage": "HTTP Only"
+		"defaultMessage": "Ainult HTTP"
 	},
 	"lets-encrypt": {
 		"defaultMessage": "Let's Encrypt"
 	},
 	"lets-encrypt-via-dns": {
-		"defaultMessage": "Let's Encrypt via DNS"
+		"defaultMessage": "Let's Encrypt DNS-i kaudu"
 	},
 	"lets-encrypt-via-http": {
-		"defaultMessage": "Let's Encrypt via HTTP"
+		"defaultMessage": "Let's Encrypt HTTP kaudu"
 	},
 	"loading": {
-		"defaultMessage": "Loading…"
+		"defaultMessage": "Laadimine…"
 	},
 	"login.2fa-code": {
-		"defaultMessage": "Verification Code"
+		"defaultMessage": "Kinnituskood"
 	},
 	"login.2fa-code-placeholder": {
-		"defaultMessage": "Enter code"
+		"defaultMessage": "Sisestage kood"
 	},
 	"login.2fa-description": {
-		"defaultMessage": "Enter the code from your authenticator app"
+		"defaultMessage": "Sisestage kood oma autentimisrakendusest"
 	},
 	"login.2fa-title": {
-		"defaultMessage": "Two-Factor Authentication"
+		"defaultMessage": "Kaheastmeline autentimine"
 	},
 	"login.2fa-verify": {
-		"defaultMessage": "Verify"
+		"defaultMessage": "Kinnita"
 	},
 	"login.title": {
-		"defaultMessage": "Login to your account"
+		"defaultMessage": "Logige oma kontole sisse"
 	},
 	"nginx-config.label": {
-		"defaultMessage": "Custom Nginx Configuration"
+		"defaultMessage": "Kohandatud Nginx-i konfiguratsioon"
 	},
 	"nginx-config.placeholder": {
-		"defaultMessage": "# Enter your custom Nginx configuration here at your own risk!"
+		"defaultMessage": "# Sisestage siia oma kohandatud Nginx-i konfiguratsioon omal vastutusel!"
 	},
 	"no-permission-error": {
-		"defaultMessage": "You do not have access to view this."
+		"defaultMessage": "Teil puudub õigus seda vaadata."
 	},
 	"notfound.action": {
-		"defaultMessage": "Take me home"
+		"defaultMessage": "Vii mind avalehele"
 	},
 	"notfound.content": {
-		"defaultMessage": "We are sorry but the page you are looking for was not found"
+		"defaultMessage": "Vabandame, kuid otsitavat lehte ei leitud"
 	},
 	"notfound.title": {
-		"defaultMessage": "Oops… You just found an error page"
+		"defaultMessage": "Oih… Leidsite vealehe"
 	},
 	"notification.error": {
-		"defaultMessage": "Error"
+		"defaultMessage": "Viga"
 	},
 	"notification.object-deleted": {
-		"defaultMessage": "{object} has been deleted"
+		"defaultMessage": "{object} on kustutatud"
 	},
 	"notification.object-disabled": {
-		"defaultMessage": "{object} has been disabled"
+		"defaultMessage": "{object} on keelatud"
 	},
 	"notification.object-enabled": {
-		"defaultMessage": "{object} has been enabled"
+		"defaultMessage": "{object} on lubatud"
 	},
 	"notification.object-renewed": {
-		"defaultMessage": "{object} has been renewed"
+		"defaultMessage": "{object} on uuendatud"
 	},
 	"notification.object-saved": {
-		"defaultMessage": "{object} has been saved"
+		"defaultMessage": "{object} on salvestatud"
 	},
 	"notification.success": {
-		"defaultMessage": "Success"
+		"defaultMessage": "Õnnestus"
 	},
 	"object.actions-title": {
 		"defaultMessage": "{object} #{id}"
 	},
 	"object.add": {
-		"defaultMessage": "Add {object}"
+		"defaultMessage": "Lisa {object}"
 	},
 	"object.delete": {
-		"defaultMessage": "Delete {object}"
+		"defaultMessage": "Kustuta {object}"
 	},
 	"object.delete.content": {
-		"defaultMessage": "Are you sure you want to delete this {object}?"
+		"defaultMessage": "Kas olete kindel, et soovite selle {object} kustutada?"
 	},
 	"object.edit": {
-		"defaultMessage": "Edit {object}"
+		"defaultMessage": "Muuda {object}"
 	},
 	"object.empty": {
-		"defaultMessage": "There are no {objects}"
+		"defaultMessage": "{objects} puuduvad"
 	},
 	"object.event.created": {
-		"defaultMessage": "Created {object}"
+		"defaultMessage": "Loodud {object}"
 	},
 	"object.event.deleted": {
-		"defaultMessage": "Deleted {object}"
+		"defaultMessage": "Kustutatud {object}"
 	},
 	"object.event.disabled": {
-		"defaultMessage": "Disabled {object}"
+		"defaultMessage": "Keelatud {object}"
 	},
 	"object.event.enabled": {
-		"defaultMessage": "Enabled {object}"
+		"defaultMessage": "Lubatud {object}"
 	},
 	"object.event.renewed": {
-		"defaultMessage": "Renewed {object}"
+		"defaultMessage": "Uuendatud {object}"
 	},
 	"object.event.updated": {
-		"defaultMessage": "Updated {object}"
+		"defaultMessage": "Uuendatud {object}"
 	},
 	"offline": {
-		"defaultMessage": "Offline"
+		"defaultMessage": "Võrguühenduseta"
 	},
 	"online": {
-		"defaultMessage": "Online"
+		"defaultMessage": "Võrgus"
 	},
 	"options": {
-		"defaultMessage": "Options"
+		"defaultMessage": "Valikud"
 	},
 	"password": {
-		"defaultMessage": "Password"
+		"defaultMessage": "Parool"
 	},
 	"password.generate": {
-		"defaultMessage": "Generate random password"
+		"defaultMessage": "Genereeri juhuslik parool"
 	},
 	"password.hide": {
-		"defaultMessage": "Hide Password"
+		"defaultMessage": "Peida parool"
 	},
 	"password.show": {
-		"defaultMessage": "Show Password"
+		"defaultMessage": "Näita parooli"
 	},
 	"permissions.hidden": {
-		"defaultMessage": "Hidden"
+		"defaultMessage": "Peidetud"
 	},
 	"permissions.manage": {
-		"defaultMessage": "Manage"
+		"defaultMessage": "Halda"
 	},
 	"permissions.view": {
-		"defaultMessage": "View Only"
+		"defaultMessage": "Ainult vaatamine"
 	},
 	"permissions.visibility.all": {
-		"defaultMessage": "All Items"
+		"defaultMessage": "Kõik üksused"
 	},
 	"permissions.visibility.title": {
-		"defaultMessage": "Item Visibility"
+		"defaultMessage": "Üksuste nähtavus"
 	},
 	"permissions.visibility.user": {
-		"defaultMessage": "Created Items Only"
+		"defaultMessage": "Ainult loodud üksused"
 	},
 	"proxy-host": {
-		"defaultMessage": "Proxy Host"
+		"defaultMessage": "Puhverserveri host"
 	},
 	"proxy-host.forward-host": {
-		"defaultMessage": "Forward Hostname / IP"
+		"defaultMessage": "Suunamise hostinimi / IP"
 	},
 	"proxy-hosts": {
-		"defaultMessage": "Proxy Hosts"
+		"defaultMessage": "Puhverserveri hostid"
 	},
 	"proxy-hosts.count": {
-		"defaultMessage": "{count} {count, plural, one {Proxy Host} other {Proxy Hosts}}"
+		"defaultMessage": "{count} {count, plural, one {puhverserveri host} other {puhverserveri hosti}}"
 	},
 	"public": {
-		"defaultMessage": "Public"
+		"defaultMessage": "Avalik"
 	},
 	"redirection-host": {
-		"defaultMessage": "Redirection Host"
+		"defaultMessage": "Ümbersuunamise host"
 	},
 	"redirection-host.forward-domain": {
-		"defaultMessage": "Forward Domain"
+		"defaultMessage": "Suunamise domeen"
 	},
 	"redirection-host.forward-http-code": {
-		"defaultMessage": "HTTP Code"
+		"defaultMessage": "HTTP-kood"
 	},
 	"redirection-hosts": {
-		"defaultMessage": "Redirection Hosts"
+		"defaultMessage": "Ümbersuunamise hostid"
 	},
 	"redirection-hosts.count": {
-		"defaultMessage": "{count} {count, plural, one {Redirection Host} other {Redirection Hosts}}"
+		"defaultMessage": "{count} {count, plural, one {ümbersuunamise host} other {ümbersuunamise hosti}}"
 	},
 	"redirection-hosts.http-code.300": {
 		"defaultMessage": "300 Multiple Choices"
@@ -642,73 +642,73 @@
 		"defaultMessage": "308 Permanent redirect"
 	},
 	"role.admin": {
-		"defaultMessage": "Administrator"
+		"defaultMessage": "Administraator"
 	},
 	"role.standard-user": {
-		"defaultMessage": "Standard User"
+		"defaultMessage": "Tavakasutaja"
 	},
 	"save": {
-		"defaultMessage": "Save"
+		"defaultMessage": "Salvesta"
 	},
 	"setting": {
-		"defaultMessage": "Setting"
+		"defaultMessage": "Seade"
 	},
 	"settings": {
-		"defaultMessage": "Settings"
+		"defaultMessage": "Seaded"
 	},
 	"settings.default-site": {
-		"defaultMessage": "Default Site"
+		"defaultMessage": "Vaikimisi sait"
 	},
 	"settings.default-site.404": {
-		"defaultMessage": "404 Page"
+		"defaultMessage": "404 leht"
 	},
 	"settings.default-site.444": {
-		"defaultMessage": "No Response (444)"
+		"defaultMessage": "Vastus puudub (444)"
 	},
 	"settings.default-site.congratulations": {
-		"defaultMessage": "Congratulations Page"
+		"defaultMessage": "Õnnitlusleht"
 	},
 	"settings.default-site.description": {
-		"defaultMessage": "What to show when Nginx is hit with an unknown Host"
+		"defaultMessage": "Mida kuvada, kui Nginx saab päringu tundmatu hostiga"
 	},
 	"settings.default-site.html": {
-		"defaultMessage": "Custom HTML"
+		"defaultMessage": "Kohandatud HTML"
 	},
 	"settings.default-site.html.placeholder": {
-		"defaultMessage": "<!-- Enter your custom HTML content here -->"
+		"defaultMessage": "<!-- Sisestage siia oma kohandatud HTML-i sisu -->"
 	},
 	"settings.default-site.redirect": {
-		"defaultMessage": "Redirect"
+		"defaultMessage": "Ümbersuunamine"
 	},
 	"setup.preamble": {
-		"defaultMessage": "Get started by creating your admin account."
+		"defaultMessage": "Alustage administraatori konto loomisega."
 	},
 	"setup.title": {
-		"defaultMessage": "Welcome!"
+		"defaultMessage": "Tere tulemast!"
 	},
 	"sign-in": {
-		"defaultMessage": "Sign in"
+		"defaultMessage": "Logi sisse"
 	},
 	"ssl-certificate": {
-		"defaultMessage": "SSL Certificate"
+		"defaultMessage": "SSL-sertifikaat"
 	},
 	"stream": {
-		"defaultMessage": "Stream"
+		"defaultMessage": "Voog"
 	},
 	"stream.forward-host": {
-		"defaultMessage": "Forward Host"
+		"defaultMessage": "Suunamise host"
 	},
 	"stream.forward-host.placeholder": {
-		"defaultMessage": "example.com or 10.0.0.1 or 2001:db8:3333:4444:5555:6666:7777:8888"
+		"defaultMessage": "example.com või 10.0.0.1 või 2001:db8:3333:4444:5555:6666:7777:8888"
 	},
 	"stream.incoming-port": {
-		"defaultMessage": "Incoming Port"
+		"defaultMessage": "Sissetulev port"
 	},
 	"streams": {
-		"defaultMessage": "Streams"
+		"defaultMessage": "Vood"
 	},
 	"streams.count": {
-		"defaultMessage": "{count} {count, plural, one {Stream} other {Streams}}"
+		"defaultMessage": "{count} {count, plural, one {voog} other {voogu}}"
 	},
 	"streams.tcp": {
 		"defaultMessage": "TCP"
@@ -720,57 +720,57 @@
 		"defaultMessage": "Test"
 	},
 	"update-available": {
-		"defaultMessage": "Update Available: {latestVersion}"
+		"defaultMessage": "Uuendus saadaval: {latestVersion}"
 	},
 	"user": {
-		"defaultMessage": "User"
+		"defaultMessage": "Kasutaja"
 	},
 	"user.change-password": {
-		"defaultMessage": "Change Password"
+		"defaultMessage": "Muuda parooli"
 	},
 	"user.confirm-password": {
-		"defaultMessage": "Confirm Password"
+		"defaultMessage": "Kinnita parool"
 	},
 	"user.current-password": {
-		"defaultMessage": "Current Password"
+		"defaultMessage": "Praegune parool"
 	},
 	"user.edit-profile": {
-		"defaultMessage": "Edit Profile"
+		"defaultMessage": "Muuda profiili"
 	},
 	"user.full-name": {
-		"defaultMessage": "Full Name"
+		"defaultMessage": "Täisnimi"
 	},
 	"user.login-as": {
-		"defaultMessage": "Sign in as {name}"
+		"defaultMessage": "Logi sisse kasutajana {name}"
 	},
 	"user.logout": {
-		"defaultMessage": "Logout"
+		"defaultMessage": "Logi välja"
 	},
 	"user.new-password": {
-		"defaultMessage": "New Password"
+		"defaultMessage": "Uus parool"
 	},
 	"user.nickname": {
-		"defaultMessage": "Nickname"
+		"defaultMessage": "Hüüdnimi"
 	},
 	"user.set-password": {
-		"defaultMessage": "Set Password"
+		"defaultMessage": "Määra parool"
 	},
 	"user.set-permissions": {
-		"defaultMessage": "Set Permissions for {name}"
+		"defaultMessage": "Määra õigused kasutajale {name}"
 	},
 	"user.switch-dark": {
-		"defaultMessage": "Switch to Dark mode"
+		"defaultMessage": "Lülitu tumedale režiimile"
 	},
 	"user.switch-light": {
-		"defaultMessage": "Switch to Light mode"
+		"defaultMessage": "Lülitu heledale režiimile"
 	},
 	"user.two-factor": {
-		"defaultMessage": "Two-Factor Auth"
+		"defaultMessage": "Kaheastmeline autentimine"
 	},
 	"username": {
-		"defaultMessage": "Username"
+		"defaultMessage": "Kasutajanimi"
 	},
 	"users": {
-		"defaultMessage": "Users"
+		"defaultMessage": "Kasutajad"
 	}
 }


### PR DESCRIPTION
- Translate all 258 UI strings in et.json
- Fix and improve HelpDoc/et markdown files
- Align terminology with UI (e.g. puhverserveri host, ümbersuunamise host)
- Fix markdown formatting in Certificates help text