### PR TITLE
Remove broken sorting from Audit Logs

### DIFF
--- a/frontend/src/pages/AuditLog/Table.tsx
+++ b/frontend/src/pages/AuditLog/Table.tsx
@@ -16,7 +16,8 @@ export default function Table({ data, isFetching, onSelectItem }: Props) {
 	const columns = useMemo(
 		() => [
 			columnHelper.accessor((row: any) => row.user, {
-				id: "user.avatar",
+				id: "owner",
+				enableSorting: false,
 				cell: (info: any) => {
 					const value = info.getValue();
 					return <GravatarFormatter url={value ? value.avatar : ""} name={value ? value.name : ""} />;
@@ -28,6 +29,7 @@ export default function Table({ data, isFetching, onSelectItem }: Props) {
 			columnHelper.accessor((row: any) => row, {
 				id: "objectType",
 				header: intl.formatMessage({ id: "column.event" }),
+				enableSorting: false,
 				cell: (info: any) => {
 					return <EventFormatter row={info.getValue()} />;
 				},


### PR DESCRIPTION
<!-- WARNING: Any PR without a description will be closed. The title is not enough! -->

<!-- ANOTHER WARNING: Don't go creating a duplicate PR! Check that someone hasn't already created something that tackles your fix and if so, help them first -->

## Why

<!-- Provide a brief description of WHY you are making your changes -->
Removed the sorting functionality from the audit logs, as it didn't provide much value. Also renamed `user.avatar` to `owner` to match the naming used for the other hosts.

<img width="301" height="168" alt="image" src="https://github.com/user-attachments/assets/a40f9229-2f9b-4592-8efd-a03b55ae3b07" />

<img width="285" height="184" alt="image" src="https://github.com/user-attachments/assets/6f29ab57-b0e3-4dfe-aa96-008e0388cfd7" />

<!-- Consider if you are changing the API, then go in to detail why and/or if
you change will break API for existing users -->

## Type of Change

<!-- Mark the relevant options with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

<!-- Mark the relevant options with an "x" -->

- [ ] AI was used to write this
- [ ] AI was used to review this

