### PR TITLE
Add LWS DNS provider

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -686,5 +686,13 @@
 		"name": "RcodeZero",
 		"package_name": "certbot-dns-rcode0",
 		"version": "~=0.0.0.2"
+	},
+	"lws": {
+	  "credentials": "dns_lws_login = 123456\ndns_lws_api_key = YOUR_API_KEY",
+	  "dependencies": "",
+	  "full_plugin_name": "dns-lws",
+	  "name": "LWS",
+	  "package_name": "certbot-dns-lws",
+	  "version": "~=1.0.0"
 	}
 }


### PR DESCRIPTION
## Add LWS DNS provider

This PR adds LWS as a DNS provider for Certbot DNS-01 challenges.

The provider uses the `certbot-dns-lws` Certbot plugin available on PyPI.

### Features tested

- DNS-01 certificate issuance
- Wildcard certificates
- Automatic TXT record creation
- Automatic TXT record cleanup
- Certbot renewal (`certbot renew --dry-run`)
- Nginx Proxy Manager 2.15.1 integration

The plugin uses the official LWS DNS API.

### Links

- PyPI: https://pypi.org/project/certbot-dns-lws/
- Source code: https://github.com/zergflag/certbot-dns-lws