### PR TITLE
Translate the entire user interface into Estonian and ensure that the Estonian flag is displayed./Tõlgi kogu kasutajaliides eesti keelde ja kinnita Eesti lipp.

### DIFF
--- a/frontend/src/locale/IntlProvider.tsx
+++ b/frontend/src/locale/IntlProvider.tsx
@@ -69,17 +69,17 @@ const loadMessages = (locale?: string): typeof langList & typeof langEn => {
 const getFlagCodeForLocale = (locale?: string) => {
 	const thisLocale = (locale || "en").slice(0, 2);
 
-  // only add to this if your flag is different from the locale code
-  const specialCases: Record<string, string> = {
-    ja: "jp", // Japan
-    zh: "cn", // China
-    vi: "vn", // Vietnam
-    ko: "kr", // Korea
-    cs: "cz", // Czechia
-    ga: "ie", // Ireland (Irish)
-    et: "ee", // Estonia
-    uk: "ua", // Ukraine
-  };
+	// only add to this if your flag is different from the locale code
+	const specialCases: Record<string, string> = {
+		ja: "jp", // Japan
+		zh: "cn", // China
+		vi: "vn", // Vietnam
+		ko: "kr", // Korea
+		cs: "cz", // Czechia
+		ga: "ie", // Ireland (Irish)
+		et: "ee", // Estonia (ISO 3166-1). "et" as a country code would be Ethiopia.
+		uk: "ua", // Ukraine
+	};
 
 	if (specialCases[thisLocale]) {
 		return specialCases[thisLocale].toUpperCase();

--- a/frontend/src/locale/Utils.test.tsx
+++ b/frontend/src/locale/Utils.test.tsx
@@ -92,8 +92,23 @@ describe("getFlagCodeForLocale", () => {
 		expect(getFlagCodeForLocale("ga-IE")).toBe("IE");
 	});
 
+	it("returns EE (Estonia) for Estonian locale, not ET (Ethiopia)", () => {
+		expect(getFlagCodeForLocale("et")).toBe("EE");
+		expect(getFlagCodeForLocale("et-EE")).toBe("EE");
+	});
+
 	it("falls back to EN when no locale is provided", () => {
 		expect(getFlagCodeForLocale()).toBe("EN");
 		expect(getFlagCodeForLocale(undefined)).toBe("EN");
+	});
+});
+
+describe("formatDateTime Estonian locale", () => {
+	it("uses 24-hour clock for et and et-EE", () => {
+		const value = "2024-06-15T15:30:00.000Z";
+		for (const locale of ["et", "et-EE"]) {
+			const text = formatDateTime(value, locale);
+			expect(text.toLowerCase()).not.toMatch(/\b(am|pm)\b/);
+		}
 	});
 });

--- a/frontend/src/locale/Utils.ts
+++ b/frontend/src/locale/Utils.ts
@@ -20,18 +20,29 @@ const parseDate = (value: string | number): Date | null => {
 	}
 };
 
+const DATE_LOCALE_BY_LANG: Record<string, string> = {
+	et: "et-EE",
+};
+
+const HOUR_CYCLE_BY_LANG: Record<string, "h12" | "h23"> = {
+	et: "h23",
+};
+
 const formatDateTime = (value: string | number, locale = "en-US"): string => {
 	const d = parseDate(value);
 	if (!d) return `${value}`;
+	const lang = (locale || "en").slice(0, 2);
+	const resolvedLocale = DATE_LOCALE_BY_LANG[lang] || locale;
+	const hourCycle = HOUR_CYCLE_BY_LANG[lang] || "h12";
 	try {
 		return intlFormat(
 			d,
 			{
 				dateStyle: "medium",
 				timeStyle: "medium",
-				hourCycle: "h12",
+				hourCycle,
 			} as IntlFormatFormatOptions,
-			{ locale },
+			{ locale: resolvedLocale },
 		);
 	} catch {
 		return `${value}`;

--- a/frontend/src/locale/et.test.ts
+++ b/frontend/src/locale/et.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import en from "./src/en.json";
+import et from "./src/et.json";
+
+const english = en as Record<string, { defaultMessage: string }>;
+const estonian = et as Record<string, { defaultMessage: string }>;
+
+// Brand names, codes and ICU-only strings can stay the same as English.
+const allowedIdentical = new Set([
+	"certificates.key-type-ecdsa",
+	"certificates.key-type-rsa",
+	"column.ssl",
+	"lets-encrypt",
+	"object.actions-title",
+	"streams.tcp",
+	"streams.udp",
+]);
+
+describe("Estonian UI locale", () => {
+	it("covers every English UI key", () => {
+		const missing = Object.keys(english).filter((key) => !(key in estonian));
+		expect(missing).toEqual([]);
+	});
+
+	it("does not add keys that are missing from English", () => {
+		const extra = Object.keys(estonian).filter((key) => !(key in english));
+		expect(extra).toEqual([]);
+	});
+
+	it("is translated, not an English copy", () => {
+		const identical = Object.keys(english).filter(
+			(key) => estonian[key]?.defaultMessage === english[key]?.defaultMessage,
+		);
+		const unexpected = identical.filter((key) => !allowedIdentical.has(key));
+		expect(unexpected).toEqual([]);
+	});
+
+	it("keeps ICU data placeholders from English strings", () => {
+		const argNames = [
+			"count",
+			"object",
+			"objects",
+			"id",
+			"date",
+			"users",
+			"rules",
+			"max",
+			"min",
+			"domain",
+			"code",
+			"latestVersion",
+			"name",
+		];
+		const usedArgs = (message: string) => argNames.filter((name) => message.includes(`{${name}`));
+		const broken: string[] = [];
+
+		for (const key of Object.keys(english)) {
+			const expected = usedArgs(english[key].defaultMessage).join(",");
+			const actual = usedArgs(estonian[key]?.defaultMessage ?? "").join(",");
+			if (expected !== actual) {
+				broken.push(`${key}: expected {${expected}} got {${actual}}`);
+			}
+		}
+
+		expect(broken).toEqual([]);
+	});
+});

--- a/frontend/src/locale/src/HelpDoc/et/AccessLists.md
+++ b/frontend/src/locale/src/HelpDoc/et/AccessLists.md
@@ -1,7 +1,7 @@
 ## Mis on juurdepääsuloend?
 
-Ligipääsuloendid pakuvad konkreetsete klientide IP-aadresside musta või valget nimekirja koos puhverserverite autentimisega põhilise HTTP-autentimise kaudu.
+Juurdepääsuloendiga saad lubada või keelata klientide IP-aadresse ning panna puhverserverile ette HTTP basic-autentimise.
 
-Saate ühe juurdepääsuloendi jaoks konfigureerida mitu kliendireeglit, kasutajanime ja parooli ning seejärel rakendada neid ühele või mitmele _puhverserverile_.
+Ühte loendisse saab panna mitu reeglit, kasutajanime ja parooli. Sama loendi saad kinnitada ühele või mitmele puhverserverile.
 
-See on kõige kasulikum edastatud veebiteenuste puhul, millel pole sisseehitatud autentimismehhanisme või kui soovite kaitsta tundmatute klientide eest.
+Sellest on kasu siis, kui edastataval teenusel endal sisselogimist pole või tahad võõrad kliendid eemal hoida.

--- a/frontend/src/locale/src/HelpDoc/et/Certificates.md
+++ b/frontend/src/locale/src/HelpDoc/et/Certificates.md
@@ -2,25 +2,20 @@
 
 ### HTTP-sertifikaat
 
-HTTP-valideeritud sertifikaat tähendab, et Let's Encrypti serverid
+HTTP-ga kinnitatud sertifikaadi puhul üritavad Let's Encrypti serverid su domeenidele ligi saada HTTP kaudu (mitte HTTPS!) ja õnnestumise korral väljastavad sertifikaadi.
 
-proovivad teie domeenidega ühendust luua HTTP (mitte HTTPS!) kaudu ja kui see õnnestub,
-väljastavad nad teile sertifikaadi.
+Selleks peab olema loodud puhverserver, mis on HTTP kaudu kättesaadav ja osutab sellele Nginxile. Kui sertifikaat on käes, võid puhverserveri panna HTTPS-i ka kasutama. Uuendamiseks peab HTTP-ligipääs siiski alles jääma.
 
-Selle meetodi jaoks peate oma domeeni(de) jaoks looma _Proxy Host_, millele pääseb ligi HTTP kaudu ja mis osutab sellele Nginxi installile. Pärast sertifikaadi väljastamist saate muuta _Proxy Host_'i, et seda sertifikaati ka HTTPS
-ühenduste jaoks kasutada. Sertifikaadi uuendamiseks tuleb aga _Proxy Host_ ikkagi HTTP-juurdepääsu jaoks konfigureerida.
-
-See protsess _ei_ toeta metamärke kasutavaid domeene.
+Metamärgid (wildcard) selle meetodiga ei tööta.
 
 ### DNS-sertifikaat
 
-DNS-i poolt valideeritud sertifikaadi saamiseks peate kasutama DNS-pakkuja pistikprogrammi. Seda DNS-teenuse pakkujat kasutatakse teie domeenis ajutiste kirjete loomiseks ja seejärel pärib Let's
-Encrypt nende kirjete kohta päringu, et veenduda, et olete omanik, ja kui see õnnestub, väljastavad nad teile sertifikaadi.
+DNS-iga kinnitatud sertifikaat vajab DNS-teenuse pakkuja pluginat. Plugin loob domeenile ajutised kirjed, Let's Encrypt kontrollib need üle ja õnnestumise korral väljastab sertifikaadi.
 
-Selle tüüpi sertifikaadi taotlemiseks ei ole vaja luua _Proxy Host_'i. Samuti ei pea teie _Proxy Host_ olema HTTP-juurdepääsu jaoks konfigureeritud.
+Puhverserverit enne taotlust looma ei pea. HTTP-ligipääsu ka ei nõuta.
 
-See protsess _toetab_ metamärke kasutavaid domeene.
+See meetod toetab metamärke.
 
 ### Kohandatud sertifikaat
 
-Kasutage seda valikut oma SSL-sertifikaadi üleslaadimiseks, mille on esitanud teie enda sertifitseerimisasutus.
+Siia saad üles laadida oma SSL-sertifikaadi, mille on väljastanud sinu sertifitseerija.

--- a/frontend/src/locale/src/HelpDoc/et/DeadHosts.md
+++ b/frontend/src/locale/src/HelpDoc/et/DeadHosts.md
@@ -1,9 +1,7 @@
-## Mis on 404 host?
+## Mis on 404-host?
 
-404 host on lihtsalt hosti seadistus, mis kuvab 404 lehte.
+404-host on lihtsalt host, mis näitab 404 lehte.
 
-See võib olla kasulik, kui teie domeen on otsingumootorites loetletud ja soovite
-esitada kenama vealehe või konkreetselt otsingu indekseerijatele öelda, et
-domeenilehed enam ei eksisteeri.
+Sellest on abi, kui domeen on otsingumootorites kirjas ja tahad näidata kenamat vealehte või anda indekseerijatele märku, et lehti enam pole.
 
-Selle hosti teine eelis on selle külastatavuste logide jälgimine ja suunajate vaatamine.
+Lisaks näed logist, kes sinna sattus ja kust nad tulid.

--- a/frontend/src/locale/src/HelpDoc/et/ProxyHosts.md
+++ b/frontend/src/locale/src/HelpDoc/et/ProxyHosts.md
@@ -1,7 +1,7 @@
 ## Mis on puhverserver?
 
-Puhverserver on veebiteenuse sissetuleva andmevoo lõpp-punkt, mida soovite edastada.
+Puhverserver on veebiteenuse sisend, mille suunad edasi oma tegelikule teenusele.
 
-See pakub valikulist SSL-i lõpetamist teie teenusele, millel ei pruugi olla sisseehitatud SSL-tuge.
+Soovi korral lõpetab see SSL-i sinu eest — isegi kui teenusel endal SSL-tuge pole.
 
-Puhverserverid on Nginxi puhverserveri halduri kõige levinum kasutusala.
+Puhverserverid on Nginx Proxy Manageri kõige tavalisem kasutus.

--- a/frontend/src/locale/src/HelpDoc/et/RedirectionHosts.md
+++ b/frontend/src/locale/src/HelpDoc/et/RedirectionHosts.md
@@ -1,5 +1,5 @@
 ## Mis on ümbersuunamishost?
 
-Ümbersuunamishost suunab sissetuleva domeeni päringud ümber ja suunab vaataja teisele domeenile.
+Ümbersuunamishost võtab päringud ühelt domeenilt ja saadab külastaja teisele.
 
-Kõige levinum põhjus seda tüüpi hosti kasutamiseks on see, kui teie veebisaidi domeenid muutuvad, kuid otsingumootori või suunaja lingid osutavad endiselt vanale domeenile.
+Kõige sagedamini on seda vaja siis, kui sait kolis uuele domeenile, aga vanad lingid otsingust või viidetest käivad veel vana aadressi pihta.

--- a/frontend/src/locale/src/HelpDoc/et/Streams.md
+++ b/frontend/src/locale/src/HelpDoc/et/Streams.md
@@ -1,5 +1,5 @@
 ## Mis on voog?
 
-Nginxi suhteliselt uus funktsioon, voog, edastab TCP/UDP liiklust otse võrgus olevale teisele arvutile.
+Voog on Nginxi suhteliselt uus võimalus suunata TCP/UDP liiklus otse teisele masinale võrgus.
 
-Kui sul on mänguserverid, FTP- või SSH-serverid, võib see kasuks tulla.
+Kasulik näiteks mängu-, FTP- või SSH-serverite puhul.

--- a/frontend/src/locale/src/et.json
+++ b/frontend/src/locale/src/et.json
@@ -1,237 +1,240 @@
 {
 	"2fa.backup-codes-remaining": {
-		"defaultMessage": "Backup codes remaining: {count}"
+		"defaultMessage": "Varukoode jäänud: {count}"
 	},
 	"2fa.backup-warning": {
-		"defaultMessage": "Save these backup codes in a secure place. Each code can only be used once."
+		"defaultMessage": "Pane need varukoodid kindlasse kohta tallele. Iga koodi saab kasutada ainult üks kord."
 	},
 	"2fa.disable": {
-		"defaultMessage": "Disable Two-Factor Authentication"
+		"defaultMessage": "Lülita kaheastmeline autentimine välja"
 	},
 	"2fa.disable-confirm": {
-		"defaultMessage": "Disable 2FA"
+		"defaultMessage": "Lülita 2FA välja"
 	},
 	"2fa.disable-warning": {
-		"defaultMessage": "Disabling two-factor authentication will make your account less secure."
+		"defaultMessage": "Ilma kaheastmelise autentimiseta on konto kergemini rünnatav."
 	},
 	"2fa.disabled": {
-		"defaultMessage": "Disabled"
+		"defaultMessage": "Väljas"
 	},
 	"2fa.done": {
-		"defaultMessage": "I have saved my backup codes"
+		"defaultMessage": "Varukoodid on tallele pandud"
 	},
 	"2fa.enable": {
-		"defaultMessage": "Enable Two-Factor Authentication"
+		"defaultMessage": "Lülita kaheastmeline autentimine sisse"
 	},
 	"2fa.enabled": {
-		"defaultMessage": "Enabled"
+		"defaultMessage": "Sees"
 	},
 	"2fa.enter-code": {
-		"defaultMessage": "Enter verification code"
+		"defaultMessage": "Sisesta kinnituskood"
 	},
 	"2fa.enter-code-disable": {
-		"defaultMessage": "Enter verification code to disable"
+		"defaultMessage": "Sisesta kinnituskood, et välja lülitada"
 	},
 	"2fa.regenerate": {
-		"defaultMessage": "Regenerate"
+		"defaultMessage": "Loo uuesti"
 	},
 	"2fa.regenerate-backup": {
-		"defaultMessage": "Regenerate Backup Codes"
+		"defaultMessage": "Loo uued varukoodid"
 	},
 	"2fa.regenerate-instructions": {
-		"defaultMessage": "Enter a verification code to generate new backup codes. Your old codes will be invalidated."
+		"defaultMessage": "Sisesta kinnituskood, et luua uued varukoodid. Vanad koodid muutuvad kehtetuks."
 	},
 	"2fa.secret-key": {
-		"defaultMessage": "Secret Key"
+		"defaultMessage": "Salavõti"
 	},
 	"2fa.setup-instructions": {
-		"defaultMessage": "Scan this QR code with your authenticator app, or enter the secret manually."
+		"defaultMessage": "Skanni QR-kood autentimisäpiga või sisesta salavõti käsitsi."
 	},
 	"2fa.status": {
-		"defaultMessage": "Status"
+		"defaultMessage": "Olek"
 	},
 	"2fa.title": {
-		"defaultMessage": "Two-Factor Authentication"
+		"defaultMessage": "Kaheastmeline autentimine"
 	},
 	"2fa.verify-enable": {
-		"defaultMessage": "Verify and Enable"
+		"defaultMessage": "Kinnita ja lülita sisse"
 	},
 	"access-list": {
-		"defaultMessage": "Access List"
+		"defaultMessage": "Juurdepääsuloend"
 	},
 	"access-list.access-count": {
-		"defaultMessage": "{count} {count, plural, one {Rule} other {Rules}}"
+		"defaultMessage": "{count} {count, plural, one {reegel} other {reeglit}}"
 	},
 	"access-list.auth-count": {
-		"defaultMessage": "{count} {count, plural, one {User} other {Users}}"
+		"defaultMessage": "{count} {count, plural, one {kasutaja} other {kasutajat}}"
 	},
 	"access-list.help-rules-last": {
-		"defaultMessage": "When at least 1 rule exists, this deny all rule will be added last"
+		"defaultMessage": "Kui vähemalt üks reegel on olemas, lisatakse lõppu keeld kõigile ülejäänutele"
 	},
 	"access-list.help.rules-order": {
-		"defaultMessage": "Note that the allow and deny directives will be applied in the order they are defined."
+		"defaultMessage": "Luba ja keela reeglid rakenduvad selles järjekorras, milles need on kirjas."
 	},
 	"access-list.pass-auth": {
-		"defaultMessage": "Pass Auth to Upstream"
+		"defaultMessage": "Edasta autentimine sihtserverile"
 	},
 	"access-list.public": {
-		"defaultMessage": "Publicly Accessible"
+		"defaultMessage": "Avalikult ligipääsetav"
 	},
 	"access-list.public.subtitle": {
-		"defaultMessage": "No basic auth required"
+		"defaultMessage": "Basic-autentimist ei küsita"
 	},
 	"access-list.rule-source.placeholder": {
-		"defaultMessage": "192.168.1.100 or 192.168.1.0/24 or 2001:0db8::/32"
+		"defaultMessage": "192.168.1.100 või 192.168.1.0/24 või 2001:0db8::/32"
 	},
 	"access-list.satisfy-any": {
-		"defaultMessage": "Satisfy Any"
+		"defaultMessage": "Piisab ühest tingimusest"
 	},
 	"access-list.subtitle": {
-		"defaultMessage": "{users} {users, plural, one {User} other {Users}}, {rules} {rules, plural, one {Rule} other {Rules}} - Created: {date}"
+		"defaultMessage": "{users} {users, plural, one {kasutaja} other {kasutajat}}, {rules} {rules, plural, one {reegel} other {reeglit}} – loodud: {date}"
 	},
 	"access-lists": {
-		"defaultMessage": "Access Lists"
+		"defaultMessage": "Juurdepääsuloendid"
 	},
 	"action.add": {
-		"defaultMessage": "Add"
+		"defaultMessage": "Lisa"
 	},
 	"action.add-location": {
-		"defaultMessage": "Add Location"
+		"defaultMessage": "Lisa asukoht"
 	},
 	"action.allow": {
-		"defaultMessage": "Allow"
+		"defaultMessage": "Luba"
+	},
+	"action.clear": {
+		"defaultMessage": "Tühjenda"
 	},
 	"action.close": {
-		"defaultMessage": "Close"
+		"defaultMessage": "Sulge"
 	},
 	"action.delete": {
-		"defaultMessage": "Delete"
+		"defaultMessage": "Kustuta"
 	},
 	"action.deny": {
-		"defaultMessage": "Deny"
+		"defaultMessage": "Keela"
 	},
 	"action.disable": {
-		"defaultMessage": "Disable"
+		"defaultMessage": "Lülita välja"
 	},
 	"action.download": {
-		"defaultMessage": "Download"
+		"defaultMessage": "Laadi alla"
 	},
 	"action.edit": {
-		"defaultMessage": "Edit"
+		"defaultMessage": "Muuda"
 	},
 	"action.enable": {
-		"defaultMessage": "Enable"
+		"defaultMessage": "Lülita sisse"
 	},
 	"action.permissions": {
-		"defaultMessage": "Permissions"
+		"defaultMessage": "Õigused"
 	},
 	"action.renew": {
-		"defaultMessage": "Renew"
+		"defaultMessage": "Uuenda"
 	},
 	"action.view-details": {
-		"defaultMessage": "View Details"
+		"defaultMessage": "Vaata üksikasju"
 	},
 	"auditlogs": {
-		"defaultMessage": "Audit Logs"
+		"defaultMessage": "Auditilogid"
 	},
 	"auto": {
-		"defaultMessage": "Auto"
+		"defaultMessage": "Automaatne"
 	},
 	"cancel": {
-		"defaultMessage": "Cancel"
+		"defaultMessage": "Tühista"
 	},
 	"certificate": {
-		"defaultMessage": "Certificate"
+		"defaultMessage": "Sertifikaat"
 	},
 	"certificate.custom-certificate": {
-		"defaultMessage": "Certificate"
+		"defaultMessage": "Sertifikaat"
 	},
 	"certificate.custom-certificate-key": {
-		"defaultMessage": "Certificate Key"
+		"defaultMessage": "Sertifikaadi võti"
 	},
 	"certificate.custom-intermediate": {
-		"defaultMessage": "Intermediate Certificate"
+		"defaultMessage": "Vahesertifikaat"
 	},
 	"certificate.in-use": {
-		"defaultMessage": "In Use"
+		"defaultMessage": "Kasutusel"
 	},
 	"certificate.none.subtitle": {
-		"defaultMessage": "No certificate assigned"
+		"defaultMessage": "Sertifikaati pole määratud"
 	},
 	"certificate.none.subtitle.for-http": {
-		"defaultMessage": "This host will not use HTTPS"
+		"defaultMessage": "See host ei kasuta HTTPS-i"
 	},
 	"certificate.none.title": {
-		"defaultMessage": "None"
+		"defaultMessage": "Puudub"
 	},
 	"certificate.not-in-use": {
-		"defaultMessage": "Not Used"
+		"defaultMessage": "Ei ole kasutusel"
 	},
 	"certificate.renew": {
-		"defaultMessage": "Renew Certificate"
+		"defaultMessage": "Uuenda sertifikaati"
 	},
 	"certificates": {
-		"defaultMessage": "Certificates"
+		"defaultMessage": "Sertifikaadid"
 	},
 	"certificates.custom": {
-		"defaultMessage": "Custom Certificate"
+		"defaultMessage": "Kohandatud sertifikaat"
 	},
 	"certificates.custom.warning": {
-		"defaultMessage": "Key files protected with a passphrase are not supported."
+		"defaultMessage": "Parooliga kaitstud võtmefaile ei toetata."
 	},
 	"certificates.dns.credentials": {
-		"defaultMessage": "Credentials File Content"
+		"defaultMessage": "Tunnuste faili sisu"
 	},
 	"certificates.dns.credentials-note": {
-		"defaultMessage": "This plugin requires a configuration file containing an API token or other credentials for your provider"
+		"defaultMessage": "See plugin tahab seadistusfaili, kus on teenusepakkuja API token või muud tunnused"
 	},
 	"certificates.dns.credentials-warning": {
-		"defaultMessage": "This data will be stored as plaintext in the database and in a file!"
+		"defaultMessage": "Need andmed jäävad andmebaasi ja faili avatekstina!"
 	},
 	"certificates.dns.propagation-seconds": {
-		"defaultMessage": "Propagation Seconds"
+		"defaultMessage": "DNS-i leviku ooteaeg"
 	},
 	"certificates.dns.propagation-seconds-note": {
-		"defaultMessage": "Leave empty to use the plugins default value. Number of seconds to wait for DNS propagation."
+		"defaultMessage": "Jäta tühjaks, kui tahad plugina vaikeväärtust. Mitu sekundit DNS-i levikut oodata."
 	},
 	"certificates.dns.provider": {
-		"defaultMessage": "DNS Provider"
+		"defaultMessage": "DNS-teenuse pakkuja"
 	},
 	"certificates.dns.provider.placeholder": {
-		"defaultMessage": "Select a Provider..."
+		"defaultMessage": "Vali pakkuja..."
 	},
 	"certificates.dns.warning": {
-		"defaultMessage": "This section requires some knowledge about Certbot and its DNS plugins. Please consult the respective plugins documentation."
+		"defaultMessage": "See osa eeldab Certboti ja selle DNS-pluginate tundmist. Vaata vastava plugina juhendit."
 	},
 	"certificates.http.reachability-404": {
-		"defaultMessage": "There is a server found at this domain but it does not seem to be Nginx Proxy Manager. Please make sure your domain points to the IP where your NPM instance is running."
+		"defaultMessage": "Sellel domeenil on küll server, aga see ei tundu olevat Nginx Proxy Manager. Vaata, et domeen osutaks IP-le, kus NPM tegelikult töötab."
 	},
 	"certificates.http.reachability-failed-to-check": {
-		"defaultMessage": "Failed to check the reachability due to a communication error with site24x7.com."
+		"defaultMessage": "Kättesaadavust ei saanud kontrollida, sest side site24x7.com-iga katkes."
 	},
 	"certificates.http.reachability-not-resolved": {
-		"defaultMessage": "There is no server available at this domain. Please make sure your domain exists and points to the IP where your NPM instance is running and if necessary port 80 is forwarded in your router."
+		"defaultMessage": "Sellel domeenil ei ole serverit. Vaata, et domeen olemas oleks, osutaks NPM-i IP-le ja vajadusel oleks ruuteris avatud port 80."
 	},
 	"certificates.http.reachability-ok": {
-		"defaultMessage": "Your server is reachable and creating certificates should be possible."
+		"defaultMessage": "Server on kättesaadav, sertifikaadi saab ära teha."
 	},
 	"certificates.http.reachability-other": {
-		"defaultMessage": "There is a server found at this domain but it returned an unexpected status code {code}. Is it the NPM server? Please make sure your domain points to the IP where your NPM instance is running."
+		"defaultMessage": "Sellel domeenil on server, aga vastus tuli ootamatu koodiga {code}. Kas see on NPM? Vaata, et domeen osutaks IP-le, kus NPM töötab."
 	},
 	"certificates.http.reachability-wrong-data": {
-		"defaultMessage": "There is a server found at this domain but it returned an unexpected data. Is it the NPM server? Please make sure your domain points to the IP where your NPM instance is running."
+		"defaultMessage": "Sellel domeenil on server, aga vastuse sisu ei klapi. Kas see on NPM? Vaata, et domeen osutaks IP-le, kus NPM töötab."
 	},
 	"certificates.http.test-results": {
-		"defaultMessage": "Test Results"
+		"defaultMessage": "Testi tulemused"
 	},
 	"certificates.http.warning": {
-		"defaultMessage": "These domains must be already configured to point to this installation."
+		"defaultMessage": "Need domeenid peavad juba osutama sellele paigaldusele."
 	},
 	"certificates.key-type": {
-		"defaultMessage": "Key Type"
+		"defaultMessage": "Võtme tüüp"
 	},
 	"certificates.key-type-description": {
-		"defaultMessage": "RSA is widely compatible, ECDSA is faster and more secure but may not be supported by older systems"
+		"defaultMessage": "RSA klapib peaaegu kõikjale, ECDSA on kiirem ja turvalisem, aga vanemad süsteemid ei pruugi seda tunda"
 	},
 	"certificates.key-type-ecdsa": {
 		"defaultMessage": "ECDSA 256"
@@ -240,475 +243,481 @@
 		"defaultMessage": "RSA 2048"
 	},
 	"certificates.request.subtitle": {
-		"defaultMessage": "with Let's Encrypt"
+		"defaultMessage": "Let's Encryptiga"
 	},
 	"certificates.request.title": {
-		"defaultMessage": "Request a new Certificate"
+		"defaultMessage": "Taotle uut sertifikaati"
 	},
 	"column.access": {
-		"defaultMessage": "Access"
+		"defaultMessage": "Juurdepääs"
 	},
 	"column.authorization": {
-		"defaultMessage": "Authorization"
+		"defaultMessage": "Autentimine"
 	},
 	"column.authorizations": {
-		"defaultMessage": "Authorizations"
+		"defaultMessage": "Autentimised"
 	},
 	"column.custom-locations": {
-		"defaultMessage": "Custom Locations"
+		"defaultMessage": "Kohandatud asukohad"
 	},
 	"column.destination": {
-		"defaultMessage": "Destination"
+		"defaultMessage": "Sihtkoht"
 	},
 	"column.details": {
-		"defaultMessage": "Details"
+		"defaultMessage": "Üksikasjad"
 	},
 	"column.email": {
-		"defaultMessage": "Email"
+		"defaultMessage": "E-post"
 	},
 	"column.event": {
-		"defaultMessage": "Event"
+		"defaultMessage": "Sündmus"
 	},
 	"column.expires": {
-		"defaultMessage": "Expires"
+		"defaultMessage": "Aegub"
 	},
 	"column.http-code": {
-		"defaultMessage": "HTTP Code"
+		"defaultMessage": "HTTP-kood"
 	},
 	"column.incoming-port": {
-		"defaultMessage": "Incoming Port"
+		"defaultMessage": "Sisendport"
 	},
 	"column.name": {
-		"defaultMessage": "Name"
+		"defaultMessage": "Nimi"
 	},
 	"column.protocol": {
-		"defaultMessage": "Protocol"
+		"defaultMessage": "Protokoll"
 	},
 	"column.provider": {
-		"defaultMessage": "Provider"
+		"defaultMessage": "Pakkuja"
 	},
 	"column.roles": {
-		"defaultMessage": "Roles"
+		"defaultMessage": "Rollid"
 	},
 	"column.rules": {
-		"defaultMessage": "Rules"
+		"defaultMessage": "Reeglid"
 	},
 	"column.satisfy": {
-		"defaultMessage": "Satisfy"
+		"defaultMessage": "Tingimus"
 	},
 	"column.satisfy-all": {
-		"defaultMessage": "All"
+		"defaultMessage": "Kõik"
 	},
 	"column.satisfy-any": {
-		"defaultMessage": "Any"
+		"defaultMessage": "Mõni"
 	},
 	"column.scheme": {
-		"defaultMessage": "Scheme"
+		"defaultMessage": "Skeem"
 	},
 	"column.source": {
-		"defaultMessage": "Source"
+		"defaultMessage": "Allikas"
 	},
 	"column.ssl": {
 		"defaultMessage": "SSL"
 	},
 	"column.status": {
-		"defaultMessage": "Status"
+		"defaultMessage": "Olek"
 	},
 	"created-on": {
-		"defaultMessage": "Created: {date}"
+		"defaultMessage": "Loodud: {date}"
 	},
 	"dashboard": {
-		"defaultMessage": "Dashboard"
+		"defaultMessage": "Töölaud"
 	},
 	"dead-host": {
-		"defaultMessage": "404 Host"
+		"defaultMessage": "404-host"
 	},
 	"dead-hosts": {
-		"defaultMessage": "404 Hosts"
+		"defaultMessage": "404-hostid"
 	},
 	"dead-hosts.count": {
-		"defaultMessage": "{count} {count, plural, one {404 Host} other {404 Hosts}}"
+		"defaultMessage": "{count} {count, plural, one {404-host} other {404-hosti}}"
 	},
 	"disabled": {
-		"defaultMessage": "Disabled"
+		"defaultMessage": "Väljas"
 	},
 	"domain-names": {
-		"defaultMessage": "Domain Names"
+		"defaultMessage": "Domeeninimed"
 	},
 	"domain-names.max": {
-		"defaultMessage": "{count} domain names maximum"
+		"defaultMessage": "Kuni {count} domeeninime"
 	},
 	"domain-names.placeholder": {
-		"defaultMessage": "Start typing to add domain..."
+		"defaultMessage": "Kirjuta, et domeen lisada..."
 	},
 	"domain-names.wildcards-not-permitted": {
-		"defaultMessage": "Wildcards not permitted for this type"
+		"defaultMessage": "Selle tüübi puhul metamärke ei saa"
 	},
 	"domain-names.wildcards-not-supported": {
-		"defaultMessage": "Wildcards not supported for this CA"
+		"defaultMessage": "See CA metamärke ei toeta"
 	},
 	"domains.advanced": {
-		"defaultMessage": "Advanced"
+		"defaultMessage": "Lisavalikud"
 	},
 	"domains.force-ssl": {
-		"defaultMessage": "Force SSL"
+		"defaultMessage": "Sunni SSL"
 	},
 	"domains.hsts-enabled": {
-		"defaultMessage": "HSTS Enabled"
+		"defaultMessage": "HSTS sees"
 	},
 	"domains.hsts-subdomains": {
-		"defaultMessage": "HSTS Sub-domains"
+		"defaultMessage": "HSTS alamdomeenidel"
 	},
 	"domains.http2-support": {
-		"defaultMessage": "HTTP/2 Support"
+		"defaultMessage": "HTTP/2 tugi"
 	},
 	"domains.trust-forwarded-proto": {
-		"defaultMessage": "Trust Upstream Forwarded Proto Headers"
+		"defaultMessage": "Usalda sihtserveri Forwarded Proto päiseid"
 	},
 	"domains.use-dns": {
-		"defaultMessage": "Use DNS Challenge"
+		"defaultMessage": "Kasuta DNS-väljakutset"
 	},
 	"email-address": {
-		"defaultMessage": "Email address"
+		"defaultMessage": "E-posti aadress"
 	},
 	"empty-search": {
-		"defaultMessage": "No results found"
+		"defaultMessage": "Tulemusi ei leitud"
 	},
 	"empty-subtitle": {
-		"defaultMessage": "Why don't you create one?"
+		"defaultMessage": "Miks mitte üks luua?"
 	},
 	"enabled": {
-		"defaultMessage": "Enabled"
+		"defaultMessage": "Sees"
 	},
 	"error.access.at-least-one": {
-		"defaultMessage": "Either one Authorization or one Access Rule is required"
+		"defaultMessage": "Vaja on vähemalt ühte kasutajat või juurdepääsureeglit"
 	},
 	"error.access.duplicate-usernames": {
-		"defaultMessage": "Authorization Usernames must be unique"
+		"defaultMessage": "Kasutajanimed peavad olema unikaalsed"
 	},
 	"error.invalid-auth": {
-		"defaultMessage": "Invalid email or password"
+		"defaultMessage": "Vale e-post või parool"
 	},
 	"error.invalid-domain": {
-		"defaultMessage": "Invalid domain: {domain}"
+		"defaultMessage": "Vigane domeen: {domain}"
 	},
 	"error.invalid-email": {
-		"defaultMessage": "Invalid email address"
+		"defaultMessage": "Vigane e-posti aadress"
 	},
 	"error.max-character-length": {
-		"defaultMessage": "Maximum length is {max} character{max, plural, one {} other {s}}"
+		"defaultMessage": "Maksimumpikkus on {max} {max, plural, one {tähemärk} other {tähemärki}}"
 	},
 	"error.max-domains": {
-		"defaultMessage": "Too many domains, max is {max}"
+		"defaultMessage": "Liiga palju domeene, maksimum on {max}"
 	},
 	"error.maximum": {
-		"defaultMessage": "Maximum is {max}"
+		"defaultMessage": "Maksimum on {max}"
 	},
 	"error.min-character-length": {
-		"defaultMessage": "Minimum length is {min} character{min, plural, one {} other {s}}"
+		"defaultMessage": "Miinimumpikkus on {min} {min, plural, one {tähemärk} other {tähemärki}}"
 	},
 	"error.minimum": {
-		"defaultMessage": "Minimum is {min}"
+		"defaultMessage": "Miinimum on {min}"
 	},
 	"error.passwords-must-match": {
-		"defaultMessage": "Passwords must match"
+		"defaultMessage": "Paroolid peavad klappima"
 	},
 	"error.required": {
-		"defaultMessage": "This is required"
+		"defaultMessage": "See on kohustuslik"
 	},
 	"expires.on": {
-		"defaultMessage": "Expires: {date}"
+		"defaultMessage": "Aegub: {date}"
 	},
 	"footer.github-fork": {
-		"defaultMessage": "Fork me on Github"
+		"defaultMessage": "Tee GitHubis fork"
 	},
 	"host.flags.block-exploits": {
-		"defaultMessage": "Block Common Exploits"
+		"defaultMessage": "Blokeeri levinud ründed"
 	},
 	"host.flags.cache-assets": {
-		"defaultMessage": "Cache Assets"
+		"defaultMessage": "Puhverda failid"
 	},
 	"host.flags.preserve-path": {
-		"defaultMessage": "Preserve Path"
+		"defaultMessage": "Säilita tee"
 	},
 	"host.flags.protocols": {
-		"defaultMessage": "Protocols"
+		"defaultMessage": "Protokollid"
 	},
 	"host.flags.websockets-upgrade": {
-		"defaultMessage": "Websockets Support"
+		"defaultMessage": "Websocketi tugi"
 	},
 	"host.forward-port": {
-		"defaultMessage": "Forward Port"
+		"defaultMessage": "Edastusport"
 	},
 	"host.forward-scheme": {
-		"defaultMessage": "Scheme"
+		"defaultMessage": "Skeem"
 	},
 	"hosts": {
-		"defaultMessage": "Hosts"
+		"defaultMessage": "Hostid"
 	},
 	"http-only": {
-		"defaultMessage": "HTTP Only"
+		"defaultMessage": "Ainult HTTP"
 	},
 	"lets-encrypt": {
 		"defaultMessage": "Let's Encrypt"
 	},
 	"lets-encrypt-via-dns": {
-		"defaultMessage": "Let's Encrypt via DNS"
+		"defaultMessage": "Let's Encrypt DNS-iga"
 	},
 	"lets-encrypt-via-http": {
-		"defaultMessage": "Let's Encrypt via HTTP"
+		"defaultMessage": "Let's Encrypt HTTP-ga"
 	},
 	"loading": {
-		"defaultMessage": "Loading…"
+		"defaultMessage": "Laadimine…"
+	},
+	"location.advanced-config": {
+		"defaultMessage": "Kohandatud Nginx seadistus olemas"
+	},
+	"location.filter": {
+		"defaultMessage": "Filtreeri tee või sihtkoha järgi"
 	},
 	"login.2fa-code": {
-		"defaultMessage": "Verification Code"
+		"defaultMessage": "Kinnituskood"
 	},
 	"login.2fa-code-placeholder": {
-		"defaultMessage": "Enter code"
+		"defaultMessage": "Sisesta kood"
 	},
 	"login.2fa-description": {
-		"defaultMessage": "Enter the code from your authenticator app"
+		"defaultMessage": "Sisesta kood autentimisäpist"
 	},
 	"login.2fa-title": {
-		"defaultMessage": "Two-Factor Authentication"
+		"defaultMessage": "Kaheastmeline autentimine"
 	},
 	"login.2fa-verify": {
-		"defaultMessage": "Verify"
+		"defaultMessage": "Kinnita"
 	},
 	"login.title": {
-		"defaultMessage": "Login to your account"
+		"defaultMessage": "Logi kontole sisse"
 	},
 	"nginx-config.label": {
-		"defaultMessage": "Custom Nginx Configuration"
+		"defaultMessage": "Kohandatud Nginx seadistus"
 	},
 	"nginx-config.placeholder": {
-		"defaultMessage": "# Enter your custom Nginx configuration here at your own risk!"
+		"defaultMessage": "# Sisesta siia oma Nginx seadistus omal vastutusel!"
 	},
 	"no-permission-error": {
-		"defaultMessage": "You do not have access to view this."
+		"defaultMessage": "Selle vaatamiseks sul õigust pole."
 	},
 	"notfound.action": {
-		"defaultMessage": "Take me home"
+		"defaultMessage": "Tagasi avalehele"
 	},
 	"notfound.content": {
-		"defaultMessage": "We are sorry but the page you are looking for was not found"
+		"defaultMessage": "Otsitud lehte ei ole."
 	},
 	"notfound.title": {
-		"defaultMessage": "Oops… You just found an error page"
+		"defaultMessage": "Oih… lehte ei leitud"
 	},
 	"notification.error": {
-		"defaultMessage": "Error"
+		"defaultMessage": "Viga"
 	},
 	"notification.object-deleted": {
-		"defaultMessage": "{object} has been deleted"
+		"defaultMessage": "{object} on kustutatud"
 	},
 	"notification.object-disabled": {
-		"defaultMessage": "{object} has been disabled"
+		"defaultMessage": "{object} on välja lülitatud"
 	},
 	"notification.object-enabled": {
-		"defaultMessage": "{object} has been enabled"
+		"defaultMessage": "{object} on sisse lülitatud"
 	},
 	"notification.object-renewed": {
-		"defaultMessage": "{object} has been renewed"
+		"defaultMessage": "{object} on uuendatud"
 	},
 	"notification.object-saved": {
-		"defaultMessage": "{object} has been saved"
+		"defaultMessage": "{object} on salvestatud"
 	},
 	"notification.success": {
-		"defaultMessage": "Success"
+		"defaultMessage": "Korras"
 	},
 	"object.actions-title": {
 		"defaultMessage": "{object} #{id}"
 	},
 	"object.add": {
-		"defaultMessage": "Add {object}"
+		"defaultMessage": "Lisa {object}"
 	},
 	"object.delete": {
-		"defaultMessage": "Delete {object}"
+		"defaultMessage": "Kustuta {object}"
 	},
 	"object.delete.content": {
-		"defaultMessage": "Are you sure you want to delete this {object}?"
+		"defaultMessage": "Kas oled kindel, et tahad selle kustutada: {object}?"
 	},
 	"object.edit": {
-		"defaultMessage": "Edit {object}"
+		"defaultMessage": "Muuda {object}"
 	},
 	"object.empty": {
-		"defaultMessage": "There are no {objects}"
+		"defaultMessage": "{objects} puuduvad"
 	},
 	"object.event.created": {
-		"defaultMessage": "Created {object}"
+		"defaultMessage": "Loodud: {object}"
 	},
 	"object.event.deleted": {
-		"defaultMessage": "Deleted {object}"
+		"defaultMessage": "Kustutatud: {object}"
 	},
 	"object.event.disabled": {
-		"defaultMessage": "Disabled {object}"
+		"defaultMessage": "Välja lülitatud: {object}"
 	},
 	"object.event.enabled": {
-		"defaultMessage": "Enabled {object}"
+		"defaultMessage": "Sisse lülitatud: {object}"
 	},
 	"object.event.renewed": {
-		"defaultMessage": "Renewed {object}"
+		"defaultMessage": "Uuendatud: {object}"
 	},
 	"object.event.updated": {
-		"defaultMessage": "Updated {object}"
+		"defaultMessage": "Muudetud: {object}"
 	},
 	"offline": {
-		"defaultMessage": "Offline"
+		"defaultMessage": "Maas"
 	},
 	"online": {
-		"defaultMessage": "Online"
+		"defaultMessage": "Töös"
 	},
 	"options": {
-		"defaultMessage": "Options"
+		"defaultMessage": "Valikud"
 	},
 	"password": {
-		"defaultMessage": "Password"
+		"defaultMessage": "Parool"
 	},
 	"password.generate": {
-		"defaultMessage": "Generate random password"
+		"defaultMessage": "Loo juhuslik parool"
 	},
 	"password.hide": {
-		"defaultMessage": "Hide Password"
+		"defaultMessage": "Peida parool"
 	},
 	"password.show": {
-		"defaultMessage": "Show Password"
+		"defaultMessage": "Näita parooli"
 	},
 	"permissions.hidden": {
-		"defaultMessage": "Hidden"
+		"defaultMessage": "Peidetud"
 	},
 	"permissions.manage": {
-		"defaultMessage": "Manage"
+		"defaultMessage": "Halda"
 	},
 	"permissions.view": {
-		"defaultMessage": "View Only"
+		"defaultMessage": "Ainult vaatamine"
 	},
 	"permissions.visibility.all": {
-		"defaultMessage": "All Items"
+		"defaultMessage": "Kõik kirjed"
 	},
 	"permissions.visibility.title": {
-		"defaultMessage": "Item Visibility"
+		"defaultMessage": "Kirjete nähtavus"
 	},
 	"permissions.visibility.user": {
-		"defaultMessage": "Created Items Only"
+		"defaultMessage": "Ainult enda loodud"
 	},
 	"proxy-host": {
-		"defaultMessage": "Proxy Host"
+		"defaultMessage": "Puhverserver"
 	},
 	"proxy-host.forward-host": {
-		"defaultMessage": "Forward Hostname / IP"
+		"defaultMessage": "Edastuse hostinimi / IP"
 	},
 	"proxy-hosts": {
-		"defaultMessage": "Proxy Hosts"
+		"defaultMessage": "Puhverserverid"
 	},
 	"proxy-hosts.count": {
-		"defaultMessage": "{count} {count, plural, one {Proxy Host} other {Proxy Hosts}}"
+		"defaultMessage": "{count} {count, plural, one {puhverserver} other {puhverserverit}}"
 	},
 	"public": {
-		"defaultMessage": "Public"
+		"defaultMessage": "Avalik"
 	},
 	"redirection-host": {
-		"defaultMessage": "Redirection Host"
+		"defaultMessage": "Ümbersuunamishost"
 	},
 	"redirection-host.forward-domain": {
-		"defaultMessage": "Forward Domain"
+		"defaultMessage": "Sihtkoha domeen"
 	},
 	"redirection-host.forward-http-code": {
-		"defaultMessage": "HTTP Code"
+		"defaultMessage": "HTTP-kood"
 	},
 	"redirection-hosts": {
-		"defaultMessage": "Redirection Hosts"
+		"defaultMessage": "Ümbersuunamishostid"
 	},
 	"redirection-hosts.count": {
-		"defaultMessage": "{count} {count, plural, one {Redirection Host} other {Redirection Hosts}}"
+		"defaultMessage": "{count} {count, plural, one {ümbersuunamishost} other {ümbersuunamishosti}}"
 	},
 	"redirection-hosts.http-code.300": {
-		"defaultMessage": "300 Multiple Choices"
+		"defaultMessage": "300 mitu valikut"
 	},
 	"redirection-hosts.http-code.301": {
-		"defaultMessage": "301 Moved permanently"
+		"defaultMessage": "301 jäädavalt teisaldatud"
 	},
 	"redirection-hosts.http-code.302": {
-		"defaultMessage": "302 Moved temporarily"
+		"defaultMessage": "302 ajutiselt teisaldatud"
 	},
 	"redirection-hosts.http-code.303": {
-		"defaultMessage": "303 See other"
+		"defaultMessage": "303 vaata mujal"
 	},
 	"redirection-hosts.http-code.307": {
-		"defaultMessage": "307 Temporary redirect"
+		"defaultMessage": "307 ajutine ümbersuunamine"
 	},
 	"redirection-hosts.http-code.308": {
-		"defaultMessage": "308 Permanent redirect"
+		"defaultMessage": "308 jäädav ümbersuunamine"
 	},
 	"role.admin": {
-		"defaultMessage": "Administrator"
+		"defaultMessage": "Administraator"
 	},
 	"role.standard-user": {
-		"defaultMessage": "Standard User"
+		"defaultMessage": "Tavakasutaja"
 	},
 	"save": {
-		"defaultMessage": "Save"
+		"defaultMessage": "Salvesta"
 	},
 	"setting": {
-		"defaultMessage": "Setting"
+		"defaultMessage": "Seade"
 	},
 	"settings": {
-		"defaultMessage": "Settings"
+		"defaultMessage": "Seaded"
 	},
 	"settings.default-site": {
-		"defaultMessage": "Default Site"
+		"defaultMessage": "Vaikesait"
 	},
 	"settings.default-site.404": {
-		"defaultMessage": "404 Page"
+		"defaultMessage": "404 leht"
 	},
 	"settings.default-site.444": {
-		"defaultMessage": "No Response (444)"
+		"defaultMessage": "Vastuseta (444)"
 	},
 	"settings.default-site.congratulations": {
-		"defaultMessage": "Congratulations Page"
+		"defaultMessage": "Õnnitlusleht"
 	},
 	"settings.default-site.description": {
-		"defaultMessage": "What to show when Nginx is hit with an unknown Host"
+		"defaultMessage": "Mida näidata, kui päring tuleb tundmatule hostile"
 	},
 	"settings.default-site.html": {
-		"defaultMessage": "Custom HTML"
+		"defaultMessage": "Kohandatud HTML"
 	},
 	"settings.default-site.html.placeholder": {
-		"defaultMessage": "<!-- Enter your custom HTML content here -->"
+		"defaultMessage": "<!-- Sisesta siia oma HTML -->"
 	},
 	"settings.default-site.redirect": {
-		"defaultMessage": "Redirect"
+		"defaultMessage": "Ümbersuunamine"
 	},
 	"setup.preamble": {
-		"defaultMessage": "Get started by creating your admin account."
+		"defaultMessage": "Alustuseks loo endale administraatori konto."
 	},
 	"setup.title": {
-		"defaultMessage": "Welcome!"
+		"defaultMessage": "Tere tulemast!"
 	},
 	"sign-in": {
-		"defaultMessage": "Sign in"
+		"defaultMessage": "Logi sisse"
 	},
 	"ssl-certificate": {
-		"defaultMessage": "SSL Certificate"
+		"defaultMessage": "SSL-sertifikaat"
 	},
 	"stream": {
-		"defaultMessage": "Stream"
+		"defaultMessage": "Voog"
 	},
 	"stream.forward-host": {
-		"defaultMessage": "Forward Host"
+		"defaultMessage": "Edastuse host"
 	},
 	"stream.forward-host.placeholder": {
-		"defaultMessage": "example.com or 10.0.0.1 or 2001:db8:3333:4444:5555:6666:7777:8888"
+		"defaultMessage": "example.com või 10.0.0.1 või 2001:db8:3333:4444:5555:6666:7777:8888"
 	},
 	"stream.incoming-port": {
-		"defaultMessage": "Incoming Port"
+		"defaultMessage": "Sisendport"
 	},
 	"streams": {
-		"defaultMessage": "Streams"
+		"defaultMessage": "Vood"
 	},
 	"streams.count": {
-		"defaultMessage": "{count} {count, plural, one {Stream} other {Streams}}"
+		"defaultMessage": "{count} {count, plural, one {voog} other {voogu}}"
 	},
 	"streams.tcp": {
 		"defaultMessage": "TCP"
@@ -717,60 +726,60 @@
 		"defaultMessage": "UDP"
 	},
 	"test": {
-		"defaultMessage": "Test"
+		"defaultMessage": "Testi"
 	},
 	"update-available": {
-		"defaultMessage": "Update Available: {latestVersion}"
+		"defaultMessage": "Uuendus saadaval: {latestVersion}"
 	},
 	"user": {
-		"defaultMessage": "User"
+		"defaultMessage": "Kasutaja"
 	},
 	"user.change-password": {
-		"defaultMessage": "Change Password"
+		"defaultMessage": "Muuda parooli"
 	},
 	"user.confirm-password": {
-		"defaultMessage": "Confirm Password"
+		"defaultMessage": "Kinnita parool"
 	},
 	"user.current-password": {
-		"defaultMessage": "Current Password"
+		"defaultMessage": "Praegune parool"
 	},
 	"user.edit-profile": {
-		"defaultMessage": "Edit Profile"
+		"defaultMessage": "Muuda profiili"
 	},
 	"user.full-name": {
-		"defaultMessage": "Full Name"
+		"defaultMessage": "Täisnimi"
 	},
 	"user.login-as": {
-		"defaultMessage": "Sign in as {name}"
+		"defaultMessage": "Logi sisse kasutajana {name}"
 	},
 	"user.logout": {
-		"defaultMessage": "Logout"
+		"defaultMessage": "Logi välja"
 	},
 	"user.new-password": {
-		"defaultMessage": "New Password"
+		"defaultMessage": "Uus parool"
 	},
 	"user.nickname": {
-		"defaultMessage": "Nickname"
+		"defaultMessage": "Hüüdnimi"
 	},
 	"user.set-password": {
-		"defaultMessage": "Set Password"
+		"defaultMessage": "Määra parool"
 	},
 	"user.set-permissions": {
-		"defaultMessage": "Set Permissions for {name}"
+		"defaultMessage": "Määra {name} õigused"
 	},
 	"user.switch-dark": {
-		"defaultMessage": "Switch to Dark mode"
+		"defaultMessage": "Lülitu tumedale kujundusele"
 	},
 	"user.switch-light": {
-		"defaultMessage": "Switch to Light mode"
+		"defaultMessage": "Lülitu heledale kujundusele"
 	},
 	"user.two-factor": {
-		"defaultMessage": "Two-Factor Auth"
+		"defaultMessage": "Kaheastmeline autentimine"
 	},
 	"username": {
-		"defaultMessage": "Username"
+		"defaultMessage": "Kasutajanimi"
 	},
 	"users": {
-		"defaultMessage": "Users"
+		"defaultMessage": "Kasutajad"
 	}
 }


### PR DESCRIPTION
UI-tekstid olid eesti keele valikus, aga sisu oli inglise keeles. Nüüd on et.json täielikult eesti keeles (sh puudunud võtmed), abitekstid ühtlustatud ja lipukoodiks jääb EE (Eesti), mitte ET (Etioopia). Kuupäevad kasutavad et-EE lokaati ja 24-tunnist kellaaega.

Muudatuse tegi Aarmaa IT - Siim Aarmaa

-------

The UI texts were available in Estonian, but the content was in English. The et.json file is now fully translated into Estonian (including previously missing keys), the helper texts have been standardized, and the flag code remains EE (Estonia), not ET (Ethiopia). Dates use the et-EE locale and 24-hour time format.

The changes were made by Aarmaa IT – Siim Aarmaa.

