### PR TITLE
Remove DNS provider credentials from disk after certbot runs

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -881,10 +881,20 @@ const internalCertificate = {
 			const result = await utils.execFile(certbotCommand, args, adds.opts);
 			logger.info(result);
 			return result;
-		} catch (err) {
-			// Don't fail if file does not exist, so no need for action in the callback
+		} finally {
+			// Remove the credentials file whether certbot succeeded or failed.
+			//
+			// This cleanup used to sit in a catch block, so it only ran when issuance FAILED.
+			// A certificate that issued successfully left its DNS provider API credentials in
+			// /etc/letsencrypt/credentials for the entire life of that certificate. Nothing
+			// reads the file between certbot runs, so there is no reason to keep it:
+			// renewLetsEncryptSslWithDnsChallenge() writes it again immediately before each
+			// renewal.
+			//
+			// unlink is fire-and-forget with an empty callback. If the file is already gone
+			// that is the end state we wanted anyway, and a missing file must never turn a
+			// successful issuance into a failure.
 			fs.unlink(credentialsLocation, () => {});
-			throw err;
 		}
 	},
 
@@ -981,6 +991,43 @@ const internalCertificate = {
 			`Renewing LetsEncrypt certificates via ${dnsPlugin.name} for Cert #${certificate.id}: ${certificate.domain_names.join(", ")}`,
 		);
 
+		// certbot reads the DNS credentials back from the path recorded in the renewal config
+		// it wrote at issuance time, for example:
+		//
+		//     authenticator = dns-cloudflare
+		//     dns_cloudflare_credentials = /etc/letsencrypt/credentials/credentials-27
+		//
+		// so the file has to be present for the duration of this run. Write it here and remove
+		// it again below rather than leaving it on disk between renewals.
+		//
+		// Leaving it is an avoidable exposure. Anything running as root - a compromised
+		// process, a script, malware - can read the token and use it to issue valid Let's
+		// Encrypt certificates for the domain. Those certificates are genuinely trusted, so
+		// traffic presented with them passes TLS inspection, IDS/IPS and DLP that would
+		// otherwise flag it, and an exfiltration path built on them looks like ordinary
+		// HTTPS. The exposure window should be one certbot run, not the life of the
+		// certificate.
+		//
+		// The value is not on the certificate object we were handed: renew() sources that from
+		// internalCertificate.get(), which pipes the row through utils.omitRow(omissions()) so
+		// meta.dns_provider_credentials can never travel out over the API. Read the row from
+		// the model directly to get at it.
+		const row = await certificateModel.query().where("id", certificate.id).first();
+		const credentials = row?.meta?.dns_provider_credentials;
+		const credentialsLocation = `/etc/letsencrypt/credentials/credentials-${certificate.id}`;
+
+		if (credentials) {
+			fs.mkdirSync("/etc/letsencrypt/credentials", { recursive: true });
+			fs.writeFileSync(credentialsLocation, credentials, { mode: 0o600 });
+		} else {
+			// Nothing stored to write. A certificate issued under the previous behaviour may
+			// still have its file on disk; leave it be and let certbot decide. Throwing here
+			// would break a renewal that would otherwise have succeeded.
+			logger.warn(
+				`No stored DNS credentials for Cert #${certificate.id}; relying on any existing ${credentialsLocation}`,
+			);
+		}
+
 		const args = [
 			"renew",
 			"--force-renewal",
@@ -1008,9 +1055,19 @@ const internalCertificate = {
 
 		logger.info(`Command: ${certbotCommand} ${args ? args.join(" ") : ""}`);
 
-		const result = await utils.execFile(certbotCommand, args, adds.opts);
-		logger.info(result);
-		return result;
+		try {
+			const result = await utils.execFile(certbotCommand, args, adds.opts);
+			logger.info(result);
+			return result;
+		} finally {
+			// Only clean up a file we put there ourselves. If `credentials` came back empty we
+			// wrote nothing, and an older file left on disk by the previous behaviour is the
+			// only thing keeping that certificate renewable - deleting it would break the next
+			// run for no gain.
+			if (credentials) {
+				fs.unlink(credentialsLocation, () => {});
+			}
+		}
 	},
 
 	/**

--- a/backend/setup.js
+++ b/backend/setup.js
@@ -1,4 +1,3 @@
-import fs from "node:fs/promises";
 import { installPlugins } from "./lib/certbot.js";
 import utils from "./lib/utils.js";
 import { setup as logger } from "./logger.js";
@@ -98,7 +97,6 @@ const setupCertbotPlugins = async () => {
 
 	if (certificates?.length) {
 		const plugins = [];
-		const promises = [];
 
 		certificates.map((certificate) => {
 			if (certificate.meta && certificate.meta.dns_challenge === true) {
@@ -106,31 +104,23 @@ const setupCertbotPlugins = async () => {
 					plugins.push(certificate.meta.dns_provider);
 				}
 
-				// Make sure credentials file exists
-				const credentials_loc = `/etc/letsencrypt/credentials/credentials-${certificate.id}`;
-				if (typeof certificate.meta.dns_provider_credentials === "string") {
-					promises.push(
-						fs
-							.mkdir("/etc/letsencrypt/credentials", { recursive: true })
-							.then(() =>
-								fs.writeFile(credentials_loc, certificate.meta.dns_provider_credentials, {
-									mode: 0o600,
-									flag: "wx",
-								}),
-							)
-							.catch((err) => {
-								if (err.code !== "EEXIST") throw err;
-							}),
-					);
-				}
+				// Deliberately does NOT write the DNS credentials file here any more.
+				//
+				// It used to, so that a later `certbot renew` would find the path recorded in its
+				// renewal config. The effect was that every backend restart rewrote a plaintext
+				// DNS provider API token for every DNS-01 certificate, and left it there.
+				//
+				// internalCertificate now writes that file immediately before it runs certbot and
+				// removes it again afterwards, so there is exactly one writer and the credential
+				// is on disk only for the length of a certbot run. Recreating the files at boot
+				// would put every one of them straight back.
 			}
 			return true;
 		});
 
 		await installPlugins(plugins);
 
-		if (promises.length) {
-			await Promise.all(promises);
+		if (plugins.length) {
 			logger.info(`Added Certbot plugins ${plugins.join(", ")}`);
 		}
 	}


### PR DESCRIPTION
## The problem

I run NPM at home with 14 proxy hosts, all on Let's Encrypt via the Cloudflare DNS-01
challenge. None of those services are publicly reachable, so HTTP-01 isn't an option —
DNS-01 is the only way to get certificates for them.

I hit this while opening a single internal service to the internet through a Cloudflare
Tunnel. Putting one thing on the public side made me go through what an attacker would
actually get if that host were compromised, rather than what I assumed they'd get. Working
down that list I got to the DNS-01 credential and went looking for where it lives:

```
/etc/letsencrypt/credentials/
-rw------- 1 root root 88 Jan 26  2026 credentials-10
-rw------- 1 root root 88 Jun 19 18:37 credentials-17
-rw------- 1 root root 65 Jun 19 21:27 credentials-18
...  14 files, one per certificate
```

Fourteen files, each holding a live Cloudflare API token in plaintext, the oldest from
January. Permissions are right — `0600`, root-owned — but they are permanent.

In `requestLetsEncryptSslWithDnsChallenge`, cleanup only runs when certbot *fails*:

```js
} catch (err) {
    // Don't fail if file does not exist, so no need for action in the callback
    fs.unlink(credentialsLocation, () => {});
    throw err;
}
```

The success path returns without unlinking, so the file survives for the life of the
certificate. The only other cleanup is in the revoke path, which runs when a certificate
is deleted.

This matters more than "a secret is on disk." Anything running as root — a compromised
process, a script, malware — can read that token and use it to issue **valid** Let's
Encrypt certificates for the domain. Those certificates are genuinely trusted, so traffic
presented with them passes TLS inspection, IDS/IPS and DLP that would otherwise flag it.
An exfiltration path built on them looks like ordinary HTTPS. With a Cloudflare
`Zone:DNS:Edit` token the same holder can also repoint every hostname in the zone.

## Why the one-line fix doesn't work

Moving that `unlink` into a `finally` breaks renewals. certbot records the credentials
path in its renewal config at issuance:

```
# /etc/letsencrypt/renewal/npm-27.conf
authenticator = dns-cloudflare
dns_cloudflare_credentials = /etc/letsencrypt/credentials/credentials-27
```

and `renewLetsEncryptSslWithDnsChallenge` shells out to `certbot renew`, which reads that
path back. Delete the file and every DNS-01 renewal fails — silently, until certificates
start expiring.

## What this changes

The renew path now writes the credentials file immediately before invoking certbot, and
both paths remove it in a `finally`. The file exists for the duration of a certbot run
instead of permanently.

There was a third writer. `setupCertbotPlugins()` in `backend/setup.js` wrote a credentials
file for every DNS-01 certificate on **every backend start** (`flag: "wx"`, so it only filled
in missing ones). That existed precisely because the renew path did not write the file itself
— something had to put it back before `certbot renew` went looking. Now that renew writes its
own, that boot-time write is the only thing restoring credentials to disk, and it would undo
the cleanup on the next container restart. Removing it leaves one writer, immediately before
use. The `fs` import and `promises` array become unused; the "Added Certbot plugins" log line
is kept, now gated on `plugins.length` rather than on a promise array that only ever held
credential writes.

One wrinkle worth explaining: the credentials aren't on the certificate object the renew
function receives. `renew()` sources it from `internalCertificate.get()`, which pipes the
row through `utils.omitRow(omissions())` — and `omissions()` lists
`meta.dns_provider_credentials` precisely so it can't travel out over the API. The renew
path therefore reads the row from the model directly.

## What it does not fix

The token still lives in the `certificates` table. It has to — otherwise there'd be
nothing to write the file from. Anyone with a backup of NPM's data volume still has it.
This narrows one of the two copies, not both.

## Behaviour changes worth flagging

- Running `certbot renew` by hand inside the container will no longer work for DNS-01
  certificates, since the credentials file won't be sitting there between runs. Renewals
  need to go through NPM, which is already how the scheduler drives them.
- Certificates issued before this change keep their existing file; the renew path
  overwrites it with the stored value. If there is no stored value, it logs a warning and
  leaves whatever is on disk alone, so an older certificate can't be broken by this.
- No schema, API, or config changes.

## Testing

Validated on a throwaway NPM **2.15.1** container against Let's Encrypt **staging**, using the
`dns-cloudflare` plugin with a real Cloudflare `Zone:DNS:Edit` token. The 2.15.1 image ships
`backend/internal/certificate.js` byte-identical to `develop`, so the patched file was mounted
straight over `/app/internal/certificate.js` — no version skew between what was tested and what
this PR changes.

**Baseline, stock 2.15.1:**

- issue a DNS-01 certificate → succeeds, `credentials-2` left on disk holding the live token
- force renew → succeeds, file still there with its **mtime unchanged**, confirming the renew
  path only ever read it

**Patched:**

| Scenario | Result |
|---|---|
| Renew a certificate whose credentials file predates the change | renewed OK — file rewritten, then removed |
| Renew again with no file on disk (the new steady state) | renewed OK — 0 files before, 0 after |
| Issue a brand new certificate | issued OK — nothing left behind |
| **Restart the container** with only `certificate.js` patched | file **reappears** — this is what surfaced the `setup.js` writer |
| **Restart the container** with both files patched | file stays gone |
| Renew after a restart, with no file on disk | renewed OK — proves the renew path is self-sufficient |

The restart case is worth calling out: with only the `certificate.js` change, issuance left 0
files but a restart brought them straight back — 0 after issuance, 1 after `docker restart`.
With both changes it stays at 0 across restart, and a renewal afterwards still succeeds. The
`Added Certbot plugins` log line still fires once per start.

The file's whole lifecycle, captured by polling once a second across a renewal:

```
67 bytes  mtime 23:26:34    pre-existing file from the stock run
67 bytes  mtime 23:28:33    rewritten by the patched renew path
ABSENT                      removed after certbot returned
```

certbot reported `Congratulations, all renewals succeeded` on every run, and both test
certificates ended up valid with fresh expiry dates.

**Not exercised:** `route53`, whose credentials path is passed through `AWS_CONFIG_FILE` rather
than a `--credentials` argument — same file lifecycle, but a different code path — and DNS
providers other than Cloudflare.


