### PR TITLE
Fix: Insufficient private key permissions led to a leak and  Effective fixing when setting PUID and PGid environment variables

### DIFF
--- a/backend/lib/config.js
+++ b/backend/lib/config.js
@@ -145,7 +145,7 @@ const generateKeys = () => {
 
 	// Write keys config
 	try {
-		fs.writeFileSync(keysFile, JSON.stringify(keys, null, 2));
+		fs.writeFileSync(keysFile, JSON.stringify(keys, null, 2), { mode: 0o600 });
 	} catch (err) {
 		logger.error(`Could not write JWT key pair to config file: ${keysFile}: ${err.message}`);
 		process.exit(1);

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/prepare/30-ownership.sh
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/prepare/30-ownership.sh
@@ -46,6 +46,12 @@ for loc in "${locations[@]}"; do
 	chownit "$loc"
 done
 
+# Ensure the JWT key file is owned by the runtime user, even when the /data
+# directory ownership already matches PUID:PGID (chownit skips recursion then)
+if [ -f /data/keys.json ]; then
+	chown "$PUID:$PGID" /data/keys.json
+fi
+
 if [ "$(is_true "${SKIP_CERTBOT_OWNERSHIP:-}")" = '1' ]; then
 	log_info 'Skipping ownership change of certbot directories'
 else


### PR DESCRIPTION
## Why
Background
When the RSA private key used for JWT signing was written to `/data/keys.json`, no specific file permissions were set, resulting in the system default of `0644` (readable/writable by the owner, readable by others).

Risks
1. `/data` is a bind mount from the host machine; the private key file is effectively exposed to the host's file system.
2. Any local user or process within a container (e.g., a compromised service) with access to this directory can read the private key.
3. Possession of the private key allows for the offline forgery of JWTs for any identity (e.g., an administrator with `attrs.id=1`). This enables a complete system takeover without requiring account credentials and bypasses 2FA (as the forged token circumvents the standard login flow).

Changes
1. `backend/lib/config.js`: Explicitly specified `{ mode: 0o600 }` in the `writeFileSync` call within `generateKeys()`.
2. Existing instances require a manual `chmod 600 /data/keys.json` (this step has already been executed as part of the current fix).

Impact
- The private key is readable only by the owner (root/container service process); access is denied to all other users.
- The attack vector for forging JWTs is completely eliminated.
- No functional impact: JWT issuance and verification logic remain unchanged; only file permissions have been tightened.

Verification
- Before fix: `nobody` user could read the private key → forged token used to call `/api/users` returned HTTP 200 (full takeover).
- After fix: `nobody` user attempting to read the private key received "Permission denied"; service operated normally (HTTP 200 on port 81).

## Type of Change

<!-- Mark the relevant options with an "x" -->

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

<!-- Mark the relevant options with an "x" -->

- [ ] AI was used to write this
- [ x] AI was used to review this

