### PR TITLE
Add configurable asset cache lifetime per proxy host

### DIFF
--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -157,6 +157,7 @@ const internalNginx = {
 						{ certificate_id: host.certificate_id },
 						{ ssl_forced: host.ssl_forced },
 						{ caching_enabled: host.caching_enabled },
+						{ asset_cache_ttl: host.asset_cache_ttl },
 						{ block_exploits: host.block_exploits },
 						{ allow_websocket_upgrade: host.allow_websocket_upgrade },
 						{ http2_support: host.http2_support },

--- a/backend/migrations/20260825180010_proxy_host_asset_cache_ttl.js
+++ b/backend/migrations/20260825180010_proxy_host_asset_cache_ttl.js
@@ -1,0 +1,37 @@
+import { migrate as logger } from "../logger.js";
+
+const migrateName = "proxy_host_asset_cache_ttl";
+
+/**
+ * @param {Object} knex
+ * @returns {Promise}
+ */
+const up = (knex) => {
+	logger.info(`[${migrateName}] Migrating Up...`);
+
+	return knex.schema
+		.alterTable("proxy_host", (table) => {
+			table.integer("asset_cache_ttl").notNullable().unsigned().defaultTo(1800);
+		})
+		.then(() => {
+			logger.info(`[${migrateName}] proxy_host Table altered`);
+		});
+};
+
+/**
+ * @param {Object} knex
+ * @returns {Promise}
+ */
+const down = (knex) => {
+	logger.info(`[${migrateName}] Migrating Down...`);
+
+	return knex.schema
+		.alterTable("proxy_host", (table) => {
+			table.dropColumn("asset_cache_ttl");
+		})
+		.then(() => {
+			logger.info(`[${migrateName}] proxy_host Table altered`);
+		});
+};
+
+export { up, down };

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
 	"type": "module",
 	"scripts": {
 		"lint": "biome lint",
+		"test": "node --test test/**/*.test.js",
 		"prettier": "biome format --write .",
 		"validate-schema": "node validate-schema.js",
 		"regenerate-config": "node scripts/regenerate-config"

--- a/backend/schema/common.json
+++ b/backend/schema/common.json
@@ -128,6 +128,13 @@
 			"type": "boolean",
 			"example": true
 		},
+		"asset_cache_ttl": {
+			"description": "Asset cache lifetime in seconds",
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 31536000,
+			"example": 1800
+		},
 		"email": {
 			"description": "Email address",
 			"type": "string",

--- a/backend/schema/components/proxy-host-object.json
+++ b/backend/schema/components/proxy-host-object.json
@@ -13,6 +13,7 @@
 		"certificate_id",
 		"ssl_forced",
 		"caching_enabled",
+		"asset_cache_ttl",
 		"block_exploits",
 		"advanced_config",
 		"meta",
@@ -64,6 +65,9 @@
 		},
 		"caching_enabled": {
 			"$ref": "../common.json#/properties/caching_enabled"
+		},
+		"asset_cache_ttl": {
+			"$ref": "../common.json#/properties/asset_cache_ttl"
 		},
 		"block_exploits": {
 			"$ref": "../common.json#/properties/block_exploits"

--- a/backend/schema/paths/nginx/proxy-hosts/get.json
+++ b/backend/schema/paths/nginx/proxy-hosts/get.json
@@ -46,6 +46,7 @@
 									"certificate_id": 1,
 									"ssl_forced": false,
 									"caching_enabled": false,
+									"asset_cache_ttl": 1800,
 									"block_exploits": false,
 									"advanced_config": "",
 									"meta": {

--- a/backend/schema/paths/nginx/proxy-hosts/hostID/get.json
+++ b/backend/schema/paths/nginx/proxy-hosts/hostID/get.json
@@ -43,6 +43,7 @@
 								"certificate_id": 0,
 								"ssl_forced": false,
 								"caching_enabled": false,
+								"asset_cache_ttl": 1800,
 								"block_exploits": false,
 								"advanced_config": "",
 								"meta": {

--- a/backend/schema/paths/nginx/proxy-hosts/hostID/put.json
+++ b/backend/schema/paths/nginx/proxy-hosts/hostID/put.json
@@ -68,6 +68,9 @@
 						"caching_enabled": {
 							"$ref": "../../../../components/proxy-host-object.json#/properties/caching_enabled"
 						},
+						"asset_cache_ttl": {
+							"$ref": "../../../../components/proxy-host-object.json#/properties/asset_cache_ttl"
+						},
 						"allow_websocket_upgrade": {
 							"$ref": "../../../../components/proxy-host-object.json#/properties/allow_websocket_upgrade"
 						},
@@ -112,6 +115,7 @@
 								"certificate_id": 0,
 								"ssl_forced": false,
 								"caching_enabled": false,
+								"asset_cache_ttl": 1800,
 								"block_exploits": false,
 								"advanced_config": "",
 								"meta": {

--- a/backend/schema/paths/nginx/proxy-hosts/post.json
+++ b/backend/schema/paths/nginx/proxy-hosts/post.json
@@ -60,6 +60,9 @@
 						"caching_enabled": {
 							"$ref": "../../../components/proxy-host-object.json#/properties/caching_enabled"
 						},
+						"asset_cache_ttl": {
+							"$ref": "../../../components/proxy-host-object.json#/properties/asset_cache_ttl"
+						},
 						"allow_websocket_upgrade": {
 							"$ref": "../../../components/proxy-host-object.json#/properties/allow_websocket_upgrade"
 						},
@@ -112,6 +115,7 @@
 								"certificate_id": 0,
 								"ssl_forced": false,
 								"caching_enabled": false,
+								"asset_cache_ttl": 1800,
 								"block_exploits": false,
 								"advanced_config": "",
 								"meta": {},

--- a/backend/templates/_assets.conf
+++ b/backend/templates/_assets.conf
@@ -1,4 +1,10 @@
 {% if caching_enabled == 1 or caching_enabled == true -%}
   # Asset Caching
-  include conf.d/include/assets.conf;
+  location ~* ^.*\.(css|js|jpe?g|gif|png|webp|woff|woff2|eot|ttf|svg|ico|css\.map|js\.map)$ {
+    proxy_cache_valid any {{ asset_cache_ttl | default: 1800 }}s;
+    proxy_cache_valid 404 1m;
+    expires {{ asset_cache_ttl | default: 1800 }}s;
+
+    include conf.d/include/assets-common.conf;
+  }
 {% endif %}

--- a/backend/test/asset-cache-templates.test.js
+++ b/backend/test/asset-cache-templates.test.js
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import utils from "../lib/utils.js";
+import internalNginx from "../internal/nginx.js";
+
+const render = async (templateName, data) => {
+	const template = fs.readFileSync(new URL(`../templates/${templateName}`, import.meta.url), "utf8");
+	return utils.getRenderEngine().parseAndRender(template, data);
+};
+
+test("renders a numeric asset cache lifetime", async () => {
+	const config = await render("_assets.conf", {
+		asset_cache_ttl: 21600,
+		caching_enabled: true,
+		certificate: null,
+	});
+
+	assert.match(config, /proxy_cache_valid any 21600s;/);
+	assert.match(config, /expires 21600s;/);
+	assert.match(config, /include conf\.d\/include\/assets-common\.conf;/);
+});
+
+test("uses the proxy host cache lifetime inside custom locations", async () => {
+	const config = await render("_location.conf", {
+		access_list_id: 0,
+		advanced_config: "",
+		allow_websocket_upgrade: false,
+		asset_cache_ttl: 3600,
+		block_exploits: false,
+		caching_enabled: true,
+		certificate: null,
+		forward_host: "127.0.0.1",
+		forward_path: "",
+		forward_port: 80,
+		forward_scheme: "http",
+		hsts_enabled: false,
+		path: "/assets",
+		ssl_forced: false,
+	});
+
+	assert.match(config, /location \/assets \{/);
+	assert.match(config, /proxy_cache_valid any 3600s;/);
+});
+
+test("retains the 30-minute lifetime when no value is provided", async () => {
+	const config = await render("_assets.conf", { caching_enabled: true });
+	assert.match(config, /proxy_cache_valid any 1800s;/);
+	assert.match(config, /expires 1800s;/);
+});
+
+test("does not emit a cache location when caching is disabled", async () => {
+	const config = await render("_assets.conf", { caching_enabled: false, asset_cache_ttl: 3600 });
+	assert.equal(config.trim(), "");
+});
+
+test("propagates the host lifetime when rendering its custom locations", async () => {
+	const config = await internalNginx.renderLocations({
+		asset_cache_ttl: 86400,
+		caching_enabled: true,
+		locations: [
+			{
+				path: "/custom",
+				forward_scheme: "http",
+				forward_host: "127.0.0.1",
+				forward_port: 8080,
+				advanced_config: "",
+			},
+		],
+	});
+	assert.match(config, /location \/custom \{/);
+	assert.match(config, /proxy_cache_valid any 86400s;/);
+	assert.match(config, /expires 86400s;/);
+});

--- a/docker/rootfs/etc/nginx/conf.d/include/assets-common.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/assets-common.conf
@@ -1,0 +1,24 @@
+if_modified_since off;
+
+# use the public cache
+proxy_cache public-cache;
+proxy_cache_key $host$request_uri;
+
+# ignore these headers for media
+proxy_ignore_headers Set-Cookie Cache-Control Expires X-Accel-Expires;
+
+# strip this header to avoid If-Modified-Since requests
+proxy_hide_header Last-Modified;
+proxy_hide_header Cache-Control;
+proxy_hide_header Vary;
+
+proxy_cache_bypass 0;
+proxy_no_cache 0;
+
+proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504 http_404;
+proxy_connect_timeout 5s;
+proxy_read_timeout 45s;
+
+access_log off;
+
+include conf.d/include/proxy.conf;

--- a/docker/rootfs/etc/nginx/conf.d/include/assets.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/assets.conf
@@ -1,31 +1,9 @@
 location ~* ^.*\.(css|js|jpe?g|gif|png|webp|woff|woff2|eot|ttf|svg|ico|css\.map|js\.map)$ {
-	if_modified_since off;
-
-	# use the public cache
-	proxy_cache public-cache;
-	proxy_cache_key $host$request_uri;
-
-	# ignore these headers for media
-	proxy_ignore_headers Set-Cookie Cache-Control Expires X-Accel-Expires;
-
 	# cache 200s and also 404s (not ideal but there are a few 404 images for some reason)
 	proxy_cache_valid any 30m;
 	proxy_cache_valid 404 1m;
 
-	# strip this header to avoid If-Modified-Since requests
-	proxy_hide_header Last-Modified;
-	proxy_hide_header Cache-Control;
-	proxy_hide_header Vary;
-
-	proxy_cache_bypass 0;
-	proxy_no_cache 0;
-
-	proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504 http_404;
-	proxy_connect_timeout 5s;
-	proxy_read_timeout 45s;
-
 	expires @30m;
-	access_log  off;
 
-	include conf.d/include/proxy.conf;
+	include conf.d/include/assets-common.conf;
 }

--- a/frontend/src/api/backend/models.ts
+++ b/frontend/src/api/backend/models.ts
@@ -118,6 +118,7 @@ export interface ProxyHost {
 	certificateId: number;
 	sslForced: boolean;
 	cachingEnabled: boolean;
+	assetCacheTtl: number;
 	blockExploits: boolean;
 	advancedConfig: string;
 	meta: Record<string, any>;

--- a/frontend/src/components/Form/ProxyCacheOptionsFields.test.tsx
+++ b/frontend/src/components/Form/ProxyCacheOptionsFields.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { Form, Formik } from "formik";
+import { describe, expect, it } from "vitest";
+import { ProxyCacheOptionsFields } from "./ProxyCacheOptionsFields";
+
+const renderFields = (overrides = {}) =>
+	render(
+		<Formik
+			initialValues={{
+				assetCacheTtl: 1800,
+				cachingEnabled: false,
+				...overrides,
+			}}
+			onSubmit={() => undefined}
+		>
+			<Form>
+				<ProxyCacheOptionsFields color="bg-lime" />
+			</Form>
+		</Formik>,
+	);
+
+describe("ProxyCacheOptionsFields", () => {
+	it("shows the cache lifetime only while asset caching is enabled", async () => {
+		renderFields();
+
+		expect(document.getElementById("assetCacheTtl")).toBeNull();
+		fireEvent.click(document.getElementById("cachingEnabled") as HTMLElement);
+
+		await waitFor(() => {
+			expect(document.getElementById("assetCacheTtl")).not.toBeNull();
+		});
+
+		fireEvent.click(document.getElementById("cachingEnabled") as HTMLElement);
+		await waitFor(() => {
+			expect(document.getElementById("assetCacheTtl")).toBeNull();
+		});
+	});
+});

--- a/frontend/src/components/Form/ProxyCacheOptionsFields.tsx
+++ b/frontend/src/components/Form/ProxyCacheOptionsFields.tsx
@@ -1,0 +1,80 @@
+import cn from "classnames";
+import { Field, useFormikContext } from "formik";
+import { T } from "src/locale";
+import { validateNumber } from "src/modules/Validations";
+
+type FormValues = {
+	assetCacheTtl: number;
+	cachingEnabled: boolean;
+};
+
+interface Props {
+	color?: string;
+}
+
+export function ProxyCacheOptionsFields({ color = "bg-cyan" }: Props) {
+	const { values } = useFormikContext<FormValues>();
+	const { assetCacheTtl, cachingEnabled } = values;
+
+	const toggleRow = (name: "cachingEnabled", label: string, enabled: boolean) => (
+		<div>
+			<label className="row" htmlFor={name}>
+				<span className="col">
+					<T id={label} />
+				</span>
+				<span className="col-auto">
+					<Field name={name} type="checkbox">
+						{({ field }: any) => (
+							<span className="form-check form-check-single form-switch">
+								<input
+									{...field}
+									id={name}
+									className={cn("form-check-input", {
+										[color]: enabled,
+									})}
+									type="checkbox"
+								/>
+							</span>
+						)}
+					</Field>
+				</span>
+			</label>
+		</div>
+	);
+
+	return (
+		<>
+			{toggleRow("cachingEnabled", "host.flags.cache-assets", cachingEnabled)}
+			{cachingEnabled ? (
+				<div className="py-3">
+					<Field name="assetCacheTtl" validate={validateNumber(1, 31536000)}>
+						{({ field, form }: any) => (
+							<div>
+								<label className="form-label" htmlFor="assetCacheTtl">
+									<T id="host.cache-ttl" />
+								</label>
+								<input
+									{...field}
+									id="assetCacheTtl"
+									type="number"
+									min={1}
+									max={31536000}
+									value={assetCacheTtl}
+									className={cn("form-control", {
+										"is-invalid": form.errors.assetCacheTtl && form.touched.assetCacheTtl,
+									})}
+								/>
+								{form.errors.assetCacheTtl && form.touched.assetCacheTtl ? (
+									<div className="invalid-feedback">{form.errors.assetCacheTtl}</div>
+								) : null}
+								<small className="form-hint">
+									<T id="host.cache-ttl-help" />
+								</small>
+							</div>
+						)}
+					</Field>
+				</div>
+			) : null}
+		</>
+	);
+}

--- a/frontend/src/components/Form/index.ts
+++ b/frontend/src/components/Form/index.ts
@@ -5,5 +5,6 @@ export * from "./DNSProviderFields";
 export * from "./DomainNamesField";
 export * from "./LocationsFields";
 export * from "./NginxConfigField";
+export * from "./ProxyCacheOptionsFields";
 export * from "./SSLCertificateField";
 export * from "./SSLOptionsFields";

--- a/frontend/src/hooks/useProxyHost.ts
+++ b/frontend/src/hooks/useProxyHost.ts
@@ -15,6 +15,7 @@ const fetchProxyHost = (id: number | "new") => {
 			certificateId: 0,
 			sslForced: false,
 			cachingEnabled: false,
+			assetCacheTtl: 1800,
 			blockExploits: false,
 			advancedConfig: "",
 			meta: {},

--- a/frontend/src/locale/src/bg.json
+++ b/frontend/src/locale/src/bg.json
@@ -359,6 +359,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Fork в GitHub"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Време за кеширане на ресурсите (секунди)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Примери: 3600 = 1 час, 21600 = 6 часа, 86400 = 1 ден."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Блокиране на често срещани експлойти"
 	},

--- a/frontend/src/locale/src/cs.json
+++ b/frontend/src/locale/src/cs.json
@@ -416,6 +416,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Forkněte mě na GitHubu"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Doba uložení prostředků v mezipaměti (sekundy)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Příklady: 3600 = 1 hodina, 21600 = 6 hodin, 86400 = 1 den."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Blokovat běžné exploity"
 	},

--- a/frontend/src/locale/src/de.json
+++ b/frontend/src/locale/src/de.json
@@ -422,6 +422,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Fork me on Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Asset-Cache-Laufzeit (Sekunden)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Beispiele: 3600 = 1 Stunde, 21600 = 6 Stunden, 86400 = 1 Tag."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Gängige Exploits blockieren"
 	},

--- a/frontend/src/locale/src/en.json
+++ b/frontend/src/locale/src/en.json
@@ -425,6 +425,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Fork me on Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Asset Cache Lifetime (seconds)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Examples: 3600 = 1 hour, 21600 = 6 hours, 86400 = 1 day."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Block Common Exploits"
 	},

--- a/frontend/src/locale/src/es.json
+++ b/frontend/src/locale/src/es.json
@@ -359,6 +359,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Bifúrcame en Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Duración de la caché de recursos (segundos)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Ejemplos: 3600 = 1 hora, 21600 = 6 horas, 86400 = 1 día."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Bloquear Exploits Comunes"
 	},

--- a/frontend/src/locale/src/et.json
+++ b/frontend/src/locale/src/et.json
@@ -422,6 +422,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Fork me on Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Varade vahemälu kestus (sekundites)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Näited: 3600 = 1 tund, 21600 = 6 tundi, 86400 = 1 päev."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Block Common Exploits"
 	},

--- a/frontend/src/locale/src/fr.json
+++ b/frontend/src/locale/src/fr.json
@@ -422,6 +422,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Forkez-moi sur Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Durée du cache des ressources (secondes)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Exemples : 3600 = 1 heure, 21600 = 6 heures, 86400 = 1 jour."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Bloquer les exploits courants"
 	},

--- a/frontend/src/locale/src/ga.json
+++ b/frontend/src/locale/src/ga.json
@@ -347,6 +347,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Forc mé ar Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Saolré taisce sócmhainní (soicindí)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Samplaí: 3600 = 1 uair, 21600 = 6 huaire, 86400 = 1 lá."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Blocáil Easnaimh Choitianta"
 	},

--- a/frontend/src/locale/src/hu.json
+++ b/frontend/src/locale/src/hu.json
@@ -416,6 +416,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Fork-olj a GitHub-on"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Eszköz-gyorsítótár élettartama (másodperc)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Példák: 3600 = 1 óra, 21600 = 6 óra, 86400 = 1 nap."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Gyakori exploitok blokkolása"
 	},

--- a/frontend/src/locale/src/id.json
+++ b/frontend/src/locale/src/id.json
@@ -347,6 +347,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Fork saya di GitHub"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Masa cache aset (detik)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Contoh: 3600 = 1 jam, 21600 = 6 jam, 86400 = 1 hari."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Blokir Eksploit Umum"
 	},

--- a/frontend/src/locale/src/it.json
+++ b/frontend/src/locale/src/it.json
@@ -344,6 +344,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Forkami su GitHub"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Durata cache risorse (secondi)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Esempi: 3600 = 1 ora, 21600 = 6 ore, 86400 = 1 giorno."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Blocca Exploit Comuni"
 	},

--- a/frontend/src/locale/src/ja.json
+++ b/frontend/src/locale/src/ja.json
@@ -344,6 +344,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Fork me on Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "アセットキャッシュの有効期間（秒）"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "例: 3600 = 1時間、21600 = 6時間、86400 = 1日。"
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "一般的なエクスプロイトをブロックする"
 	},

--- a/frontend/src/locale/src/ko.json
+++ b/frontend/src/locale/src/ko.json
@@ -359,6 +359,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "GitHub에서 포크하기"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "에셋 캐시 수명(초)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "예: 3600 = 1시간, 21600 = 6시간, 86400 = 1일."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "일반적인 공격 차단"
 	},

--- a/frontend/src/locale/src/nl.json
+++ b/frontend/src/locale/src/nl.json
@@ -422,6 +422,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Maak een Fork op Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Cacheduur voor assets (seconden)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Voorbeelden: 3600 = 1 uur, 21600 = 6 uur, 86400 = 1 dag."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Veelvoorkomende kwetsbaarheden blokkeren"
 	},

--- a/frontend/src/locale/src/no.json
+++ b/frontend/src/locale/src/no.json
@@ -422,6 +422,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Fork meg på Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Levetid for ressursbuffer (sekunder)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Eksempler: 3600 = 1 time, 21600 = 6 timer, 86400 = 1 dag."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Blokker vanlige utnyttelser"
 	},

--- a/frontend/src/locale/src/pl.json
+++ b/frontend/src/locale/src/pl.json
@@ -350,6 +350,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Forkuj mnie na Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Czas przechowywania zasobów w pamięci podręcznej (sekundy)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Przykłady: 3600 = 1 godzina, 21600 = 6 godzin, 86400 = 1 dzień."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Blokuj typowe exploity"
 	},

--- a/frontend/src/locale/src/pt.json
+++ b/frontend/src/locale/src/pt.json
@@ -347,6 +347,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Faz fork no GitHub"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Duração da cache de recursos (segundos)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Exemplos: 3600 = 1 hora, 21600 = 6 horas, 86400 = 1 dia."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Bloquear Exploits Comuns"
 	},

--- a/frontend/src/locale/src/ru.json
+++ b/frontend/src/locale/src/ru.json
@@ -422,6 +422,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Сделать форк на GitHub"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Время хранения ресурсов в кэше (секунды)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Примеры: 3600 = 1 час, 21600 = 6 часов, 86400 = 1 день."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Блокировать известные эксплойты"
 	},

--- a/frontend/src/locale/src/sk.json
+++ b/frontend/src/locale/src/sk.json
@@ -416,6 +416,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Forknite ma na GitHube"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Doba uloženia prostriedkov vo vyrovnávacej pamäti (sekundy)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Príklady: 3600 = 1 hodina, 21600 = 6 hodín, 86400 = 1 deň."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Blokovať bežné exploity"
 	},

--- a/frontend/src/locale/src/tr.json
+++ b/frontend/src/locale/src/tr.json
@@ -350,6 +350,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Github'da Fork Yap"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Varlık önbelleği ömrü (saniye)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Örnekler: 3600 = 1 saat, 21600 = 6 saat, 86400 = 1 gün."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Yaygın Saldırıları Engelle"
 	},

--- a/frontend/src/locale/src/uk.json
+++ b/frontend/src/locale/src/uk.json
@@ -425,6 +425,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Зробити форк на GitHub"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Asset Cache Lifetime (seconds)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Examples: 3600 = 1 hour, 21600 = 6 hours, 86400 = 1 day."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Блокувати відомі експлойти"
 	},

--- a/frontend/src/locale/src/vi.json
+++ b/frontend/src/locale/src/vi.json
@@ -344,6 +344,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "Fork dự án này trên Github"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "Thời gian lưu bộ nhớ đệm tài nguyên (giây)"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "Ví dụ: 3600 = 1 giờ, 21600 = 6 giờ, 86400 = 1 ngày."
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "Chặn các hoạt động khai thác phổ biến"
 	},

--- a/frontend/src/locale/src/zh.json
+++ b/frontend/src/locale/src/zh.json
@@ -350,6 +350,12 @@
 	"footer.github-fork": {
 		"defaultMessage": "在 Github 上复刻 (Fork) 本项目"
 	},
+	"host.cache-ttl": {
+		"defaultMessage": "资源缓存时长（秒）"
+	},
+	"host.cache-ttl-help": {
+		"defaultMessage": "示例：3600 = 1 小时，21600 = 6 小时，86400 = 1 天。"
+	},
 	"host.flags.block-exploits": {
 		"defaultMessage": "阻止常见攻击"
 	},

--- a/frontend/src/modals/ProxyHostModal.tsx
+++ b/frontend/src/modals/ProxyHostModal.tsx
@@ -13,6 +13,7 @@ import {
 	Loading,
 	LocationsFields,
 	NginxConfigField,
+	ProxyCacheOptionsFields,
 	SSLCertificateField,
 	SSLOptionsFields,
 } from "src/components";
@@ -78,6 +79,7 @@ const ProxyHostModal = EasyModal.create(({ id, visible, remove }: Props) => {
 							forwardPort: data?.forwardPort || undefined,
 							accessListId: data?.accessListId || 0,
 							cachingEnabled: data?.cachingEnabled || false,
+							assetCacheTtl: data?.assetCacheTtl ?? 1800,
 							blockExploits: data?.blockExploits || false,
 							allowWebsocketUpgrade: data?.allowWebsocketUpgrade || false,
 							// Locations tab
@@ -259,29 +261,7 @@ const ProxyHostModal = EasyModal.create(({ id, visible, remove }: Props) => {
 														<T id="options" />
 													</h4>
 													<div className="divide-y">
-														<div>
-															<label className="row" htmlFor="cachingEnabled">
-																<span className="col">
-																	<T id="host.flags.cache-assets" />
-																</span>
-																<span className="col-auto">
-																	<Field name="cachingEnabled" type="checkbox">
-																		{({ field }: any) => (
-																			<label className="form-check form-check-single form-switch">
-																				<input
-																					{...field}
-																					id="cachingEnabled"
-																					className={cn("form-check-input", {
-																						"bg-lime": field.checked,
-																					})}
-																					type="checkbox"
-																				/>
-																			</label>
-																		)}
-																	</Field>
-																</span>
-															</label>
-														</div>
+														<ProxyCacheOptionsFields color="bg-lime" />
 														<div>
 															<label className="row" htmlFor="blockExploits">
 																<span className="col">

--- a/test/cypress/e2e/api/ProxyHostAssetCache.cy.js
+++ b/test/cypress/e2e/api/ProxyHostAssetCache.cy.js
@@ -1,0 +1,74 @@
+/// <reference types="cypress" />
+
+describe('Proxy Host asset cache lifetime', () => {
+	let token;
+	let proxyHostId;
+
+	before(() => {
+		cy.resetUsers();
+		cy.getToken().then((value) => {
+			token = value;
+		});
+	});
+
+	after(() => {
+		if (proxyHostId) {
+			cy.task('backendApiDelete', { token, path: '/api/nginx/proxy-hosts/' + proxyHostId });
+		}
+	});
+
+	it('Keeps the 30-minute default when a client omits the new field', () => {
+		cy.task('backendApiPost', {
+			token,
+			path: '/api/nginx/proxy-hosts',
+			data: {
+				domain_names: ['asset-cache.example.com'],
+				forward_scheme: 'http',
+				forward_host: '127.0.0.1',
+				forward_port: 8080,
+				access_list_id: 0,
+				certificate_id: 0,
+				meta: {},
+				locations: [],
+				caching_enabled: false,
+			},
+		}).then((data) => {
+			proxyHostId = data.id;
+			cy.validateSwaggerSchema('post', 201, '/nginx/proxy-hosts', data);
+			expect(data).to.have.property('asset_cache_ttl', 1800);
+		});
+	});
+
+	it('Persists a custom cache lifetime across updates and reads', () => {
+		cy.task('backendApiPut', {
+			token,
+			path: '/api/nginx/proxy-hosts/' + proxyHostId,
+			data: { caching_enabled: true, asset_cache_ttl: 86400 },
+		}).then((data) => {
+			cy.validateSwaggerSchema('put', 200, '/nginx/proxy-hosts/{hostID}', data);
+			expect(data).to.have.property('asset_cache_ttl', 86400);
+			cy.task('backendApiGet', {
+				token,
+				path: '/api/nginx/proxy-hosts/' + proxyHostId,
+			}).then((savedData) => {
+				cy.validateSwaggerSchema('get', 200, '/nginx/proxy-hosts/{hostID}', savedData);
+				expect(savedData).to.have.property('caching_enabled', true);
+				expect(savedData).to.have.property('asset_cache_ttl', 86400);
+				expect(savedData).to.have.nested.property('meta.nginx_online', true);
+			});
+		});
+	});
+
+	for (const invalidTtl of [0, 31536001, 1.5, '1h; include /tmp/unsafe.conf']) {
+		it('Rejects an invalid cache lifetime: ' + invalidTtl, () => {
+			cy.task('backendApiPut', {
+				token,
+				path: '/api/nginx/proxy-hosts/' + proxyHostId,
+				returnOnError: true,
+				data: { asset_cache_ttl: invalidTtl },
+			}).then((data) => {
+				expect(data).to.have.nested.property('error.message');
+			});
+		});
+	}
+});


### PR DESCRIPTION
## Why

Issue #5448 requests configurable asset cache lifetimes without manual Advanced configuration directives.

This is the asset-caching portion of #5803, split out following the [maintainer's request](https://github.com/NginxProxyManager/nginx-proxy-manager/pull/5803#issuecomment-5467808678). It targets `develop` independently and does not include gzip or HTTP/3 controls. It addresses the caching part of #5448; the gzip part is submitted separately in #5816. The HTTP/3 portion is in #5817.

## What Changed

- Add the optional API field `asset_cache_ttl`, with a database default of 1800 seconds and validation from 1 to 31536000 seconds.
- Show the lifetime field only when Cache Assets is enabled.
- Apply the configured lifetime to both the main host and custom locations.
- Extract shared asset proxy directives while keeping the existing static `assets.conf` include available.
- Include a dedicated migration, OpenAPI definitions/examples, translations, and focused backend, frontend, and API tests.

Existing API clients can omit the new field. There are no removed or renamed fields, and no HTTP/3 listener, port, or gzip changes.

## Validation

- Backend tests: 5 passed; full frontend suite: 11 passed.
- Backend/frontend lint, OpenAPI validation, locale compilation, TypeScript, and production frontend build passed.
- Fresh isolated Linux/SQLite setup: all 20 migrations passed; persisted defaults and absence of unrelated feature columns verified.
- SQLite upgrade/rollback checks verified defaults, saved values, and removal of only this feature's column.
- Real Nginx configuration and HTTP checks passed for regular/custom locations, 1800/21600/31536000-second lifetimes, and disabled caching.
- Feature-specific Cypress API scenarios are included; the full Cypress CI stack was not rerun locally.

The Windows frontend test run used `NODE_OPTIONS=--no-experimental-webstorage` with Node 26. The runtime checks used the project's `nginxproxymanager/nginx-full:certbot-node` image with Node 22.

A temporary combined checkout of all three split changes also passed 13 backend tests, 13 frontend tests, the frontend build, all 22 migrations, and the Nginx runtime checks after resolving the shared insertion points.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [x] API changes
- [x] Performance improvement
- [x] Test addition or update

## AI Usage

- [x] AI was used to write this
- [x] AI was used to review this
