### PR TITLE
Auto-split pasted URLs into scheme/host/port on forward host fields

### DIFF
--- a/frontend/src/components/Form/LocationsFields.tsx
+++ b/frontend/src/components/Form/LocationsFields.tsx
@@ -2,9 +2,10 @@ import { IconSettings } from "@tabler/icons-react";
 import CodeEditor from "@uiw/react-textarea-code-editor";
 import cn from "classnames";
 import { useFormikContext } from "formik";
-import { useState } from "react";
+import { type ClipboardEvent, useState } from "react";
 import type { ProxyLocation } from "src/api/backend";
 import { intl, T } from "src/locale";
+import { parseForwardUrl } from "src/modules/ForwardUrl";
 import styles from "./LocationsFields.module.css";
 
 interface Props {
@@ -40,6 +41,24 @@ export function LocationsFields({ initialValues, name = "locations" }: Props) {
 
 	const handleChange = (idx: number, field: string, fieldValue: string) => {
 		const newValues = values.map((v: ProxyLocation, i: number) => (i === idx ? { ...v, [field]: fieldValue } : v));
+		setValues(newValues);
+		setFormField(newValues);
+	};
+
+	const handlePaste = (idx: number, e: ClipboardEvent<HTMLInputElement>) => {
+		const parsed = parseForwardUrl(e.clipboardData.getData("text"));
+		if (!parsed) return;
+		e.preventDefault();
+		const newValues = values.map((v: ProxyLocation, i: number) =>
+			i === idx
+				? {
+						...v,
+						forwardHost: parsed.host + (parsed.path || ""),
+						forwardPort: parsed.port,
+						forwardScheme: parsed.scheme || v.forwardScheme,
+					}
+				: v,
+		);
 		setValues(newValues);
 		setFormField(newValues);
 	};
@@ -119,6 +138,7 @@ export function LocationsFields({ initialValues, name = "locations" }: Props) {
 										placeholder="eg: 10.0.0.1/path/"
 										value={item.forwardHost}
 										onChange={(e) => handleChange(idx, "forwardHost", e.target.value)}
+										onPaste={(e) => handlePaste(idx, e)}
 									/>
 								</div>
 							</div>

--- a/frontend/src/modals/ProxyHostModal.tsx
+++ b/frontend/src/modals/ProxyHostModal.tsx
@@ -18,6 +18,7 @@ import {
 } from "src/components";
 import { useProxyHost, useSetProxyHost, useUser } from "src/hooks";
 import { T } from "src/locale";
+import { parseForwardUrl } from "src/modules/ForwardUrl";
 import { MANAGE, PROXY_HOSTS } from "src/modules/Permissions";
 import { validateNumber, validateString } from "src/modules/Validations";
 import { showObjectSuccess } from "src/notifications";
@@ -210,6 +211,27 @@ const ProxyHostModal = EasyModal.create(({ id, visible, remove }: Props) => {
 																		required
 																		placeholder="example.com"
 																		{...field}
+																		onPaste={(e) => {
+																			const parsed = parseForwardUrl(
+																				e.clipboardData.getData("text"),
+																			);
+																			if (!parsed) return;
+																			e.preventDefault();
+																			form.setFieldValue(
+																				"forwardHost",
+																				parsed.host,
+																			);
+																			form.setFieldValue(
+																				"forwardPort",
+																				parsed.port,
+																			);
+																			if (parsed.scheme) {
+																				form.setFieldValue(
+																					"forwardScheme",
+																					parsed.scheme,
+																				);
+																			}
+																		}}
 																	/>
 																	{form.errors.forwardHost ? (
 																		<div className="invalid-feedback">

--- a/frontend/src/modules/ForwardUrl.test.ts
+++ b/frontend/src/modules/ForwardUrl.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { parseForwardUrl } from "./ForwardUrl";
+
+describe("parseForwardUrl", () => {
+	it("splits a full url", () => {
+		expect(parseForwardUrl("http://192.168.5.150:8096")).toEqual({
+			scheme: "http",
+			host: "192.168.5.150",
+			port: 8096,
+			path: undefined,
+		});
+	});
+
+	it("splits https and defaults the port", () => {
+		expect(parseForwardUrl("https://example.com")).toEqual({
+			scheme: "https",
+			host: "example.com",
+			port: 443,
+			path: undefined,
+		});
+	});
+
+	it("splits host:port without touching the scheme", () => {
+		expect(parseForwardUrl("192.168.5.150:8096")).toEqual({
+			scheme: undefined,
+			host: "192.168.5.150",
+			port: 8096,
+			path: undefined,
+		});
+	});
+
+	it("keeps the path separate", () => {
+		expect(parseForwardUrl("http://example.com:8080/web/index.html")).toEqual({
+			scheme: "http",
+			host: "example.com",
+			port: 8080,
+			path: "/web/index.html",
+		});
+	});
+
+	it("keeps the query string with the path", () => {
+		expect(parseForwardUrl("http://example.com:8080/web?x=1")?.path).toEqual("/web?x=1");
+	});
+
+	it("rejects input the url parser would rewrite into a different host", () => {
+		// these would otherwise become ip addresses the user never typed
+		expect(parseForwardUrl("5000:8080")).toBeNull();
+		expect(parseForwardUrl("192.168.1:8080")).toBeNull();
+	});
+
+	it("ignores things that are not worth splitting", () => {
+		expect(parseForwardUrl("example.com")).toBeNull();
+		expect(parseForwardUrl("192.168.5.150")).toBeNull();
+		expect(parseForwardUrl("ftp://example.com:21")).toBeNull();
+		expect(parseForwardUrl("not a url")).toBeNull();
+		expect(parseForwardUrl("")).toBeNull();
+	});
+});

--- a/frontend/src/modules/ForwardUrl.ts
+++ b/frontend/src/modules/ForwardUrl.ts
@@ -1,0 +1,46 @@
+interface ParsedForwardUrl {
+	scheme?: "http" | "https";
+	host: string;
+	port: number;
+	path?: string;
+}
+
+/**
+ * Parses pasted text like "http://192.168.5.150:8096/path" so the forward
+ * scheme/host/port fields can be filled in one go. Returns null when the text
+ * isn't worth splitting (plain hostname, unsupported scheme, not a url) so the
+ * default paste can happen instead.
+ */
+export const parseForwardUrl = (text: string): ParsedForwardUrl | null => {
+	const trimmed = text.trim();
+	if (!trimmed || /\s/.test(trimmed)) {
+		return null;
+	}
+	const hasScheme = trimmed.includes("://");
+	let url: URL;
+	try {
+		url = new URL(hasScheme ? trimmed : `http://${trimmed}`);
+	} catch {
+		return null;
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		return null;
+	}
+	if (!hasScheme && !url.port) {
+		// just a hostname, nothing to split
+		return null;
+	}
+	if (!trimmed.toLowerCase().includes(url.hostname)) {
+		// the URL parser rewrote the hostname (eg "5000:8080" becomes ip
+		// "0.0.19.136") - don't silently fill in something the user never typed
+		return null;
+	}
+	const scheme = url.protocol === "https:" ? "https" : "http";
+	const path = url.pathname + url.search;
+	return {
+		scheme: hasScheme ? scheme : undefined,
+		host: url.hostname,
+		port: url.port ? Number.parseInt(url.port, 10) : scheme === "https" ? 443 : 80,
+		path: path !== "/" ? path : undefined,
+	};
+};


### PR DESCRIPTION
## Why

A very common workflow when adding a proxy host is copying a service's URL straight from the browser — e.g. `http://192.168.5.150:8096` — and pasting it into the **Forward Hostname / IP** field. Today the whole string lands in the host field, and the user has to manually delete the scheme, move the port to the port field, and set the scheme dropdown.

With this change, pasting a full URL into the Forward Hostname / IP field (on the proxy host form and on custom locations) parses it and distributes the parts: the scheme dropdown and port field are filled, and only the bare hostname/IP stays in the host field. Pasting a plain hostname or IP behaves exactly as before — the split only triggers when the pasted text parses as a URL with a scheme.

No API or backend changes; frontend-only. Unit tests included for the URL parsing module (`ForwardUrl.test.ts`).

Full disclosure: this was AI-written (boxes checked below) — I made it because I wanted the feature myself. It's been running on my own NPM instance and works for my day-to-day use, but that's the extent of the real-world testing, so review accordingly.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [x] Test addition or update

## AI Usage

- [x] AI was used to write this
- [x] AI was used to review this
