### PR TITLE
fix(stream): bracket IPv6 forward host for valid nginx upstream

### DIFF
--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import net from "node:net";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import _ from "lodash";
@@ -219,6 +220,14 @@ const internalNginx = {
 			// For redirection hosts, if the scheme is not http or https, set it to $scheme
 			if (nice_host_type === "redirection_host" && ['http', 'https'].indexOf(host.forward_scheme.toLowerCase()) === -1) {
 				host.forward_scheme = "$scheme";
+			}
+
+			// A stream forwarding to an IPv6 literal must have the address wrapped in
+			// square brackets before nginx appends ":<port>". Without the brackets nginx
+			// reads the trailing ":<port>" as part of the address and rejects the upstream
+			// ("invalid port in upstream"), so the stream saves but never activates (#5740).
+			if (nice_host_type === "stream" && net.isIPv6(host.forwarding_host)) {
+				host.forwarding_host = `[${host.forwarding_host}]`;
 			}
 
 			if (host.locations) {


### PR DESCRIPTION
## Why

Fixes #5740.

When a **Stream Host** uses an IPv6 address as its Forward Host, NPM accepts and stores it, but the generated nginx stream config is invalid, so the stream saves yet never activates.

`backend/templates/stream.conf` renders the upstream as:

```
proxy_pass {{ forwarding_host }}:{{ forwarding_port }};
```

For `forwarding_host = fe80::528:3c87:e7bb:ab08`, `forwarding_port = 25` this produces:

```
proxy_pass fe80::528:3c87:e7bb:ab08:25;
```

which nginx rejects, because an IPv6 literal must be wrapped in square brackets before the port:

```
nginx: [emerg] invalid port in upstream "fe80::528:3c87:e7bb:ab08:25"
```

The stream row is saved (`nginx_online: false`), but the config never loads.

### Fix

Normalize the stream forward host in `internalNginx.generateConfig`, in the same "manipulate the data before the template" block that already special-cases `redirection_host`. Using Node's `net.isIPv6()` (authoritative, no regex/heuristics), an IPv6 forward host is wrapped in brackets so it renders `proxy_pass [address]:port;`; IPv4 addresses and hostnames are left untouched.

`generateConfig` operates on a deep copy of the row (`JSON.parse(JSON.stringify(host_row))`), so persisted and audit-log data are unaffected — this only shapes the value handed to the template.

Scope is intentionally limited to Stream Hosts (the reported bug). Proxy Hosts use a different field/template path and are out of scope here.

### Verification

Rendered the real `backend/templates/stream.conf` with LiquidJS 10.27.0 (the version in `backend/package.json`) after applying the same normalization:

| Forward Host | Rendered `proxy_pass` |
|---|---|
| `fe80::528:3c87:e7bb:ab08` (bug report) | `proxy_pass [fe80::528:3c87:e7bb:ab08]:25;` ✅ |
| `::1` | `proxy_pass [::1]:25;` ✅ |
| `192.168.1.10` | `proxy_pass 192.168.1.10:25;` (unchanged) ✅ |
| `backend.internal` | `proxy_pass backend.internal:25;` (unchanged) ✅ |

`biome lint` passes on the changed file.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

- [ ] AI was used to write this
- [ ] AI was used to review this
