### PR TITLE
Use the row's own model and host type in regenerate-config

### DIFF
--- a/backend/scripts/regenerate-config
+++ b/backend/scripts/regenerate-config
@@ -46,7 +46,7 @@ const logIt = (msg, type = "info") => logger[type](
 
 // Let's do it.
 
-const processItems = async (model, type) => {
+const processItems = async (model, type, hostType) => {
 	const rows = await model
 		.query()
 		.where("is_deleted", 0)
@@ -60,17 +60,17 @@ const processItems = async (model, type) => {
 	for (const row of rows) {
 		if (!DRY_RUN) {
 			logIt(`[${type}] Regenerating config #${row.id}: ${row.domain_names ? row.domain_names.join(", ") : 'port ' + row.incoming_port}`);
-			await internalNginx.configure(proxyHostModel, "proxy_host", row);
+			await internalNginx.configure(model, hostType, row);
 		} else {
 			logIt(`[${type}] Skipping generation of config #${row.id}: ${row.domain_names ? row.domain_names.join(", ") : 'port ' + row.incoming_port}`);
 		}
 	}
 };
 
-await processItems(proxyHostModel, "Proxy Host");
-await processItems(redirectionHostModel, "Redirection Host");
-await processItems(deadHostModel, "404 Host");
-await processItems(streamModel, "Stream");
+await processItems(proxyHostModel, "Proxy Host", "proxy_host");
+await processItems(redirectionHostModel, "Redirection Host", "redirection_host");
+await processItems(deadHostModel, "404 Host", "dead_host");
+await processItems(streamModel, "Stream", "stream");
 
 logIt("Completed", "success");
 process.exit(0);


### PR DESCRIPTION
### Problem

`backend/scripts/regenerate-config` walks four host types, but `processItems()` hands the same model and the literal `"proxy_host"` to `configure()` for all of them:

```js
await internalNginx.configure(proxyHostModel, "proxy_host", row);
```

`host_type` picks both the template and the output path: `generateConfig()` reads `templates/${nice_host_type}.conf` and writes `/data/nginx/${nice_host_type}/${id}.conf`. Each host type has its own id sequence, so redirection host 1, 404 host 1 and stream 1 all end up pointed at `/data/nginx/proxy_host/1.conf`.

For every redirection host, 404 host and stream, the script deletes the config of the proxy host that happens to share the id, renders the row through `proxy_host.conf` (which has no `forward_scheme`, `forward_host` or `forward_port` to fill in), fails `nginx -t`, and writes the error into the `proxy_host` row's `meta`.

The proxy host ends up offline and blamed for a config it never had. Its own `meta` is overwritten, and the redirection host's `meta` is never updated.

### Reproduction

Stock 2.15.1 container with one proxy host and one redirection host, both id 1:

```
$ node scripts/regenerate-config -y
[Proxy Host] Regenerating config #1: proxy.example.com
[Redirection Host] Regenerating config #1: redirect.example.com
Completed

$ ls /data/nginx/proxy_host/
(empty)

sqlite> select meta from proxy_host where id = 1;
{"nginx_online":false,"nginx_err":"nginx: [emerg] invalid number of arguments in
\"set\" directive in /data/nginx/proxy_host/1.conf:14\n..."}
```

`proxy.example.com` stops being served, and the error recorded against it points at line 14 of a file that was generated from the redirection host row. Nothing is left on disk to show what happened, which is #5812.

With this change, on the same instance:

```
$ node scripts/regenerate-config -y
$ ls /data/nginx/proxy_host/ /data/nginx/redirection_host/
/data/nginx/proxy_host/:       1.conf
/data/nginx/redirection_host/: 1.conf

$ grep server_name /data/nginx/proxy_host/1.conf /data/nginx/redirection_host/1.conf
  server_name proxy.example.com;
  server_name redirect.example.com;

proxy_host 1       {"nginx_online":true,"nginx_err":null}
redirection_host 1 {"nginx_online":true,"nginx_err":null}
```

### Fix

Pass the model and the host type of the rows being processed. `type` keeps its current job as the label used in log lines.
