### PR TITLE
Switched to local QR code generation to prevent leaking 2FA keys to third-party QR services.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
 		"react-dom": "^19.2.8",
 		"react-intl": "^10.1.22",
 		"react-markdown": "^10.1.0",
+		"react-qr-code": "^2.2.0",
 		"react-router-dom": "^7.18.2",
 		"react-select": "^5.10.2",
 		"react-toastify": "^11.1.0",

--- a/frontend/src/modals/TwoFactorModal.tsx
+++ b/frontend/src/modals/TwoFactorModal.tsx
@@ -7,6 +7,7 @@ import { disable2FA, enable2FA, get2FAStatus, regenerateBackupCodes, start2FASet
 import { Button } from "src/components";
 import { T } from "src/locale";
 import { validateString } from "src/modules/Validations";
+import QRCode from "react-qr-code";
 
 type Step = "loading" | "status" | "setup" | "verify" | "backup" | "disable";
 
@@ -155,11 +156,10 @@ const TwoFactorModal = EasyModal.create(({ id, visible, remove }: Props) => {
 						<T id="2fa.setup-instructions" />
 					</p>
 					<div className="text-center mb-3">
-						<img
-							src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(setupData.otpauthUrl)}`}
-							alt="QR Code"
-							className="img-fluid"
-							style={{ maxWidth: "200px" }}
+						<QRCode
+							value={setupData.otpauthUrl}
+							size={200}
+							style={{ maxWidth: "200px", height: "auto" }}
 						/>
 					</div>
 					<label className="mb-3 d-block">

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2260,6 +2260,11 @@ property-information@^7.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.2.0.tgz#0809b34264e995c0bfcd3227028a1e35210af80a"
   integrity sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==
 
+qrcode-generator@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/qrcode-generator/-/qrcode-generator-2.0.4.tgz#e8b3f30922577eba52078aa9c0d5a2a74fe1fd94"
+  integrity sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==
+
 query-string@^9.5.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-9.5.0.tgz#e6f4003dcb321580dd043109b6fbe2a3890afff6"
@@ -2369,6 +2374,14 @@ react-markdown@^10.1.0:
     unified "^11.0.0"
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
+
+react-qr-code@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-qr-code/-/react-qr-code-2.2.0.tgz#301b5dc4d2fed503e1e313f237a7f32c1885152a"
+  integrity sha512-e5nS0UUN22K3Nf8KBRUzemfdJ6OmnN5w+kbnj1lvJaol9RyVRFeGl05bCkxSN2ZegbLxjjYjX1+mmAoX9+fAhw==
+  dependencies:
+    prop-types "^15.8.1"
+    qrcode-generator "^2.0.4"
 
 react-router-dom@^7.18.2:
   version "7.18.2"


### PR DESCRIPTION
## Why

Background
When 2FA was enabled, the original implementation embedded the `otpauth://` link (containing the TOTP secret) into the `src` attribute of an `<img>` tag and sent it to the third-party QR code service `api.qrserver.com` to generate the QR code. The browser automatically initiated this request without user interaction; consequently, the TOTP secret for every user enabling 2FA was transmitted in plaintext to an external service.

Risks
1. TOTP secrets were exposed to a third-party service; the provider could store them indefinitely and replay 2FA codes, rendering 2FA ineffective.
2. Dependency on external service availability: users could not complete 2FA setup if `qrserver.com` experienced an outage.
3. The request also transmitted account information, creating a potential privacy leak.

Changes
1. Removed the dependency on `api.qrserver.com`.
2. Integrated the `react-qr-code` library to generate QR codes locally within the browser (using data URIs), ensuring the TOTP secret never leaves the browser.
3. Added new dependencies: `react-qr-code ^2.2.0` . https://www.npmjs.com/package/react-qr-code


## Type of Change

<!-- Mark the relevant options with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ x] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

<!-- Mark the relevant options with an "x" -->

- [ ] AI was used to write this
- [x ] AI was used to review this

