### PR TITLE
feat: add Tencent Cloud EdgeOne DNS provider

### DIFF
--- a/backend/certbot/dns-plugins.json
+++ b/backend/certbot/dns-plugins.json
@@ -231,6 +231,14 @@
 		"package_name": "certbot-plugin-edgedns",
 		"version": "~=0.1.0"
 	},
+	"edgeone": {
+        "credentials": "dns_edgeone_secret_id = YOUR_TENCENTCLOUD_SECRET_ID\ndns_edgeone_secret_key = YOUR_TENCENTCLOUD_SECRET_KEY",
+        "dependencies": "",
+        "full_plugin_name": "dns-edgeone",
+        "name": "Tencent Cloud EdgeOne",
+        "package_name": "certbot-dns-edgeone",
+        "version": ">=0.1.0"
+    },
 	"eurodns": {
 		"credentials": "dns_eurodns_applicationId = myuser\ndns_eurodns_apiKey = mysecretpassword\ndns_eurodns_endpoint = https://rest-api.eurodns.com/dns-zones/",
 		"dependencies": "",


### PR DESCRIPTION
## Why

This PR adds support for **Tencent Cloud EdgeOne (TEO)** as a DNS provider for Let's Encrypt DNS-01 certificate validation using the [`certbot-dns-
  edgeone`](<https://pypi.org/project/certbot-dns-edgeone/>) plugin.

```ini
dns_edgeone_secret_id = YOUR_TENCENTCLOUD_SECRET_ID
dns_edgeone_secret_key = YOUR_TENCENTCLOUD_SECRET_KEY
```

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] API changes
- [ ] Performance improvement
- [ ] Test addition or update

## AI Usage

- [x] AI was used to write this
- [x] AI was used to review this

