### PR TITLE
fix(certbot): update Websupport DNS plugin to 5.0.0

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -661,7 +661,7 @@
 		"full_plugin_name": "dns-websupport",
 		"name": "Websupport.sk",
 		"package_name": "certbot-dns-websupport",
-		"version": "~=2.0.1"
+		"version": "~=5.0.0"
 	},
 	"wedos": {
 		"credentials": "dns_wedos_user = <wedos_registration>\ndns_wedos_auth = <wapi_password>",


### PR DESCRIPTION
<!-- WARNING: Any PR without a description will be closed. The title is not enough! -->

<!-- ANOTHER WARNING: Don't go creating a duplicate PR! Check that someone hasn't already created something that tackles your fix and if so, help them first -->

## Why

Updates `certbot-dns-websupport` from `~=2.0.1` to `~=5.0.0`.

Version 2.0.1 requires Certbot `<3.0.0`. Installing it in NPM 2.15.x
downgrades the bundled Certbot/ACME packages while retaining a newer
pyOpenSSL version. This produces:

`AttributeError: module 'OpenSSL.crypto' has no attribute 'X509Extension'`

Version 5.0.0 supports Certbot `>=3.2.0,<6`, including the Certbot 5.x
version bundled with current NPM images.

This addresses the Websupport-specific case reported in #5719.

<!-- Provide a brief description of WHY you are making your changes -->

<!-- Consider if you are changing the API, then go in to detail why and/or if
you change will break API for existing users -->

## Type of Change

<!-- Mark the relevant options with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

<!-- Mark the relevant options with an "x" -->

- [ ] AI was used to write this
- [ ] AI was used to review this

