### PR TITLE
Fix Tencent Cloud apex and wildcard certificate issuance

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -629,7 +629,7 @@
 		"full_plugin_name": "dns-tencentcloud",
 		"name": "Tencent Cloud",
 		"package_name": "certbot-dns-tencentcloud",
-		"version": "~=2.0.2"
+		"version": "~=2.1.1"
 	},
 	"timeweb": {
 		"credentials": "dns_timeweb_api_key = XXXXXXXXXXXXXXXXXXX",


### PR DESCRIPTION
## Why

Nginx Proxy Manager v2.15.1 currently installs `certbot-dns-tencentcloud~=2.0.2`.

This version fails when requesting a certificate that combines an apex domain and its wildcard domain.

Upgrading `certbot-dns-tencentcloud` to 2.1.1 fixes the issue. The upstream changelog specifically mentions fixing TXT record cleanup for combined apex and wildcard certificates: https://github.com/Frefreak/certbot-dns-tencentcloud/blob/master/CHANGELOG.md#211

Version 2.1.1 is available on PyPI: https://pypi.org/project/certbot-dns-tencentcloud/2.1.1/

## Changes

Update the Tencent Cloud DNS plugin requirement from:

`certbot-dns-tencentcloud~=2.0.2`

to:

`certbot-dns-tencentcloud~=2.1.1`

## Verification

- Confirmed that `dns-plugins.json` remains valid JSON.
- Confirmed that the change only affects the Tencent Cloud plugin version.
- Reproduced the failure with Nginx Proxy Manager v2.15.1 and
  `certbot-dns-tencentcloud` 2.0.2.
- Manually upgraded the plugin to 2.1.1 in the same container.
- Successfully requested a certificate containing both the apex domain
  and wildcard domain after the upgrade.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

- [x] AI was used to write this
- [x] AI was used to review this