### PR TITLE
fix: trim whitespace from domain names before saving hosts

### DIFF
--- a/backend/lib/helpers.js
+++ b/backend/lib/helpers.js
@@ -55,4 +55,24 @@ const convertBoolFieldsToInt = (obj, fields) => {
  */
 const castJsonIfNeed = (colName) => (isPostgres() ? ref(colName).castText() : colName);
 
-export { parseDatePeriod, convertIntFieldsToBool, convertBoolFieldsToInt, castJsonIfNeed };
+/**
+ * Normalizes a domain_names array before it is persisted: drops null/undefined
+ * entries, trims surrounding whitespace, removes any entry that is left empty,
+ * and sorts. A leading or trailing space in a hostname produces an invalid
+ * nginx server_name/upstream, so it must be stripped before the config is built.
+ *
+ * @param   {Array}  domainNames
+ * @returns {Array}
+ */
+const cleanDomainNames = (domainNames) => {
+	if (typeof domainNames === "undefined") {
+		return [];
+	}
+	return domainNames
+		.filter((name) => name != null)
+		.map((name) => name.trim())
+		.filter((name) => name.length > 0)
+		.sort();
+};
+
+export { parseDatePeriod, convertIntFieldsToBool, convertBoolFieldsToInt, castJsonIfNeed, cleanDomainNames };

--- a/backend/models/certificate.js
+++ b/backend/models/certificate.js
@@ -3,7 +3,7 @@
 
 import { Model } from "objection";
 import db from "../db.js";
-import { convertBoolFieldsToInt, convertIntFieldsToBool } from "../lib/helpers.js";
+import { cleanDomainNames, convertBoolFieldsToInt, convertIntFieldsToBool } from "../lib/helpers.js";
 import deadHostModel from "./dead_host.js";
 import now from "./now_helper.js";
 import proxyHostModel from "./proxy_host.js";
@@ -14,16 +14,6 @@ import userModel from "./user.js";
 Model.knex(db());
 
 const boolFields = ["is_deleted"];
-
-const cleanDomainNames = (domainNames) => {
-	// Sort domain_names
-	if (typeof domainNames !== "undefined") {
-		const newDomainNames = domainNames.filter((name) => name != null);
-		newDomainNames.sort();
-		return newDomainNames;
-	}
-	return [];
-};
 
 class Certificate extends Model {
 	$beforeInsert() {

--- a/backend/models/dead_host.js
+++ b/backend/models/dead_host.js
@@ -3,7 +3,7 @@
 
 import { Model } from "objection";
 import db from "../db.js";
-import { castJsonIfNeed, convertBoolFieldsToInt, convertIntFieldsToBool } from "../lib/helpers.js";
+import { castJsonIfNeed, cleanDomainNames, convertBoolFieldsToInt, convertIntFieldsToBool } from "../lib/helpers.js";
 import Certificate from "./certificate.js";
 import now from "./now_helper.js";
 import User from "./user.js";
@@ -27,15 +27,14 @@ class DeadHost extends Model {
 			this.meta = {};
 		}
 
-		this.domain_names.sort();
+		this.domain_names = cleanDomainNames(this.domain_names);
 	}
 
 	$beforeUpdate() {
 		this.modified_on = now();
 
-		// Sort domain_names
 		if (typeof this.domain_names !== "undefined") {
-			this.domain_names.sort();
+			this.domain_names = cleanDomainNames(this.domain_names);
 		}
 	}
 

--- a/backend/models/proxy_host.js
+++ b/backend/models/proxy_host.js
@@ -3,7 +3,7 @@
 
 import { Model } from "objection";
 import db from "../db.js";
-import { castJsonIfNeed, convertBoolFieldsToInt, convertIntFieldsToBool } from "../lib/helpers.js";
+import { castJsonIfNeed, cleanDomainNames, convertBoolFieldsToInt, convertIntFieldsToBool } from "../lib/helpers.js";
 import AccessList from "./access_list.js";
 import Certificate from "./certificate.js";
 import now from "./now_helper.js";
@@ -39,15 +39,14 @@ class ProxyHost extends Model {
 			this.meta = {};
 		}
 
-		this.domain_names.sort();
+		this.domain_names = cleanDomainNames(this.domain_names);
 	}
 
 	$beforeUpdate() {
 		this.modified_on = now();
 
-		// Sort domain_names
 		if (typeof this.domain_names !== "undefined") {
-			this.domain_names.sort();
+			this.domain_names = cleanDomainNames(this.domain_names);
 		}
 	}
 

--- a/backend/models/redirection_host.js
+++ b/backend/models/redirection_host.js
@@ -3,7 +3,7 @@
 
 import { Model } from "objection";
 import db from "../db.js";
-import { castJsonIfNeed, convertBoolFieldsToInt, convertIntFieldsToBool } from "../lib/helpers.js";
+import { castJsonIfNeed, cleanDomainNames, convertBoolFieldsToInt, convertIntFieldsToBool } from "../lib/helpers.js";
 import Certificate from "./certificate.js";
 import now from "./now_helper.js";
 import User from "./user.js";
@@ -36,15 +36,14 @@ class RedirectionHost extends Model {
 			this.meta = {};
 		}
 
-		this.domain_names.sort();
+		this.domain_names = cleanDomainNames(this.domain_names);
 	}
 
 	$beforeUpdate() {
 		this.modified_on = now();
 
-		// Sort domain_names
 		if (typeof this.domain_names !== "undefined") {
-			this.domain_names.sort();
+			this.domain_names = cleanDomainNames(this.domain_names);
 		}
 	}
 


### PR DESCRIPTION
## Why

Fixes #5654.

When a domain/host is entered with a leading or trailing space (easy to do via copy‑paste), NPM stores the space verbatim. The generated nginx config then contains an invalid `server_name`/upstream, so the host **saves but never loads** — the user sees a misleading `502` that looks like an upstream problem rather than bad input.

### Fix

The `proxy_host`, `dead_host` and `redirection_host` models each sorted `domain_names` in their `$beforeInsert`/`$beforeUpdate` hooks but never trimmed them, and `certificate.js` carried its own near‑identical (also untrimmed) `cleanDomainNames`.

This adds a single shared `cleanDomainNames` helper in `backend/lib/helpers.js` that:

- drops `null`/`undefined` entries,
- **trims surrounding whitespace**,
- removes any entry left empty after trimming,
- sorts,

and uses it across all four models, replacing the ad‑hoc per‑model `.sort()` and removing the duplicated copy in `certificate.js`. Trimming now applies consistently to every host type (and certificates) at the persistence layer.

Behaviour is a superset of the previous logic (which already filtered `null` and sorted), so existing well‑formed input is unaffected.

### Verification

- `biome lint` passes on all five changed files.
- Unit-style checks of the helper:

  | Input | Output |
  |---|---|
  | `[" example.com ", "b.com"]` | `["b.com", "example.com"]` |
  | `["  spaced.test  "]` | `["spaced.test"]` |
  | `["z.com", "a.com", ""]` | `["a.com", "z.com"]` |
  | `["keep.com", null, "  ", "  x.io"]` | `["keep.com", "x.io"]` |
  | `undefined` | `[]` |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

- [ ] AI was used to write this
- [ ] AI was used to review this
