### PR TITLE
Add default_allow feature to access lists and integrate ASN resolution

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import app from "./app.js";
+import internalAsn from "./internal/asn.js";
 import internalCertificate from "./internal/certificate.js";
 import internalIpRanges from "./internal/ip_ranges.js";
 import { global as logger } from "./logger.js";
@@ -27,6 +28,7 @@ async function appStart() {
 		.then(() => {
 			internalCertificate.initTimer();
 			internalIpRanges.initTimer();
+			internalAsn.initTimer();
 
 			const server = app.listen(3000, () => {
 				logger.info(`Backend PID ${process.pid} listening on port 3000 ...`);

--- a/backend/internal/access-list.js
+++ b/backend/internal/access-list.js
@@ -8,11 +8,42 @@ import accessListModel from "../models/access_list.js";
 import accessListAuthModel from "../models/access_list_auth.js";
 import accessListClientModel from "../models/access_list_client.js";
 import proxyHostModel from "../models/proxy_host.js";
+import internalAsn from "./asn.js";
 import internalAuditLog from "./audit-log.js";
 import internalNginx from "./nginx.js";
 
 const omissions = () => {
 	return ["is_deleted"];
+};
+
+/**
+ * Builds the insertable client rows, resolving ASN prefixes up front so a
+ * resolution failure aborts before anything is written to the database.
+ *
+ * @param   {Integer} accessListId
+ * @param   {Array}   clients
+ * @returns {Promise} resolving to an array of insertable rows
+ */
+const buildClientRows = async (accessListId, clients) => {
+	const rows = [];
+	for (const client of clients) {
+		if (!client.address) {
+			continue;
+		}
+		const row = {
+			access_list_id: accessListId,
+			address: client.address,
+			directive: client.directive,
+		};
+		if (internalAsn.regex.test(client.address)) {
+			row.meta = {
+				asn_prefixes: await internalAsn.resolvePrefixes(client.address),
+				asn_fetched_on: new Date().toISOString(),
+			};
+		}
+		rows.push(row);
+	}
+	return rows;
 };
 
 const internalAccessList = {
@@ -29,6 +60,7 @@ const internalAccessList = {
 				name: data.name,
 				satisfy_any: data.satisfy_any,
 				pass_auth: data.pass_auth,
+				default_allow: data.default_allow,
 				owner_user_id: access.token.getUserId(1),
 			})
 			.then(utils.omitRow(omissions()));
@@ -51,12 +83,8 @@ const internalAccessList = {
 		await Promise.all(promises);
 
 		// Clients
-		for (const client of data.clients ?? []) {
-			await accessListClientModel.query().insert({
-				access_list_id: row.id,
-				address: client.address,
-				directive: client.directive,
-			});
+		for (const clientRow of await buildClientRows(row.id, data.clients ?? [])) {
+			await accessListClientModel.query().insert(clientRow);
 		}
 
 		// re-fetch with expansions
@@ -112,6 +140,7 @@ const internalAccessList = {
 				name: data.name,
 				satisfy_any: data.satisfy_any,
 				pass_auth: data.pass_auth,
+				default_allow: data.default_allow,
 			});
 		}
 
@@ -151,17 +180,14 @@ const internalAccessList = {
 
 		// Check for clients and add/update/remove them
 		if (typeof data.clients !== "undefined" && data.clients) {
-			const query = accessListClientModel.query().delete().where("access_list_id", data.id);
-			await query;
+			// Resolve ASN prefixes before deleting anything so a failed
+			// resolution doesn't leave the list half-saved
+			const clientRows = await buildClientRows(data.id, data.clients);
 
-			for (const client of data.clients) {
-				if (client.address) {
-					await accessListClientModel.query().insert({
-						access_list_id: data.id,
-						address: client.address,
-						directive: client.directive,
-					});
-				}
+			await accessListClientModel.query().delete().where("access_list_id", data.id);
+
+			for (const clientRow of clientRows) {
+				await accessListClientModel.query().insert(clientRow);
 			}
 		}
 

--- a/backend/internal/asn.js
+++ b/backend/internal/asn.js
@@ -1,0 +1,122 @@
+import errs from "../lib/error.js";
+import { asn as logger } from "../logger.js";
+import accessListClientModel from "../models/access_list_client.js";
+import proxyHostModel from "../models/proxy_host.js";
+import internalIpRanges from "./ip_ranges.js";
+import internalNginx from "./nginx.js";
+
+const RIPE_ANNOUNCED_PREFIXES_URL = "https://stat.ripe.net/data/announced-prefixes/data.json?resource=";
+
+const internalAsn = {
+	interval_timeout: 1000 * 60 * 60 * 6, // 6 hours
+	interval: null,
+	interval_processing: false,
+
+	regex: /^AS\d+$/i,
+
+	initTimer: () => {
+		logger.info("ASN Prefixes Renewal Timer initialized");
+		internalAsn.interval = setInterval(internalAsn.refresh, internalAsn.interval_timeout);
+	},
+
+	/**
+	 * Resolves the announced prefixes for an AS number via the RIPEstat API
+	 *
+	 * @param   {String}  address  eg "AS12345"
+	 * @returns {Promise} resolving to an array of prefix strings
+	 */
+	resolvePrefixes: async (address) => {
+		const asn = address.toUpperCase();
+		logger.info(`Resolving announced prefixes for ${asn}`);
+
+		let prefixes;
+		try {
+			const raw = await internalIpRanges.fetchUrl(`${RIPE_ANNOUNCED_PREFIXES_URL}${asn}`);
+			prefixes = (JSON.parse(raw)?.data?.prefixes || []).map((item) => item.prefix);
+		} catch (err) {
+			throw new errs.ValidationError(`Could not resolve announced prefixes for ${asn}: ${err.message}`);
+		}
+
+		// Never accept an empty result: a deny rule that expands to nothing would fail open
+		if (!prefixes.length) {
+			throw new errs.ValidationError(`No announced prefixes found for ${asn}`);
+		}
+		return prefixes;
+	},
+
+	/**
+	 * Triggered by a timer, this refreshes the cached prefixes of all ASN access
+	 * rules and regenerates the configs of affected proxy hosts. Rules whose
+	 * resolution fails keep their previously cached prefixes.
+	 *
+	 * @returns {Promise}
+	 */
+	refresh: async () => {
+		if (internalAsn.interval_processing) {
+			return;
+		}
+		internalAsn.interval_processing = true;
+
+		try {
+			const clients = await accessListClientModel.query().withGraphFetched("access_list");
+			const asnClients = clients.filter(
+				(client) => client.access_list && internalAsn.regex.test(client.address),
+			);
+
+			if (asnClients.length) {
+				logger.info(`Refreshing announced prefixes for ${asnClients.length} ASN access rules...`);
+
+				// Resolve each distinct ASN once
+				const prefixesByAsn = {};
+				for (const asn of new Set(asnClients.map((client) => client.address.toUpperCase()))) {
+					try {
+						prefixesByAsn[asn] = await internalAsn.resolvePrefixes(asn);
+					} catch (err) {
+						logger.error(`Keeping cached prefixes for ${asn}: ${err.message}`);
+					}
+				}
+
+				const changedListIds = new Set();
+				for (const client of asnClients) {
+					const prefixes = prefixesByAsn[client.address.toUpperCase()];
+					if (!prefixes) {
+						continue;
+					}
+					if (JSON.stringify(prefixes) !== JSON.stringify(client.meta?.asn_prefixes || [])) {
+						changedListIds.add(client.access_list_id);
+					}
+					await accessListClientModel
+						.query()
+						.where("id", client.id)
+						.patch({
+							meta: {
+								...client.meta,
+								asn_prefixes: prefixes,
+								asn_fetched_on: new Date().toISOString(),
+							},
+						});
+				}
+
+				if (changedListIds.size) {
+					const hosts = await proxyHostModel
+						.query()
+						.where("is_deleted", 0)
+						.whereIn("access_list_id", Array.from(changedListIds))
+						.withGraphFetched("[certificate,access_list.[clients,items]]");
+
+					if (hosts.length) {
+						logger.info(`ASN prefixes changed, regenerating ${hosts.length} proxy host configs`);
+						await internalNginx.bulkGenerateConfigs("proxy_host", hosts);
+						await internalNginx.reload();
+					}
+				}
+			}
+		} catch (err) {
+			logger.error(`ASN prefix refresh failed: ${err.message}`);
+		} finally {
+			internalAsn.interval_processing = false;
+		}
+	},
+};
+
+export default internalAsn;

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -93,9 +93,16 @@ const getRenderEngine = () => {
 	 *
 	 * directive  string
 	 * address    string
+	 *
+	 * An AS number address (eg "AS12345") expands to one rule per announced
+	 * prefix, resolved at save time and cached in meta.asn_prefixes.
 	 */
 	renderEngine.registerFilter("nginxAccessRule", (v) => {
 		if (typeof v.directive !== "undefined" && typeof v.address !== "undefined" && v.directive && v.address) {
+			if (/^AS\d+$/i.test(v.address)) {
+				const prefixes = v.meta?.asn_prefixes || [];
+				return prefixes.map((prefix) => `${v.directive} ${prefix}; # ${v.address.toUpperCase()}`).join("\n    ");
+			}
 			return `${v.directive} ${v.address};`;
 		}
 		return "";

--- a/backend/logger.js
+++ b/backend/logger.js
@@ -15,6 +15,7 @@ const certbot = new signale.Signale({ scope: "Certbot  ", ...opts });
 const importer = new signale.Signale({ scope: "Importer ", ...opts });
 const setup = new signale.Signale({ scope: "Setup    ", ...opts });
 const ipRanges = new signale.Signale({ scope: "IP Ranges", ...opts });
+const asn = new signale.Signale({ scope: "ASN      ", ...opts });
 const remoteVersion = new signale.Signale({ scope: "Remote Version", ...opts });
 
 const debug = (logger, ...args) => {
@@ -23,4 +24,4 @@ const debug = (logger, ...args) => {
 	}
 };
 
-export { debug, global, migrate, express, access, nginx, ssl, certbot, importer, setup, ipRanges, remoteVersion };
+export { debug, global, migrate, express, access, nginx, ssl, certbot, importer, setup, ipRanges, asn, remoteVersion };

--- a/backend/migrations/20260730000000_access_list_default_allow.js
+++ b/backend/migrations/20260730000000_access_list_default_allow.js
@@ -1,0 +1,43 @@
+import { migrate as logger } from "../logger.js";
+
+const migrateName = "access_list_default_allow";
+
+/**
+ * Migrate
+ *
+ * @see http://knexjs.org/#Schema
+ *
+ * @param   {Object}  knex
+ * @returns {Promise}
+ */
+const up = (knex) => {
+	logger.info(`[${migrateName}] Migrating Up...`);
+
+	return knex.schema
+		.table("access_list", (access_list) => {
+			access_list.integer("default_allow").notNull().defaultTo(0);
+		})
+		.then(() => {
+			logger.info(`[${migrateName}] access_list Table altered`);
+		});
+};
+
+/**
+ * Undo Migrate
+ *
+ * @param {Object} knex
+ * @returns {Promise}
+ */
+const down = (knex) => {
+	logger.info(`[${migrateName}] Migrating Down...`);
+
+	return knex.schema
+		.table("access_list", (access_list) => {
+			access_list.dropColumn("default_allow");
+		})
+		.then(() => {
+			logger.info(`[${migrateName}] access_list default_allow Column dropped`);
+		});
+};
+
+export { up, down };

--- a/backend/models/access_list.js
+++ b/backend/models/access_list.js
@@ -12,7 +12,7 @@ import User from "./user.js";
 
 Model.knex(db());
 
-const boolFields = ["is_deleted", "satisfy_any", "pass_auth"];
+const boolFields = ["is_deleted", "satisfy_any", "pass_auth", "default_allow"];
 
 class AccessList extends Model {
 	$beforeInsert() {

--- a/backend/schema/common.json
+++ b/backend/schema/common.json
@@ -152,6 +152,10 @@
 				{
 					"type": "string",
 					"pattern": "^all$"
+				},
+				{
+					"type": "string",
+					"pattern": "^[Aa][Ss][0-9]+$"
 				}
 			],
 			"example": "192.168.0.11"

--- a/backend/schema/components/access-list-object.json
+++ b/backend/schema/components/access-list-object.json
@@ -1,7 +1,7 @@
 {
 	"type": "object",
 	"description": "Access List object",
-	"required": ["id", "created_on", "modified_on", "owner_user_id", "name", "meta", "satisfy_any", "pass_auth", "proxy_host_count"],
+	"required": ["id", "created_on", "modified_on", "owner_user_id", "name", "meta", "satisfy_any", "pass_auth", "default_allow", "proxy_host_count"],
 	"properties": {
 		"id": {
 			"$ref": "../common.json#/properties/id"
@@ -29,6 +29,11 @@
 			"example": true
 		},
 		"pass_auth": {
+			"type": "boolean",
+			"example": false
+		},
+		"default_allow": {
+			"description": "When true, clients not matching any rule are allowed instead of denied",
 			"type": "boolean",
 			"example": false
 		},

--- a/backend/schema/paths/nginx/access-lists/get.json
+++ b/backend/schema/paths/nginx/access-lists/get.json
@@ -39,6 +39,7 @@
 						"meta": {},
 						"satisfy_any": true,
 						"pass_auth": false,
+						"default_allow": false,
 						"proxy_host_count": 0
 					},
 					"schema": {

--- a/backend/schema/paths/nginx/access-lists/listID/get.json
+++ b/backend/schema/paths/nginx/access-lists/listID/get.json
@@ -40,6 +40,7 @@
                                 "meta": {},
                                 "satisfy_any": false,
                                 "pass_auth": false,
+                                "default_allow": false,
                                 "proxy_host_count": 1
                             }
                         }

--- a/backend/schema/paths/nginx/access-lists/listID/put.json
+++ b/backend/schema/paths/nginx/access-lists/listID/put.json
@@ -39,6 +39,9 @@
 						"pass_auth": {
 							"$ref": "../../../../components/access-list-object.json#/properties/pass_auth"
 						},
+						"default_allow": {
+							"$ref": "../../../../components/access-list-object.json#/properties/default_allow"
+						},
 						"items": {
 							"$ref": "../../../../common.json#/properties/access_items"
 						},
@@ -51,6 +54,7 @@
 					"name": "My Access List",
 					"satisfy_any": true,
 					"pass_auth": false,
+					"default_allow": false,
 					"items": [
 						{
 							"username": "admin2",
@@ -83,6 +87,7 @@
 								"meta": {},
 								"satisfy_any": true,
 								"pass_auth": false,
+								"default_allow": false,
 								"proxy_host_count": 0,
 								"owner": {
 									"id": 1,

--- a/backend/schema/paths/nginx/access-lists/post.json
+++ b/backend/schema/paths/nginx/access-lists/post.json
@@ -30,6 +30,9 @@
 						"pass_auth": {
 							"$ref": "../../../components/access-list-object.json#/properties/pass_auth"
 						},
+						"default_allow": {
+							"$ref": "../../../components/access-list-object.json#/properties/default_allow"
+						},
 						"items": {
 							"$ref": "../../../common.json#/properties/access_items"
 						},
@@ -42,6 +45,7 @@
 					"name": "My Access List",
 					"satisfy_any": true,
 					"pass_auth": false,
+					"default_allow": false,
 					"items": [
 						{
 							"username": "admin",
@@ -74,6 +78,7 @@
 								"meta": {},
 								"satisfy_any": true,
 								"pass_auth": false,
+								"default_allow": false,
 								"proxy_host_count": 0,
 								"owner": {
 									"id": 1,

--- a/backend/templates/_access.conf
+++ b/backend/templates/_access.conf
@@ -15,7 +15,11 @@
     {% for client in access_list.clients %}
     {{client | nginxAccessRule}}
     {% endfor %}
+    {% if access_list.default_allow == 1 or access_list.default_allow == true %}
+    allow all;
+    {% else %}
     deny all;
+    {% endif %}
     {% endif %}
 
     # Access checks must...

--- a/frontend/src/api/backend/models.ts
+++ b/frontend/src/api/backend/models.ts
@@ -53,6 +53,7 @@ export interface AccessList {
 	meta: Record<string, any>;
 	satisfyAny: boolean;
 	passAuth: boolean;
+	defaultAllow: boolean;
 	proxyHostCount?: number;
 	// Expansions:
 	owner?: User;

--- a/frontend/src/components/Form/AccessClientFields.tsx
+++ b/frontend/src/components/Form/AccessClientFields.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 export function AccessClientFields({ initialValues, name = "clients" }: Props) {
 	const [values, setValues] = useState<AccessListClient[]>(initialValues || []);
-	const { setFieldValue } = useFormikContext();
+	const { setFieldValue, values: formValues } = useFormikContext<any>();
 
 	const blankClient: AccessListClient = { directive: "allow", address: "" };
 
@@ -49,6 +49,9 @@ export function AccessClientFields({ initialValues, name = "clients" }: Props) {
 		<>
 			<p className="text-muted">
 				<T id="access-list.help.rules-order" />
+			</p>
+			<p className="text-muted">
+				<T id="access-list.help-asn" />
 			</p>
 			{values.map((client: AccessListClient, idx: number) => (
 				<div className="row mb-1" key={idx}>
@@ -107,11 +110,16 @@ export function AccessClientFields({ initialValues, name = "clients" }: Props) {
 					<div className="input-group mb-2">
 						<span className="input-group-select">
 							<select
-								className="form-select m-0 bg-orange-lt"
-								name="clients[last].directive"
-								value="deny"
-								disabled
+								className={cn(
+									"form-select",
+									"m-0",
+									formValues?.defaultAllow ? "bg-lime-lt" : "bg-orange-lt",
+								)}
+								name="defaultAllow"
+								value={formValues?.defaultAllow ? "allow" : "deny"}
+								onChange={(e) => setFieldValue("defaultAllow", e.target.value === "allow")}
 							>
+								<option value="allow"><T id="action.allow" /></option>
 								<option value="deny"><T id="action.deny" /></option>
 							</select>
 						</span>

--- a/frontend/src/hooks/useAccessList.ts
+++ b/frontend/src/hooks/useAccessList.ts
@@ -17,6 +17,7 @@ const fetchAccessList = (id: number | "new", expand: AccessListExpansion[] = ["o
 			name: "",
 			satisfyAny: false,
 			passAuth: false,
+			defaultAllow: false,
 			meta: {},
 		} as AccessList);
 	}

--- a/frontend/src/locale/src/de.json
+++ b/frontend/src/locale/src/de.json
@@ -8,8 +8,11 @@
 	"access-list.auth-count": {
 		"defaultMessage": "{count} {count, plural, one {User} other {Users}}"
 	},
+	"access-list.help-asn": {
+		"defaultMessage": "AS-Nummern (z. B. AS12345) werden beim Speichern der Liste in die zugehörigen angekündigten IP-Präfixe aufgelöst und alle 6 Stunden automatisch aktualisiert."
+	},
 	"access-list.help-rules-last": {
-		"defaultMessage": "Wenn mindestens eine Regel vorhanden ist, wird diese Regel zum Ablehnen aller Anfragen als letzte hinzugefügt."
+		"defaultMessage": "Wenn mindestens eine Regel vorhanden ist, wird diese abschließende Regel als letzte hinzugefügt und bestimmt, was mit Anfragen geschieht, die keine der obigen Regeln erfüllen."
 	},
 	"access-list.help.rules-order": {
 		"defaultMessage": "Beachten Sie, dass die Anweisungen „Erlauben“ und „Verbieten“ in der Reihenfolge ihrer Definition angewendet werden."

--- a/frontend/src/locale/src/en.json
+++ b/frontend/src/locale/src/en.json
@@ -65,8 +65,11 @@
 	"access-list.auth-count": {
 		"defaultMessage": "{count} {count, plural, one {User} other {Users}}"
 	},
+	"access-list.help-asn": {
+		"defaultMessage": "AS numbers (eg AS12345) are expanded to their announced IP prefixes when the list is saved and refreshed automatically every 6 hours."
+	},
 	"access-list.help-rules-last": {
-		"defaultMessage": "When at least 1 rule exists, this deny all rule will be added last"
+		"defaultMessage": "When at least 1 rule exists, this final rule will be added last and decides the fate of clients not matching any rule above"
 	},
 	"access-list.help.rules-order": {
 		"defaultMessage": "Note that the allow and deny directives will be applied in the order they are defined."
@@ -81,7 +84,7 @@
 		"defaultMessage": "No basic auth required"
 	},
 	"access-list.rule-source.placeholder": {
-		"defaultMessage": "192.168.1.100 or 192.168.1.0/24 or 2001:0db8::/32"
+		"defaultMessage": "192.168.1.100 or 192.168.1.0/24 or 2001:0db8::/32 or AS12345"
 	},
 	"access-list.satisfy-any": {
 		"defaultMessage": "Satisfy Any"

--- a/frontend/src/modals/AccessListModal.tsx
+++ b/frontend/src/modals/AccessListModal.tsx
@@ -100,6 +100,7 @@ const AccessListModal = EasyModal.create(({ id, visible, remove }: Props) => {
 							name: data?.name,
 							satisfyAny: data?.satisfyAny,
 							passAuth: data?.passAuth,
+							defaultAllow: data?.defaultAllow ?? false,
 							items: data?.items || [],
 							clients: data?.clients || [],
 						} as AccessList

--- a/test/cypress/e2e/api/AccessLists.cy.js
+++ b/test/cypress/e2e/api/AccessLists.cy.js
@@ -1,0 +1,74 @@
+/// <reference types="cypress" />
+
+describe('Access Lists endpoints', () => {
+	let token;
+	let listId;
+
+	before(() => {
+		cy.resetUsers();
+		cy.getToken().then((tok) => {
+			token = tok;
+		});
+	});
+
+	it('Should be able to create an access list with default_allow', () => {
+		cy.task('backendApiPost', {
+			token: token,
+			path:  '/api/nginx/access-lists',
+			data:  {
+				name:          'Test Blocklist',
+				satisfy_any:   true,
+				pass_auth:     false,
+				default_allow: true,
+				items:         [],
+				clients:       [
+					{
+						directive: 'deny',
+						address:   '192.168.0.0/24'
+					}
+				]
+			}
+		}).then((data) => {
+			cy.validateSwaggerSchema('post', 201, '/nginx/access-lists', data);
+			expect(data).to.have.property('id');
+			expect(data.id).to.be.greaterThan(0);
+			expect(data).to.have.property('default_allow', true);
+			listId = data.id;
+		});
+	});
+
+	it('Should be able to update the default_allow flag', () => {
+		cy.task('backendApiPut', {
+			token: token,
+			path:  `/api/nginx/access-lists/${listId}`,
+			data:  {
+				name:          'Test Blocklist',
+				default_allow: false
+			}
+		}).then((data) => {
+			cy.validateSwaggerSchema('put', 200, '/nginx/access-lists/{listID}', data);
+			expect(data).to.have.property('id', listId);
+			expect(data).to.have.property('default_allow', false);
+		});
+	});
+
+	it('Should default to default_allow false when not given', () => {
+		cy.task('backendApiPost', {
+			token: token,
+			path:  '/api/nginx/access-lists',
+			data:  {
+				name:    'Test Allowlist',
+				items:   [],
+				clients: [
+					{
+						directive: 'allow',
+						address:   '10.0.0.0/8'
+					}
+				]
+			}
+		}).then((data) => {
+			cy.validateSwaggerSchema('post', 201, '/nginx/access-lists', data);
+			expect(data).to.have.property('default_allow', false);
+		});
+	});
+});


### PR DESCRIPTION
- Introduced default_allow property in access lists to allow clients not matching any rule.
- Implemented ASN prefix resolution for clients using AS numbers.
- Updated related schemas, models, and templates to support the new feature.
- Added Cypress tests for creating and updating access lists with default_allow functionality.

## Why

Access Lists currently only support an allowlist model: any client rules are always followed by an implicit deny all, so it is impossible to run a blocklist
("block these networks, allow everyone else"). This PR adds two new capabilities to Access Lists:

1. A new per-list boolean (default_allow), which switches the implicit rule from deny all to allow all.
2. Filtering by AS-Number, as adding all prefixes for a specific network to be added or blocked can be very tedious (some ASNs like AS3320 have ~ 1 025 prefixes). Since nginx has no native ASN support, the backend fetches the ASNs announced prefixes via the RIPEstat API every 6 hours. If RIPEstat is unreachable or returns zero, the save fails with a 400, so a deny ASN-Rule can never silently expand to nothing.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] API changes
- [ ] Performance improvement
- [x] Test addition or update

## AI Usage

- [x] AI was used to write this
- [x] AI was used to review this

AI was used to write the PR's code as well as the commit message. The resulting code has been manually reviewed.

