### PR TITLE
Fix nginx reload after certificate renewal

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -904,6 +904,7 @@ const internalCertificate = {
 				: internalCertificate.renewLetsEncryptSsl;
 
 			await renewMethod(certificate);
+			await internalNginx.reload();
 			const certInfo = await internalCertificate.getCertificateInfoFromFile(
 				`${internalCertificate.getLiveCertPath(certificate.id)}/fullchain.pem`,
 			);


### PR DESCRIPTION
  ## Why

  A successful Let's Encrypt renewal updates the certificate files on disk, but nginx continues serving the certificate already loaded in memory until it is reloaded.

  The shared certificate renewal path did not reload nginx after Certbot completed. This affects both HTTP and DNS challenge renewals, including Cloudflare.

  This change calls the existing nginx reload function immediately after a successful renewal, allowing the renewed certificate to be served without restarting the container or manually reloading nginx.

  This restores behavior that was lost when auto-renewal was changed to use the shared renewal function in #3392.

  Fixes #3803

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] API changes
  - [ ] Performance improvement
  - [ ] Test addition or update

  ## AI Usage

  - [ ] AI was used to write this
  - [x] AI was used to review this
