### PR TITLE
Keep the failed nginx config as a .conf.err file

### DIFF
--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -34,7 +34,7 @@ const internalNginx = {
 				// We're deleting this config regardless.
 				// Don't throw errors, as the file may not exist at all
 				// Delete the .err file too
-				return internalNginx.deleteConfig(host_type, host, false, true);
+				return internalNginx.deleteConfig(host_type, host, true);
 			})
 			.then(() => {
 				return internalNginx.generateConfig(host_type, host);
@@ -83,10 +83,12 @@ const internalNginx = {
 								meta: combined_meta,
 							})
 							.then(() => {
-								internalNginx.renameConfigAsError(host_type, host);
+								// Keep the failed config as a .err file for inspection
+								return internalNginx.renameConfigAsError(host_type, host);
 							})
 							.then(() => {
-								return internalNginx.deleteConfig(host_type, host, true);
+								// The rename removed the live config already, don't touch the .err file
+								return internalNginx.deleteConfig(host_type, host, false);
 							});
 					});
 			})
@@ -378,8 +380,8 @@ const internalNginx = {
 		const config_file_err = `${config_file}.err`;
 
 		return new Promise((resolve /*, reject*/) => {
-			fs.unlink(config_file, () => {
-				// ignore result, continue
+			fs.unlink(config_file_err, () => {
+				// ignore result, a previous .err file may not exist
 				fs.rename(config_file, config_file_err, () => {
 					// also ignore result, as this is a debugging informative file anyway
 					resolve();


### PR DESCRIPTION
### Problem

When `nginx -t` fails after saving a host, `configure()` is supposed to move the broken config to `<id>.conf.err` so you can look at what went wrong. That file is never written, and the config is deleted instead.

Three things go wrong in the failure path:

1. `renameConfigAsError()` unlinks `config_file` and then renames that same, already deleted file to `config_file.err`. The rename always fails, so the broken config is gone. If an `.err` file from an earlier failure is still around it survives untouched, which is worse than having none: it describes a different failure.
2. The `.then()` that calls it does not return the promise, so the `deleteConfig()` after it races the rename.
3. That `deleteConfig()` is called with `delete_err_file = true`, so it removes the `.err` file step 1 was meant to produce.

The success path has a leftover argument from an older signature: `deleteConfig(host_type, host, false, true)` passes four arguments to `(host_type, host, delete_err_file)`. `delete_err_file` ends up `false`, so the stale `.err` file is not cleaned up after a host is fixed, despite the comment right above the call.

### Why it matters

A host with an invalid nginx config loses its config file and stops serving, with nothing left on disk to explain why. The reason is only in `meta.nginx_err` in the database.

I ran into this attaching a Let's Encrypt certificate to a proxy host. Another host's advanced config declared `ssl_session_cache shared:SSL:1m`, which collides with the `shared:SSL:50m` in `conf.d/include/ssl-cache.conf` that `_certificates.conf` includes for Let's Encrypt hosts. `nginx -t` failed, the proxy host config disappeared, the site went down, and there was no `.conf.err` to inspect.

### Fix

- `renameConfigAsError()` unlinks the destination `.err` file rather than the source, so the rename succeeds and `.err` holds the config that actually failed
- return the rename promise so `deleteConfig()` runs after it
- pass `delete_err_file = false` there, keeping the file just written
- drop the stale fourth argument in the success path so old `.err` files are cleaned up

### Verification

Called the real `renameConfigAsError()` and `deleteConfig()` from a running 2.15.1 container, with a stale `999.conf.err` and a `999.conf` containing `# broken config`.

Before:

```
before rename:       conf=true err=true
after rename:        conf=false err=true | err content: "# stale err\n"
after delete(false): conf=false err=true
after delete(true):  conf=false err=false
```

After:

```
before rename:       conf=true err=true
after rename:        conf=false err=true | err content: "# broken config\n"
after delete(false): conf=false err=true
after delete(true):  conf=false err=false
```

`biome check` on the changed file is clean.
